### PR TITLE
refactor(transfer): update css class name

### DIFF
--- a/examples/config-provider/demos/others.vue
+++ b/examples/config-provider/demos/others.vue
@@ -204,7 +204,7 @@ export default defineComponent({
   margin: 24px -120px 0 0;
 }
 
-:deep() .tdesign-demo-item--locale-provider-base .t-transfer-list {
+:deep() .tdesign-demo-item--locale-provider-base .t-transfer__list {
   width: 280px;
 }
 

--- a/src/transfer/components/transfer-list.tsx
+++ b/src/transfer/components/transfer-list.tsx
@@ -16,10 +16,8 @@ import ripple from '../../utils/ripple';
 import Search from './transfer-search';
 import { renderTNodeJSXDefault } from '../../utils/render-tnode';
 
-const name = `${prefix}-transfer-list`;
-
 export default defineComponent({
-  name,
+  name: 'TTransferList',
   components: {
     Search,
     TCheckbox,
@@ -78,7 +76,6 @@ export default defineComponent({
   emits: ['pageChange', 'checkedChange', 'scroll', 'search'],
   data() {
     return {
-      name,
       filterValue: '', // 搜索框输入内容,
       // 用于兼容处理 Pagination 的非受控属性（非受控属性仅有 change 事件变化，无 props 变化，因此只需监听事件）
       defaultCurrent: 1,
@@ -194,7 +191,10 @@ export default defineComponent({
             <TCheckbox
               disabled={this.disabled || item.disabled}
               value={item.value}
-              class={[`${name}__item`, this.checkedValue.includes(item.value) ? `${prefix}-is-checked` : '']}
+              class={[
+                `${prefix}-transfer__list-item`,
+                this.checkedValue.includes(item.value) ? `${prefix}-is-checked` : '',
+              ]}
               key={item.key}
               v-ripple
               {...{ props: this.checkboxProps }}
@@ -208,7 +208,7 @@ export default defineComponent({
         </TCheckboxGroup>
       );
       return (
-        <div class={`${name}__content narrow-scrollbar`} onScroll={this.scroll}>
+        <div class={`${prefix}-transfer__list-content narrow-scrollbar`} onScroll={this.scroll}>
           {renderTNodeJSXDefault(rootNode, 'tree', {
             defaultNode,
             params: {
@@ -224,7 +224,7 @@ export default defineComponent({
       const empty = this.empty || this.t(this.global.empty);
       const defaultNode: VNode = typeof empty === 'string' ? <span>{empty}</span> : null;
       return (
-        <div class="t-transfer-empty">
+        <div class={`${prefix}-transfer__empty`}>
           {renderTNodeJSXDefault(this, 'empty', {
             defaultNode,
             params: {
@@ -236,7 +236,7 @@ export default defineComponent({
     },
     renderFooter() {
       const defaultNode =
-        typeof this.footer === 'string' ? <div class={`${prefix}-transfer-footer`}>{this.footer}</div> : null;
+        typeof this.footer === 'string' ? <div class={`${prefix}-transfer__footer`}>{this.footer}</div> : null;
       return renderTNodeJSXDefault(this, 'footer', {
         defaultNode,
         params: {
@@ -247,8 +247,8 @@ export default defineComponent({
   },
   render() {
     return (
-      <div class={`${this.name} ${this.name}-${this.listType}`}>
-        <div class={`${this.name}__header`}>
+      <div class={`${prefix}-transfer__list ${prefix}-transfer__list-${this.listType}`}>
+        <div class={`${prefix}-transfer__list-header`}>
           <div>
             {this.checkAll && (
               <TCheckbox
@@ -267,7 +267,7 @@ export default defineComponent({
           </div>
           {this.renderTitle()}
         </div>
-        <div class={[`${this.name}__body`, this.search ? `${this.name}-with-search` : '']}>
+        <div class={[`${prefix}-transfer__list-body`, this.search ? `${prefix}-transfer__list--with-search` : '']}>
           {this.search && (
             <search
               searchValue={this.filterValue}
@@ -280,7 +280,7 @@ export default defineComponent({
           {this.curPageData.length > 0 ? this.renderContent() : this.renderEmpty()}
         </div>
         {this.pagination && this.pageSize > 0 && this.pageTotal > 0 && (
-          <div class={`${this.name}__pagination`}>
+          <div class={`${prefix}-transfer__list-pagination`}>
             <t-pagination {...this.paginationProps} onChange={this.handlePaginationChange} />
           </div>
         )}

--- a/src/transfer/components/transfer-operations.tsx
+++ b/src/transfer/components/transfer-operations.tsx
@@ -4,10 +4,8 @@ import { prefix } from '../../config';
 import TButton from '../../button';
 import { TNode } from '../../common';
 
-const name = `${prefix}-transfer-operations`;
-
 export default defineComponent({
-  name,
+  name: 'TTransferOperations',
   components: {
     TButton,
   },
@@ -83,7 +81,7 @@ export default defineComponent({
   render(h: any) {
     const { leftDisabled, rightDisabled } = this.$props;
     return (
-      <div class={name}>
+      <div class={`${prefix}-transfer__operations`}>
         <t-button
           variant={rightDisabled ? 'outline' : 'base'}
           key={rightDisabled ? 'right-outline' : 'right-base'}

--- a/src/transfer/components/transfer-search.tsx
+++ b/src/transfer/components/transfer-search.tsx
@@ -4,10 +4,8 @@ import { prefix } from '../../config';
 import { SearchOption } from '../interface';
 import TInput from '../../input';
 
-const name = `${prefix}-transfer-search`;
-
 export default defineComponent({
-  name,
+  name: 'TTransferSearch',
   props: {
     value: {
       type: String,
@@ -41,7 +39,7 @@ export default defineComponent({
           };
 
     return (
-      <div class="t-transfer-list-search-wrapper">
+      <div class={`${prefix}-transfer__search-wrapper`}>
         <TInput {...inputProps} defaultValue={value} onChange={this.handleChange} placeholder={placeholder}>
           <SearchIcon slot="suffix-icon" />
         </TInput>

--- a/src/transfer/transfer.tsx
+++ b/src/transfer/transfer.tsx
@@ -30,19 +30,17 @@ import getConfigReceiverMixins from '../config-provider/config-receiver';
 import props from './props';
 import { TNode } from '../common';
 
-const name = `${prefix}-transfer`;
 const SOURCE = 'source';
 const TARGET = 'target';
 
 type DataType = {
-  name: string;
   SOURCE: TransferListType;
   TARGET: TransferListType;
 };
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins('transfer')),
-  name: 'TTransfer',
+  name: TRANSFER_NAME,
   components: {
     TransferList,
     TransferOperations,
@@ -62,7 +60,6 @@ export default defineComponent({
   ],
   data(): DataType {
     return {
-      name,
       SOURCE,
       TARGET,
     };
@@ -246,11 +243,11 @@ export default defineComponent({
     return (
       <div
         class={[
-          't-transfer',
-          this.showSearch ? 't-transfer-search' : '',
-          this.hasFooter ? 't-transfer-footer' : '',
-          this.showPagination ? 't-transfer-pagination' : '',
-          this.isTreeMode ? 't-transfer-with-tree' : '',
+          `${prefix}-transfer`,
+          this.showSearch ? `${prefix}-transfer__search` : '',
+          this.hasFooter ? `${prefix}-transfer__footer` : '',
+          this.showPagination ? `${prefix}-transfer__pagination` : '',
+          this.isTreeMode ? `${prefix}-transfer--with-tree` : '',
         ]}
       >
         {this.renderTransferList(SOURCE)}

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -9938,61 +9938,61 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
     </div>
     <!--]-->
   </form><br><br>
-  <div class="t-transfer t-transfer-search">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20</span></div><span><!----></span>
+  <div class="t-transfer t-transfer__search">
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body t-transfer-list-with-search">
-        <div class="t-transfer-list-search-wrapper" searchvalue>
+      <div class="t-transfer__list-body t-transfer__list--with-search">
+        <div class="t-transfer__search-wrapper" searchvalue>
           <div class="t-input t-size-m">
             <!----><input autocomplete="false" placeholder="type keyword to search" type="text" value class="t-input__inner">
             <!---->
           </div>
         </div>
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 19</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>content 20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -10001,9 +10001,9 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -10014,21 +10014,21 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body t-transfer-list-with-search">
-        <div class="t-transfer-list-search-wrapper" searchvalue>
+      <div class="t-transfer__list-body t-transfer__list--with-search">
+        <div class="t-transfer__search-wrapper" searchvalue>
           <div class="t-input t-size-m">
             <!----><input autocomplete="false" placeholder="type keyword to search" type="text" value class="t-input__inner">
             <!---->
           </div>
         </div>
-        <div class="t-transfer-empty"><span>Empty Data</span></div>
+        <div class="t-transfer__empty"><span>Empty Data</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div><br><br>
   <div class="t-select__wrap" style="width:400px;">
@@ -35308,55 +35308,55 @@ exports[`ssr snapshot test renders ./examples/tooltip/demos/trigger.vue correctl
 exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 1`] = `
 <div>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>1 / 20 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>1 / 20 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35365,9 +35365,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-base t-button--theme-primary" type="button">
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-base t-button--theme-primary" type="button">
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35378,16 +35378,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35396,55 +35396,55 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
 exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correctly 1`] = `
 <div>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>5 / 20 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>5 / 20 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35453,9 +35453,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-base t-button--theme-primary" type="button">
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-base t-button--theme-primary" type="button">
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35466,16 +35466,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35483,56 +35483,56 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
 
 exports[`ssr snapshot test renders ./examples/transfer/demos/custom.vue correctly 1`] = `
 <div>
-  <div class="t-transfer t-transfer-footer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!--[--><div>来源</div><!--]--></span>
+  <div class="t-transfer t-transfer__footer">
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!--[--><div>来源</div><!--]--></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35545,14 +35545,14 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom.vue correctl
       <div style="padding:10px;border-top:1px solid #e7e7e7;"><span>选中并加入</span></div>
       <!--]-->
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->加入<!--]--><!--]--></span></button><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->移除<!--]--><!--]--></span></button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!--[--><div>目标</div><!--]--></span>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->加入<!--]--><!--]--></span></button><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->移除<!--]--><!--]--></span></button></div>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!--[--><div>目标</div><!--]--></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
       <!--[-->
@@ -35566,55 +35566,55 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom.vue correctl
 exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue correctly 1`] = `
 <div>
   <div class="t-transfer" theme="primary">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容1 - 第1段信息</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容1 - 第1段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容2 - 第2段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容2 - 第2段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容3 - 第3段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容3 - 第3段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容4 - 第4段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容4 - 第4段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容5 - 第5段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容5 - 第5段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容6 - 第6段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容6 - 第6段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容7 - 第7段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容7 - 第7段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容8 - 第8段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容8 - 第8段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容9 - 第9段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容9 - 第9段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容10 - 第10段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容10 - 第10段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容11 - 第11段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容11 - 第11段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容12 - 第12段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容12 - 第12段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容13 - 第13段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容13 - 第13段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容14 - 第14段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容14 - 第14段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容15 - 第15段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容15 - 第15段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容16 - 第16段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容16 - 第16段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容17 - 第17段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容17 - 第17段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容18 - 第18段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容18 - 第18段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容19 - 第19段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容19 - 第19段信息</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容20 - 第20段信息</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span class="transfer-item">内容20 - 第20段信息</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35623,9 +35623,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue c
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35636,16 +35636,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue c
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35654,35 +35654,35 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue c
 exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correctly 1`] = `
 <div>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35691,9 +35691,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correc
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35704,35 +35704,35 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correc
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35741,7 +35741,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correc
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35751,18 +35751,18 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
 <div>
   <p style="margin:10px 0px;">默认暂无数据</p>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35773,32 +35773,32 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
   <p style="margin:10px;">自定义空状态</p>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty">No Data</div>
+        <div class="t-transfer__empty">No Data</div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35809,16 +35809,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty">No Data</div>
+        <div class="t-transfer__empty">No Data</div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35826,36 +35826,36 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
 
 exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue correctly 1`] = `
 <div>
-  <div class="t-transfer t-transfer-pagination" theme="primary">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+  <div class="t-transfer t-transfer__pagination" theme="primary">
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -35863,7 +35863,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
           </div>
         </div>
       </div>
-      <div class="t-transfer-list__pagination">
+      <div class="t-transfer__list-pagination">
         <div class="t-pagination t-size-s" modelvalue="1">
           <!---->
           <!---->
@@ -35913,9 +35913,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
           <!---->
         </div>
       </div>
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -35926,16 +35926,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -35943,61 +35943,61 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
 
 exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctly 1`] = `
 <div>
-  <div class="t-transfer t-transfer-search" theme="primary">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+  <div class="t-transfer t-transfer__search" theme="primary">
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body t-transfer-list-with-search">
-        <div class="t-transfer-list-search-wrapper" searchvalue>
+      <div class="t-transfer__list-body t-transfer__list--with-search">
+        <div class="t-transfer__search-wrapper" searchvalue>
           <div class="t-input t-size-m">
             <!----><input autocomplete="false" placeholder="请输入关键词搜索" type="text" value class="t-input__inner">
             <!---->
           </div>
         </div>
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -36006,9 +36006,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctl
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -36019,21 +36019,21 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctl
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body t-transfer-list-with-search">
-        <div class="t-transfer-list-search-wrapper" searchvalue>
+      <div class="t-transfer__list-body t-transfer__list--with-search">
+        <div class="t-transfer__search-wrapper" searchvalue>
           <div class="t-input t-size-m">
             <!----><input autocomplete="false" placeholder="请输入关键词搜索" type="text" value class="t-input__inner">
             <!---->
           </div>
         </div>
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -36042,35 +36042,35 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctl
 exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue correctly 1`] = `
 <div>
   <div class="t-transfer">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -36079,9 +36079,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -36092,35 +36092,35 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="0"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="4"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容5</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="8"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容9</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="12"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容13</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="16"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容17</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -36129,7 +36129,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>
@@ -36137,20 +36137,20 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
 
 exports[`ssr snapshot test renders ./examples/transfer/demos/tree.vue correctly 1`] = `
 <div>
-  <div class="t-transfer t-transfer-with-tree">
-    <div class="t-transfer-list t-transfer-list-source">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 5 项</span></div><span><!----></span>
+  <div class="t-transfer t-transfer--with-tree">
+    <div class="t-transfer__list t-transfer__list-source">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 5 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-list__content narrow-scrollbar">
+        <div class="t-transfer__list-content narrow-scrollbar">
           <div class="t-checkbox-group">
             <!---->
             <!--[-->
-            <!--[--><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>1</span>
+            <!--[--><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>1</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer-list__item t-transfer-list__item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>2</span>
+            </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>2</span>
               <!--]--></span>
             </label>
             <!--]-->
@@ -36159,9 +36159,9 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/tree.vue correctly 
         </div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
-    <div class="t-transfer-operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
+    <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled>
         <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right" style="">
           <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
         </svg><span class="t-button__text"><!--[--><!--]--></span>
@@ -36172,16 +36172,16 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/tree.vue correctly 
         </svg><span class="t-button__text"><!--[--><!--]--></span>
         <!--]-->
       </button></div>
-    <div class="t-transfer-list t-transfer-list-target">
-      <div class="t-transfer-list__header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+    <div class="t-transfer__list t-transfer__list-target">
+      <div class="t-transfer__list-header">
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
-      <div class="t-transfer-list__body">
+      <div class="t-transfer__list-body">
         <!---->
-        <div class="t-transfer-empty"><span>暂无数据</span></div>
+        <div class="t-transfer__empty"><span>暂无数据</span></div>
       </div>
       <!---->
-      <div class="t-transfer-footer"></div>
+      <div class="t-transfer__footer"></div>
     </div>
   </div>
 </div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -9941,7 +9941,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
   <div class="t-transfer t-transfer__search">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body t-transfer__list--with-search">
         <div class="t-transfer__search-wrapper" searchvalue>
@@ -10016,7 +10016,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body t-transfer__list--with-search">
         <div class="t-transfer__search-wrapper" searchvalue>
@@ -35310,7 +35310,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>1 / 20 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>1 / 20 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35322,7 +35322,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
@@ -35380,7 +35380,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/base.vue correctly 
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35398,7 +35398,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>5 / 20 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-indeterminate" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="true"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>5 / 20 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35410,7 +35410,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="1"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容2</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="2" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容3</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="3"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容4</span>
               <!--]--></span>
@@ -35418,7 +35418,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="5"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容6</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="6" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容7</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="7"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容8</span>
               <!--]--></span>
@@ -35426,7 +35426,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="9"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容10</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="10" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容11</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="11"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容12</span>
               <!--]--></span>
@@ -35434,7 +35434,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="13"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容14</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="14" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容15</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="15"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容16</span>
               <!--]--></span>
@@ -35442,7 +35442,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="17"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容18</span>
               <!--]--></span>
-            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
+            </label><label class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="18" checked><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容19</span>
               <!--]--></span>
             </label><label class="t-checkbox t-transfer__list-item t-transfer__list-item" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name value="19"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!--[--><span>内容20</span>
               <!--]--></span>
@@ -35468,7 +35468,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/checked.vue correct
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35486,7 +35486,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom.vue correctl
   <div class="t-transfer t-transfer__footer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!--[--><div>来源</div><!--]--></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!--[--><div>来源</div><!--]--></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35548,7 +35548,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom.vue correctl
     <div class="t-transfer__operations"><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->加入<!--]--><!--]--></span></button><button class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled" type="button" disabled><span class="t-button__text"><!--[--><!--[-->移除<!--]--><!--]--></span></button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!--[--><div>目标</div><!--]--></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!--[--><div>目标</div><!--]--></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35568,7 +35568,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue c
   <div class="t-transfer" theme="primary">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35638,7 +35638,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/custom-render.vue c
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35656,7 +35656,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correc
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35706,7 +35706,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/disabled.vue correc
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35753,7 +35753,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35775,7 +35775,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35789,7 +35789,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35811,7 +35811,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/empty.vue correctly
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35829,7 +35829,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
   <div class="t-transfer t-transfer__pagination" theme="primary">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35928,7 +35928,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -35946,7 +35946,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctl
   <div class="t-transfer t-transfer__search" theme="primary">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 20 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body t-transfer__list--with-search">
         <div class="t-transfer__search-wrapper" searchvalue>
@@ -36021,7 +36021,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/search.vue correctl
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body t-transfer__list--with-search">
         <div class="t-transfer__search-wrapper" searchvalue>
@@ -36044,7 +36044,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
   <div class="t-transfer">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -36094,7 +36094,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/target-value.vue co
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 10 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -36140,7 +36140,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/tree.vue correctly 
   <div class="t-transfer t-transfer--with-tree">
     <div class="t-transfer__list t-transfer__list-source">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 5 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined" modelvalue="false"><input type="checkbox" class="t-checkbox__former" indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 5 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->
@@ -36174,7 +36174,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/tree.vue correctly 
       </button></div>
     <div class="t-transfer__list t-transfer__list-target">
       <div class="t-transfer__list-header">
-        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false" name="t-transfer"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
+        <div><label class="t-checkbox undefined t-is-disabled" modelvalue="false"><input type="checkbox" class="t-checkbox__former" disabled indeterminate="false"><span class="t-checkbox__input"></span><span class="t-checkbox__label"><!----></span></label><span>0 / 0 项</span></div><span><!----></span>
       </div>
       <div class="t-transfer__list-body">
         <!---->

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -6065,14 +6065,14 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
   <br />
   <br />
   <div
-    class="t-transfer t-transfer-search"
+    class="t-transfer t-transfer__search"
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -6101,10 +6101,10 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body t-transfer-list-with-search"
+        class="t-transfer__list-body t-transfer__list--with-search"
       >
         <div
-          class="t-transfer-list-search-wrapper"
+          class="t-transfer__search-wrapper"
           disabled="false"
           searchvalue=""
         >
@@ -6122,7 +6122,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           </div>
         </div>
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -6132,7 +6132,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6157,7 +6157,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6181,7 +6181,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6205,7 +6205,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6229,7 +6229,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6254,7 +6254,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6278,7 +6278,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6302,7 +6302,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6326,7 +6326,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6351,7 +6351,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6375,7 +6375,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6399,7 +6399,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6423,7 +6423,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6448,7 +6448,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6472,7 +6472,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6496,7 +6496,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6520,7 +6520,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6545,7 +6545,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6569,7 +6569,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6593,7 +6593,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -6623,13 +6623,13 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -6689,10 +6689,10 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -6722,10 +6722,10 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body t-transfer-list-with-search"
+        class="t-transfer__list-body t-transfer__list--with-search"
       >
         <div
-          class="t-transfer-list-search-wrapper"
+          class="t-transfer__search-wrapper"
           disabled="false"
           searchvalue=""
         >
@@ -6743,7 +6743,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           </div>
         </div>
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             Empty Data
@@ -6752,7 +6752,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>

--- a/test/unit/transfer/__snapshots__/demo.test.js.snap
+++ b/test/unit/transfer/__snapshots__/demo.test.js.snap
@@ -7,10 +7,10 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -39,11 +39,11 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -53,7 +53,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -78,7 +78,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -102,7 +102,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -126,7 +126,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -150,7 +150,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -175,7 +175,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -199,7 +199,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -223,7 +223,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -247,7 +247,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -272,7 +272,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -296,7 +296,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -320,7 +320,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -344,7 +344,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -369,7 +369,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -393,7 +393,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -417,7 +417,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -441,7 +441,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -466,7 +466,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -490,7 +490,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -514,7 +514,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -544,13 +544,13 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-base t-button--theme-primary"
@@ -609,10 +609,10 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -642,11 +642,11 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -655,7 +655,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -671,10 +671,10 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -703,11 +703,11 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -717,7 +717,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -742,7 +742,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -766,7 +766,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -790,7 +790,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -814,7 +814,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -839,7 +839,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -863,7 +863,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -887,7 +887,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -911,7 +911,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -936,7 +936,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -960,7 +960,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -984,7 +984,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1008,7 +1008,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1033,7 +1033,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1057,7 +1057,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1081,7 +1081,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1105,7 +1105,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1130,7 +1130,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1154,7 +1154,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-checked t-is-checked t-transfer-list__item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1178,7 +1178,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1208,13 +1208,13 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-base t-button--theme-primary"
@@ -1273,10 +1273,10 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -1306,11 +1306,11 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -1319,7 +1319,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -1337,10 +1337,10 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
     theme="primary"
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -1369,11 +1369,11 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -1383,7 +1383,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1411,7 +1411,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1439,7 +1439,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1467,7 +1467,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1495,7 +1495,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1523,7 +1523,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1551,7 +1551,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1579,7 +1579,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1607,7 +1607,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1635,7 +1635,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1663,7 +1663,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1691,7 +1691,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1719,7 +1719,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1747,7 +1747,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1775,7 +1775,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1803,7 +1803,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1831,7 +1831,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1859,7 +1859,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1887,7 +1887,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1915,7 +1915,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1949,13 +1949,13 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -2015,10 +2015,10 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -2048,11 +2048,11 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -2061,7 +2061,7 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -2073,14 +2073,14 @@ exports[`Transfer Transfer customRenderVue demo works fine 1`] = `
 exports[`Transfer Transfer customVue demo works fine 1`] = `
 <div>
   <div
-    class="t-transfer t-transfer-footer"
+    class="t-transfer t-transfer__footer"
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -2113,11 +2113,11 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -2127,7 +2127,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2151,7 +2151,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2175,7 +2175,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2199,7 +2199,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2223,7 +2223,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2247,7 +2247,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2271,7 +2271,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2295,7 +2295,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2319,7 +2319,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2343,7 +2343,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2367,7 +2367,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2391,7 +2391,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2415,7 +2415,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2439,7 +2439,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2463,7 +2463,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2487,7 +2487,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2511,7 +2511,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2535,7 +2535,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2559,7 +2559,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2583,7 +2583,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2623,7 +2623,7 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
       
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -2657,10 +2657,10 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -2694,11 +2694,11 @@ exports[`Transfer Transfer customVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -2727,10 +2727,10 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -2759,11 +2759,11 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -2773,7 +2773,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2797,7 +2797,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2821,7 +2821,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2845,7 +2845,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2869,7 +2869,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2893,7 +2893,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2917,7 +2917,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2941,7 +2941,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2965,7 +2965,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -2989,7 +2989,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3019,13 +3019,13 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -3085,10 +3085,10 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3118,11 +3118,11 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -3132,7 +3132,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3157,7 +3157,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3182,7 +3182,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3207,7 +3207,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3232,7 +3232,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3257,7 +3257,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3282,7 +3282,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3307,7 +3307,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3332,7 +3332,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3357,7 +3357,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-is-disabled t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-is-disabled t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3388,7 +3388,7 @@ exports[`Transfer Transfer disabledVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -3409,10 +3409,10 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3442,11 +3442,11 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -3455,13 +3455,13 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -3521,10 +3521,10 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3554,11 +3554,11 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -3567,7 +3567,7 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -3583,10 +3583,10 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3616,24 +3616,24 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           No Data
         </div>
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -3693,10 +3693,10 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3726,18 +3726,18 @@ exports[`Transfer Transfer emptyVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           No Data
         </div>
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -3750,15 +3750,15 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
 <div>
   <div
     checked-value=""
-    class="t-transfer t-transfer-pagination"
+    class="t-transfer t-transfer__pagination"
     modelvalue=""
     theme="primary"
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -3787,11 +3787,11 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -3801,7 +3801,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3825,7 +3825,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3849,7 +3849,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3873,7 +3873,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3897,7 +3897,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3921,7 +3921,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3945,7 +3945,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3969,7 +3969,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -3993,7 +3993,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4017,7 +4017,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4046,7 +4046,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-transfer-list__pagination"
+        class="t-transfer__list-pagination"
       >
         <div
           class="t-pagination t-size-s"
@@ -4193,13 +4193,13 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
         </div>
       </div>
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -4259,10 +4259,10 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -4292,11 +4292,11 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -4305,7 +4305,7 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -4318,15 +4318,15 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
 <div>
   <div
     checked-value=""
-    class="t-transfer t-transfer-search"
+    class="t-transfer t-transfer__search"
     modelvalue=""
     theme="primary"
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -4355,10 +4355,10 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body t-transfer-list-with-search"
+        class="t-transfer__list-body t-transfer__list--with-search"
       >
         <div
-          class="t-transfer-list-search-wrapper"
+          class="t-transfer__search-wrapper"
           disabled="false"
           searchvalue=""
         >
@@ -4376,7 +4376,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
           </div>
         </div>
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -4386,7 +4386,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4410,7 +4410,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4434,7 +4434,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4458,7 +4458,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4482,7 +4482,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4506,7 +4506,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4530,7 +4530,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4554,7 +4554,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4578,7 +4578,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4602,7 +4602,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4626,7 +4626,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4650,7 +4650,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4674,7 +4674,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4698,7 +4698,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4722,7 +4722,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4746,7 +4746,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4770,7 +4770,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4794,7 +4794,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4818,7 +4818,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4842,7 +4842,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -4872,13 +4872,13 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -4938,10 +4938,10 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -4971,10 +4971,10 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body t-transfer-list-with-search"
+        class="t-transfer__list-body t-transfer__list--with-search"
       >
         <div
-          class="t-transfer-list-search-wrapper"
+          class="t-transfer__search-wrapper"
           disabled="false"
           searchvalue=""
         >
@@ -4992,7 +4992,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
           </div>
         </div>
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -5001,7 +5001,7 @@ exports[`Transfer Transfer searchVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -5017,10 +5017,10 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
     modelvalue="0,2,4,6,8,10,12,14,16,18"
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -5049,11 +5049,11 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -5063,7 +5063,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5087,7 +5087,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5111,7 +5111,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5135,7 +5135,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5159,7 +5159,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5183,7 +5183,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5207,7 +5207,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5231,7 +5231,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5255,7 +5255,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5279,7 +5279,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5309,13 +5309,13 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -5375,10 +5375,10 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -5407,11 +5407,11 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -5421,7 +5421,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5445,7 +5445,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5469,7 +5469,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5493,7 +5493,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5517,7 +5517,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5541,7 +5541,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5565,7 +5565,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5589,7 +5589,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5613,7 +5613,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5637,7 +5637,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5667,7 +5667,7 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
@@ -5679,14 +5679,14 @@ exports[`Transfer Transfer targetValueVue demo works fine 1`] = `
 exports[`Transfer Transfer treeVue demo works fine 1`] = `
 <div>
   <div
-    class="t-transfer t-transfer-with-tree"
+    class="t-transfer t-transfer--with-tree"
     modelvalue=""
   >
     <div
-      class="t-transfer-list t-transfer-list-source"
+      class="t-transfer__list t-transfer__list-source"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -5715,11 +5715,11 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-list__content narrow-scrollbar"
+          class="t-transfer__list-content narrow-scrollbar"
         >
           <div
             class="t-checkbox-group"
@@ -5729,7 +5729,7 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
             
             
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5753,7 +5753,7 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer-list__item t-transfer-list__item"
+              class="t-checkbox t-transfer__list-item t-transfer__list-item"
               modelvalue="false"
               props="[object Object]"
             >
@@ -5783,13 +5783,13 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>
     </div>
     <div
-      class="t-transfer-operations"
+      class="t-transfer__operations"
     >
       <button
         class="t-button t-size-m t-button--variant-outline t-button--theme-default t-is-disabled"
@@ -5849,10 +5849,10 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
       </button>
     </div>
     <div
-      class="t-transfer-list t-transfer-list-target"
+      class="t-transfer__list t-transfer__list-target"
     >
       <div
-        class="t-transfer-list__header"
+        class="t-transfer__list-header"
       >
         <div>
           <label
@@ -5882,11 +5882,11 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
         </span>
       </div>
       <div
-        class="t-transfer-list__body"
+        class="t-transfer__list-body"
       >
         <!---->
         <div
-          class="t-transfer-empty"
+          class="t-transfer__empty"
         >
           <span>
             暂无数据
@@ -5895,7 +5895,7 @@ exports[`Transfer Transfer treeVue demo works fine 1`] = `
       </div>
       <!---->
       <div
-        class="t-transfer-footer"
+        class="t-transfer__footer"
       >
         
       </div>

--- a/test/unit/transfer/__snapshots__/demo.test.js.snap
+++ b/test/unit/transfer/__snapshots__/demo.test.js.snap
@@ -102,7 +102,7 @@ exports[`Transfer Transfer baseVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -766,7 +766,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -863,7 +863,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -960,7 +960,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1057,7 +1057,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >
@@ -1154,7 +1154,7 @@ exports[`Transfer Transfer checkedVue demo works fine 1`] = `
               </span>
             </label>
             <label
-              class="t-checkbox t-transfer__list-item t-is-checked t-transfer__list-item t-is-checked"
+              class="t-checkbox t-transfer__list-item t-is-checked t-is-checked t-transfer__list-item t-is-checked"
               modelvalue="false"
               props="[object Object]"
             >

--- a/test/unit/transfer/index.test.js
+++ b/test/unit/transfer/index.test.js
@@ -30,7 +30,7 @@ describe('Transfer', () => {
             return <Transfer data={data} checked={checkedValue} pagination={pagination} />;
           },
         });
-        const domLabels = wrapper.vm.$el.querySelectorAll('.t-transfer-list__content')[0].querySelectorAll('label');
+        const domLabels = wrapper.vm.$el.querySelectorAll('.t-transfer__list-content')[0].querySelectorAll('label');
 
         checkedValue.forEach((item) => {
           const i = Number(item);
@@ -47,7 +47,7 @@ describe('Transfer', () => {
             return <Transfer data={data} defaultChecked={checkedValue} pagination={pagination} />;
           },
         });
-        const domLabels = wrapper.vm.$el.querySelectorAll('.t-transfer-list__content')[0].querySelectorAll('label');
+        const domLabels = wrapper.vm.$el.querySelectorAll('.t-transfer__list-content')[0].querySelectorAll('label');
 
         checkedValue.forEach((item) => {
           const i = Number(item);
@@ -70,7 +70,7 @@ describe('Transfer', () => {
           },
         });
 
-        const len = wrapper.vm.$el.querySelectorAll('.t-transfer-list__item').length; // wrapper.vm.$el.getElementsByTagName('li').length
+        const len = wrapper.vm.$el.querySelectorAll('.t-transfer__list-item').length; // wrapper.vm.$el.getElementsByTagName('li').length
         expect(len).toBe(data.length);
         expect(wrapper.vm.$el.getElementsByClassName('t-checkbox t-is-disabled').length).toBe(8);
       });
@@ -82,7 +82,7 @@ describe('Transfer', () => {
           },
         });
 
-        wrapper.vm.$el.querySelectorAll('.t-transfer-list__item').forEach((el, index) => {
+        wrapper.vm.$el.querySelectorAll('.t-transfer__list-item').forEach((el, index) => {
           expect(el.innerHTML.indexOf(data[index].label) > 0).toEqual(true);
         });
       });
@@ -96,7 +96,7 @@ describe('Transfer', () => {
           },
         });
 
-        const [el] = wrapper.vm.$el.querySelectorAll('.t-transfer-operations button');
+        const [el] = wrapper.vm.$el.querySelectorAll('.t-transfer__operations button');
         expect([...el.classList]).toContain('t-is-disabled');
       });
 
@@ -107,7 +107,7 @@ describe('Transfer', () => {
           },
         });
 
-        const [, el] = wrapper.vm.$el.querySelectorAll('.t-transfer-operations button');
+        const [, el] = wrapper.vm.$el.querySelectorAll('.t-transfer__operations button');
         expect([...el.classList]).toContain('t-is-disabled');
       });
 
@@ -118,7 +118,7 @@ describe('Transfer', () => {
           },
         });
 
-        const [right, left] = wrapper.vm.$el.querySelectorAll('.t-transfer-operations button');
+        const [right, left] = wrapper.vm.$el.querySelectorAll('.t-transfer__operations button');
         expect([...right.classList]).not.toContain('t-is-disabled');
         expect([...left.classList]).not.toContain('t-is-disabled');
       });
@@ -149,12 +149,12 @@ describe('Transfer', () => {
           },
         });
 
-        expect(wrapper.vm.$el.querySelector('.t-transfer-empty').innerHTML).toEqual('没有数据~');
+        expect(wrapper.vm.$el.querySelector('.t-transfer__empty').innerHTML).toEqual('没有数据~');
       });
 
       it('function', async () => {
         // eslint-disable-next-line
-        const empty = h => (
+        const empty = (h) => (
           <div>
             <button>数据为空</button>
           </div>
@@ -165,8 +165,8 @@ describe('Transfer', () => {
             return <Transfer empty={empty}></Transfer>;
           },
         });
-        expect(wrapper.vm.$el.querySelector('.t-transfer-empty').outerHTML).toEqual(
-          '<div class="t-transfer-empty"><div><button>数据为空</button></div></div>',
+        expect(wrapper.vm.$el.querySelector('.t-transfer__empty').outerHTML).toEqual(
+          '<div class="t-transfer__empty"><div><button>数据为空</button></div></div>',
         );
       });
     });
@@ -180,7 +180,7 @@ describe('Transfer', () => {
           },
         });
 
-        expect(wrapper.vm.$el.querySelector('.t-transfer-list-source > div:last-child').innerHTML).toEqual(
+        expect(wrapper.vm.$el.querySelector('.t-transfer__list-source > div:last-child').innerHTML).toEqual(
           'render footer: source',
         );
       });
@@ -198,7 +198,7 @@ describe('Transfer', () => {
       //     },
       //   });
       //   expect(wrapper.vm.$el
-      //     .querySelector('.t-transfer-list-source')
+      //     .querySelector('.t-transfer__list-source')
       //     .lastChild.querySelector('p')
       //     .innerHTML)
       //     .toBe('source源');
@@ -221,12 +221,12 @@ describe('Transfer', () => {
       });
 
       it('data length', async () => {
-        const len = wrapper.vm.$el.querySelectorAll('.t-transfer-list__item').length; // wrapper.vm.$el.getElementsByTagName('li').length
+        const len = wrapper.vm.$el.querySelectorAll('.t-transfer__list-item').length; // wrapper.vm.$el.getElementsByTagName('li').length
         expect(len).toBe(otherData.length);
       });
 
       it('key label', async () => {
-        wrapper.vm.$el.querySelectorAll('.t-transfer-list__item').forEach((el, index) => {
+        wrapper.vm.$el.querySelectorAll('.t-transfer__list-item').forEach((el, index) => {
           expect(el.innerHTML.indexOf(otherData[index].name) > 0).toEqual(true);
         });
       });
@@ -241,7 +241,7 @@ describe('Transfer', () => {
           },
         });
 
-        expect(wrapper.vm.$el.querySelectorAll('.t-transfer-operations .t-button__text')[0].innerHTML).toEqual(
+        expect(wrapper.vm.$el.querySelectorAll('.t-transfer__operations .t-button__text')[0].innerHTML).toEqual(
           'to right',
         );
       });
@@ -262,7 +262,7 @@ describe('Transfer', () => {
         });
         const el = wrapper.vm.$el;
 
-        const len = el.querySelectorAll('.t-transfer-list__item').length; // wrapper.vm.$el.getElementsByTagName('li').length
+        const len = el.querySelectorAll('.t-transfer__list-item').length; // wrapper.vm.$el.getElementsByTagName('li').length
         expect(len).toBe(pageSize);
       });
 
@@ -278,7 +278,7 @@ describe('Transfer', () => {
           },
         });
 
-        const [el] = wrapper.vm.$el.querySelectorAll('.t-transfer-list__item');
+        const [el] = wrapper.vm.$el.querySelectorAll('.t-transfer__list-item');
 
         expect(el.querySelector('input').value).toBe(data[(pageConfig.current - 1) * pageConfig.pageSize].value);
       });
@@ -313,7 +313,7 @@ describe('Transfer', () => {
           },
         });
 
-        wrapper.vm.$el.querySelectorAll('.t-transfer-operations button')[0].click();
+        wrapper.vm.$el.querySelectorAll('.t-transfer__operations button')[0].click();
         expect(wrapper.vm.$data.targetValue).toEqual(['1', '2', '5']);
       });
 
@@ -334,7 +334,7 @@ describe('Transfer', () => {
           },
         });
 
-        wrapper.vm.$el.querySelectorAll('.t-transfer-operations button')[0].click();
+        wrapper.vm.$el.querySelectorAll('.t-transfer__operations button')[0].click();
         expect(wrapper.vm.$data.targetValue).toEqual(['1', '5', '2']);
       });
 
@@ -355,7 +355,7 @@ describe('Transfer', () => {
           },
         });
 
-        wrapper.vm.$el.querySelectorAll('.t-transfer-operations button')[0].click();
+        wrapper.vm.$el.querySelectorAll('.t-transfer__operations button')[0].click();
         expect(wrapper.vm.$data.targetValue).toEqual(['2', '1', '5']);
       });
     });
@@ -367,7 +367,7 @@ describe('Transfer', () => {
             title: ['源列表', '目标列表'],
           },
         });
-        const doms = wrapper.vm.$el.querySelectorAll('.t-transfer-list__header');
+        const doms = wrapper.vm.$el.querySelectorAll('.t-transfer__list-header');
         expect(doms[0].lastChild.innerHTML).toEqual('源列表');
         expect(doms[1].lastChild.innerHTML).toEqual('目标列表');
       });
@@ -387,7 +387,7 @@ describe('Transfer', () => {
         });
 
         const allTransferItem = wrapper.vm.$el.querySelectorAll(
-          '.t-transfer-list-source .t-transfer-list__item .transfer-item',
+          '.t-transfer__list-source .t-transfer__list-item .transfer-item',
         );
 
         allTransferItem.forEach((item, index) => {
@@ -415,7 +415,7 @@ describe('Transfer', () => {
         });
 
         const allTransferItem = wrapper.vm.$el.querySelectorAll(
-          '.t-transfer-list-source .t-transfer-list__item .transfer-item',
+          '.t-transfer__list-source .t-transfer__list-item .transfer-item',
         );
 
         allTransferItem.forEach((item, index) => {
@@ -434,7 +434,7 @@ describe('Transfer', () => {
 
         let count = 0;
         const domLabels = wrapper.vm.$el
-          .querySelectorAll('.t-transfer-list-target .t-transfer-list__content')[0]
+          .querySelectorAll('.t-transfer__list-target .t-transfer__list-content')[0]
           .querySelectorAll('.t-checkbox__label');
 
         targetValue.forEach((item) => {
@@ -463,7 +463,7 @@ describe('Transfer', () => {
           },
         });
 
-        wrapper.vm.$el.querySelectorAll('.t-transfer-operations button')[0].click();
+        wrapper.vm.$el.querySelectorAll('.t-transfer__operations button')[0].click();
         expect(wrapper.vm.$data.targetValue).toEqual(['1', '2', '5']);
       });
     });
@@ -478,7 +478,7 @@ describe('Transfer', () => {
         },
       });
 
-      wrapper.vm.$el.querySelectorAll('.t-transfer-operations button')[0].click();
+      wrapper.vm.$el.querySelectorAll('.t-transfer__operations button')[0].click();
 
       await wrapper.vm.$nextTick();
       expect(fn).toHaveBeenCalled();


### PR DESCRIPTION

规范CSS类名。

子仓库修改见：https://github.com/Tencent/tdesign-common/pull/18

Component | old class name | new class name
-- | -- | --
Transfer | t-transfer-list | t-transfer__list
Transfer | t-transfer-list-source | t-transfer__list-source
Transfer | t-transfer-list-target | t-transfer__list-target
Transfer | t-transfer-list__header | t-transfer__list-header
Transfer | t-transfer-list__body | t-transfer__list-body
Transfer | t-transfer-list-with-search | t-transfer__list--with-search
Transfer | t-transfer-list-search-wrapper | t-transfer__search-wrapper
Transfer | t-transfer-list__content | t-transfer__list-content
Transfer | t-transfer-list__item | t-transfer__list-item
Transfer | t-transfer-list__wrapper | t-transfer__list-wrapper
Transfer | t-transfer-list__pagination | t-transfer__list-pagination
Transfer | t-transfer-list__footer | t-transfer__list-footer
Transfer | t-transfer-operations | t-transfer__operations
Transfer | t-transfer-search | t-transfer__search
Transfer | t-transfer-with-tree | t-transfer--with-tree
Transfer | t-transfer-pagination | t-transfer__pagination
Transfer | t-transfer-footer | t-transfer__footer
Transfer | t-transfer-wrapper | t-transfer__wrapper
Transfer | t-transfer-empty | t-transfer__empty


