### PR TITLE
chore: upgrade icon-view

### DIFF
--- a/examples/icon/icon.md
+++ b/examples/icon/icon.md
@@ -51,7 +51,7 @@
 
 ### 全部图标
 
-<tdesign-icons-view />
+<td-icons-view />
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "rollup-plugin-styles": "^3.14.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-vue": "^6.0.0",
-    "tdesign-icons-view": "^0.0.1-beta.1",
+    "tdesign-icons-view": "0.0.1",
     "tdesign-publish-cli": "^0.0.8",
     "ts-jest": "^26.0.0",
     "typescript": "^4.5.2",


### PR DESCRIPTION
升级展示用的icon-view包 规范web component 名称为`td-icon-view` 和其他tdesign的web-component保持一致。