### PR TITLE
fix(icon): re-render props

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dayjs": "^1.9.7",
     "less": "^4.1.2",
     "lodash": "^4.17.15",
-    "tdesign-icons-vue-next": "0.0.5-alpha.1",
+    "tdesign-icons-vue-next": "~0.0.5",
     "validator": "^13.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dayjs": "^1.9.7",
     "less": "^4.1.2",
     "lodash": "^4.17.15",
-    "tdesign-icons-vue-next": "0.0.3",
+    "tdesign-icons-vue-next": "0.0.5-alpha.1",
     "validator": "^13.5.1"
   },
   "peerDependencies": {

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -8447,7 +8447,7 @@ exports[`ssr snapshot test renders ./examples/comment/demos/reply.vue correctly 
       <div class="t-comment__inner">
         <div class="t-comment__avatar"><img src="https://tdesign.gtimg.com/site/avatar.jpg" alt class="t-comment__avatar-image"></div>
         <div class="t-comment__content">
-          <div class="t-comment__author"><span class="t-comment__name"><!--[--><span>评论作者名B</span><svg class="t-icon t-icon-caret-right-small t-size-s author-icon author-icon" style="">
+          <div class="t-comment__author"><span class="t-comment__name"><!--[--><span>评论作者名B</span><svg class="t-icon t-icon-caret-right-small t-size-s author-icon" style="">
               <use href="#t-icon-caret-right-small"></use>
             </svg><span>评论作者名A</span>
             <!--]--></span><span class="t-comment__time">今天16:38</span>
@@ -9846,7 +9846,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/dialog.vue c
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-info" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
         </svg>confirm</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">Would you like to be my friends？</div>
@@ -9860,7 +9860,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/dialog.vue c
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-warning" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>confirm</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">Would you like to be my friends？</div>
@@ -9874,7 +9874,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/dialog.vue c
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-danger" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error t-is-error" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>confirm</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">Would you like to be my friends？</div>
@@ -9888,7 +9888,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/dialog.vue c
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-success" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success t-is-success" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
         </svg>confirm</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">Would you like to be my friends？</div>
@@ -9931,7 +9931,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
           <div class="t-input t-size-m t-input--suffix" modelvalue style="width:400px;">
             <!---->
             <!----><input class="t-input__inner" autocomplete="false" placeholder="There is required mark on the left of this input in Form" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -10221,7 +10221,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -10271,7 +10271,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
           <!---->
           <!---->
         </div>
-        <!----><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        <!----><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -10341,7 +10341,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -10541,7 +10541,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
       <div class="t-time-picker__input" size="medium"><span class="t-time-picker__input-placeholder">select time</span></div>
     </div>
     <!--]-->
-  </div><br><br><br><!-- 自定义关闭按钮示例 --><span class="t-tag t-tag--primary t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><br><br><!-- 数组件空数据 -->
+  </div><br><br><br><!-- 自定义关闭按钮示例 --><span class="t-tag t-tag--primary t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->Fearure Tag<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle t-tag__icon-close" style=""><path fill="currentColor" d="M4.98 10.31L7.3 8 5 5.69l.7-.7L8 7.28 10.31 5l.7.7L8.72 8l2.3 2.31-.7.7L8 8.72 5.69 11l-.7-.7z" fillopacity="0.9"></path><path fill="currentColor" d="M8 1a7 7 0 110 14A7 7 0 018 1zm0 1a6 6 0 100 12A6 6 0 008 2z" fillopacity="0.9"></path></svg></span><br><br><!-- 数组件空数据 -->
   <div class="t-tree t-tree--transition">
     <div></div>
     <div class="t-tree__empty">Tree Empty Data</div>
@@ -10693,7 +10693,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/popconfirm.v
       <div class="t-popup__content t-popup__content--arrow t-popconfirm">
         <!--[-->
         <div class="t-popconfirm__content">
-          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
               <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
             </svg>
             <div class="t-popconfirm__inner">Do you want to delete</div>
@@ -10714,7 +10714,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/popconfirm.v
       <div class="t-popup__content t-popup__content--arrow t-popconfirm">
         <!--[-->
         <div class="t-popconfirm__content">
-          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning" style="">
+          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning" style="">
               <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
             </svg>
             <div class="t-popconfirm__inner">Do you want to delete</div>
@@ -10735,7 +10735,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/popconfirm.v
       <div class="t-popup__content t-popup__content--arrow t-popconfirm">
         <!--[-->
         <div class="t-popconfirm__content">
-          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger t-popconfirm__icon--danger" style="">
+          <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger" style="">
               <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
             </svg>
             <div class="t-popconfirm__inner">Do you want to delete</div>
@@ -10755,7 +10755,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/popconfirm.v
     <div class="t-drawer__mask"></div>
     <div class="t-drawer__content-wrapper t-drawer__content-wrapper--right" style="width:300px;height:;">
       <div class="t-drawer__header">Drawer</div>
-      <div class="t-drawer__close-btn"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-submenu-icon t-submenu-icon" style="">
+      <div class="t-drawer__close-btn"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-submenu-icon" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></div>
       <div class="t-drawer__body narrow-scrollbar">
@@ -10808,9 +10808,9 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/table.vue co
                             </div>
                           </div>
                           <!--[-->
-                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:18px;transform:rotate(-180deg);top:-1px;left:0px;">
+                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:18px;transform:rotate(-180deg);top:-1px;left:0px;">
                             <path fill="currentColor" d="M11 6H5l3 4.5L11 6z" fillopacity="0.9"></path>
-                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:18px;left:0px;bottom:-1px;">
+                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:18px;left:0px;bottom:-1px;">
                             <path fill="currentColor" d="M11 6H5l3 4.5L11 6z" fillopacity="0.9"></path>
                           </svg>
                           <!--]-->
@@ -10875,9 +10875,9 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/table.vue co
                             </div>
                           </div>
                           <!--[-->
-                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:18px;transform:rotate(-180deg);top:-1px;left:0px;">
+                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:18px;transform:rotate(-180deg);top:-1px;left:0px;">
                             <path fill="currentColor" d="M11 6H5l3 4.5L11 6z" fillopacity="0.9"></path>
-                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:18px;left:0px;bottom:-1px;">
+                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:18px;left:0px;bottom:-1px;">
                             <path fill="currentColor" d="M11 6H5l3 4.5L11 6z" fillopacity="0.9"></path>
                           </svg>
                           <!--]-->
@@ -15476,7 +15476,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/icon.vue correctly 1`
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-info" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
         </svg>下单确认</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">信息已全部保存，是否确认下单？</div>
@@ -15490,7 +15490,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/icon.vue correctly 1`
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-warning" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>温馨提示</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">系统重启后会短暂影响页面访问，确认重启吗？</div>
@@ -15504,7 +15504,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/icon.vue correctly 1`
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-danger" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error t-is-error" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>推送失败</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">请检查推送数据是否符合要求</div>
@@ -15518,7 +15518,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/icon.vue correctly 1`
     <!--[-->
     <!---->
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-success" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success t-is-success" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
         </svg>操作成功</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">是否前往查看订单列表</div>
@@ -15630,7 +15630,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/warning.vue correctly
     <!--[-->
     <div class="t-dialog__mask"></div>
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-info t-dialog--fixed" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
         </svg>提示</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">对话框内容</div>
@@ -15644,7 +15644,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/warning.vue correctly
     <!--[-->
     <div class="t-dialog__mask"></div>
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-success t-dialog--fixed" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success t-is-success" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success" style="">
           <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
         </svg>恭喜</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">对话框内容</div>
@@ -15658,7 +15658,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/warning.vue correctly
     <!--[-->
     <div class="t-dialog__mask"></div>
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-warning t-dialog--fixed" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-warning" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>警示</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">对话框内容</div>
@@ -15674,7 +15674,7 @@ exports[`ssr snapshot test renders ./examples/dialog/demos/warning.vue correctly
     <!--[-->
     <div class="t-dialog__mask"></div>
     <div class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-danger t-dialog--fixed" style="max-height:calc(100% - 20%);">
-      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error t-is-error" style="">
+      <div class="t-dialog__header"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-is-error" style="">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
         </svg>错误</div><span class="t-dialog__close"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
       <div class="t-dialog__body__icon">对话框内容</div>
@@ -15788,7 +15788,7 @@ exports[`ssr snapshot test renders ./examples/drawer/demos/base.vue correctly 1`
     <div class="t-drawer__mask"></div>
     <div class="t-drawer__content-wrapper t-drawer__content-wrapper--right" style="width:300px;height:;">
       <div class="t-drawer__header">header</div>
-      <div class="t-drawer__close-btn"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-submenu-icon t-submenu-icon" style="">
+      <div class="t-drawer__close-btn"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-submenu-icon" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></div>
       <div class="t-drawer__body narrow-scrollbar">
@@ -16145,7 +16145,7 @@ exports[`ssr snapshot test renders ./examples/dropdown/demos/custom.vue correctl
             </div>
             <div maxcolumnwidth="100" mincolumnwidth="100">
               <div class="t-dropdown__item t-dropdown--suffix">
-                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项二</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon" style="">
+                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项二</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon" style="">
                   <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
                 </svg>
               </div>
@@ -16469,7 +16469,7 @@ exports[`ssr snapshot test renders ./examples/dropdown/demos/multiple.vue correc
             <!--[-->
             <div maxcolumnwidth="120" mincolumnwidth="10">
               <div class="t-dropdown__item t-dropdown--suffix">
-                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项一</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon" style="">
+                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项一</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon" style="">
                   <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
                 </svg>
               </div>
@@ -16477,7 +16477,7 @@ exports[`ssr snapshot test renders ./examples/dropdown/demos/multiple.vue correc
             </div>
             <div maxcolumnwidth="120" mincolumnwidth="10">
               <div class="t-dropdown__item t-dropdown--suffix">
-                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项二选项二选项二选项二</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon" style="">
+                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项二选项二选项二选项二</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon" style="">
                   <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
                 </svg>
               </div>
@@ -16485,7 +16485,7 @@ exports[`ssr snapshot test renders ./examples/dropdown/demos/multiple.vue correc
             </div>
             <div maxcolumnwidth="120" mincolumnwidth="10">
               <div class="t-dropdown__item t-dropdown--suffix">
-                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项三</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon" style="">
+                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项三</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon" style="">
                   <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
                 </svg>
               </div>
@@ -16493,7 +16493,7 @@ exports[`ssr snapshot test renders ./examples/dropdown/demos/multiple.vue correc
             </div>
             <div maxcolumnwidth="120" mincolumnwidth="10">
               <div class="t-dropdown__item t-dropdown--suffix">
-                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项四</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon" style="">
+                <div class="t-dropdown__item-content"><span class="t-dropdown__item-text">选项四</span></div><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-dropdown__item__item-icon" style="">
                   <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fillopacity="0.9"></path>
                 </svg>
               </div>
@@ -16645,7 +16645,7 @@ exports[`ssr snapshot test renders ./examples/form/demos/align.vue correctly 1`]
           <div class="t-input t-size-m t-input--suffix" modelvalue>
             <!---->
             <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -16798,7 +16798,7 @@ exports[`ssr snapshot test renders ./examples/form/demos/custom-validator.vue co
           <div class="t-input t-size-m t-input--suffix" modelvalue>
             <!---->
             <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -16814,7 +16814,7 @@ exports[`ssr snapshot test renders ./examples/form/demos/custom-validator.vue co
           <div class="t-input t-size-m t-input--suffix" modelvalue>
             <!---->
             <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -16874,7 +16874,7 @@ exports[`ssr snapshot test renders ./examples/form/demos/layout.vue correctly 1`
           <div class="t-input t-size-m t-input--suffix" modelvalue>
             <!---->
             <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -16914,7 +16914,7 @@ exports[`ssr snapshot test renders ./examples/form/demos/login.vue correctly 1`]
           <!--[-->
           <div class="t-input t-size-m t-input--prefix t-input--suffix" modelvalue><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fillopacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fillopacity="0.9"></path></svg><!--]--></span>
             <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入密码" type="password" value>
-            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+            <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
           </div>
           <!--]-->
           <!---->
@@ -18335,11 +18335,11 @@ exports[`ssr snapshot test renders ./examples/input/demos/password.vue correctly
 <div class="tdesign-demo-block-column" style="max-width:500px;">
   <div class="t-input t-size-m t-input--prefix t-input--suffix"><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fillopacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fillopacity="0.9"></path></svg><!--]--></span>
     <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value="520 TDesign">
-    <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+    <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
   </div><!-- 使用 function 的形式定义 icon -->
   <div class="t-input t-size-m t-input--prefix t-input--suffix"><span class="t-input__prefix t-input__prefix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fillopacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fillopacity="0.9"></path></svg></span>
     <!----><input class="t-input__inner" autocomplete="false" placeholder="请输入" type="password" value="520 TDesign">
-    <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
+    <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fillopacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fillopacity="0.9"></path></svg></span>
   </div>
 </div>
 `;
@@ -18843,11 +18843,11 @@ exports[`ssr snapshot test renders ./examples/layout/demos/combine.vue correctly
             <!--]-->
           </ul>
           <div class="t-menu__operations">
-            <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+            <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
                 <use href="#t-icon-search"></use>
-              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-notification-filled t-menu__operations-icon t-menu__operations-icon" style="">
+              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-notification-filled t-menu__operations-icon" style="">
                 <use href="#t-icon-notification-filled"></use>
-              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-home t-menu__operations-icon t-menu__operations-icon" style="">
+              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-home t-menu__operations-icon" style="">
                 <use href="#t-icon-home"></use>
               </svg></a>
             <!--]-->
@@ -18976,11 +18976,11 @@ exports[`ssr snapshot test renders ./examples/layout/demos/top.vue correctly 1`]
             <!--]-->
           </ul>
           <div class="t-menu__operations">
-            <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+            <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
                 <use href="#t-icon-search"></use>
-              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-notification-filled t-menu__operations-icon t-menu__operations-icon" style="">
+              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-notification-filled t-menu__operations-icon" style="">
                 <use href="#t-icon-notification-filled"></use>
-              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-home t-menu__operations-icon t-menu__operations-icon" style="">
+              </svg></a><a href="javascript:;"><svg class="t-icon t-icon-home t-menu__operations-icon" style="">
                 <use href="#t-icon-home"></use>
               </svg></a>
             <!--]-->
@@ -20117,7 +20117,7 @@ exports[`ssr snapshot test renders ./examples/menu/demos/closable-side.vue corre
       <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><svg class="t-icon t-icon-chevron-right t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><svg class="t-icon t-icon-chevron-right t-menu__operations-icon" style="">
         <use href="#t-icon-chevron-right"></use>
       </svg>
       <!--]-->
@@ -20239,13 +20239,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/double.vue correctly 1`
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -20306,13 +20306,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/double.vue correctly 1`
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -20365,7 +20365,7 @@ exports[`ssr snapshot test renders ./examples/menu/demos/group-side.vue correctl
       <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon" style="">
         <use href="#t-icon-view-list"></use>
       </svg>
       <!--]-->
@@ -20398,13 +20398,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/head-menu-dark.vue corr
       <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
           <use href="#t-icon-search"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
           <use href="#t-icon-mail"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
           <use href="#t-icon-user"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
           <use href="#t-icon-ellipsis"></use>
         </svg></a>
       <!--]-->
@@ -20464,13 +20464,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/head-menu-mode-tile.vue
       <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
           <use href="#t-icon-search"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
           <use href="#t-icon-mail"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
           <use href="#t-icon-user"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
           <use href="#t-icon-ellipsis"></use>
         </svg></a>
       <!--]-->
@@ -20542,13 +20542,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/head-menu-tile.vue corr
     <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
           <use href="#t-icon-search"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
           <use href="#t-icon-mail"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
           <use href="#t-icon-user"></use>
-        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+        </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
           <use href="#t-icon-ellipsis"></use>
         </svg></a>
       <!--]-->
@@ -20676,7 +20676,7 @@ exports[`ssr snapshot test renders ./examples/menu/demos/multi-side.vue correctl
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon" style="">
           <use href="#t-icon-view-list"></use>
         </svg>
         <!--]-->
@@ -20805,7 +20805,7 @@ exports[`ssr snapshot test renders ./examples/menu/demos/multi-side.vue correctl
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon" style="">
           <use href="#t-icon-view-list"></use>
         </svg>
         <!--]-->
@@ -20919,13 +20919,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/multiple.vue correctly 
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -20994,13 +20994,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/multiple.vue correctly 
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -21087,7 +21087,7 @@ exports[`ssr snapshot test renders ./examples/menu/demos/popup-side.vue correctl
       <!--]-->
     </ul>
     <div class="t-menu__operations">
-      <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon" style="">
+      <!--[--><svg class="t-icon t-icon-view-list t-menu__operations-icon" style="">
         <use href="#t-icon-view-list"></use>
       </svg>
       <!--]-->
@@ -21146,13 +21146,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/single.vue correctly 1`
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -21180,13 +21180,13 @@ exports[`ssr snapshot test renders ./examples/menu/demos/single.vue correctly 1`
         <!--]-->
       </ul>
       <div class="t-menu__operations">
-        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon" style="">
+        <!--[--><a href="javascript:;"><svg class="t-icon t-icon-search t-menu__operations-icon" style="">
             <use href="#t-icon-search"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-mail t-menu__operations-icon" style="">
             <use href="#t-icon-mail"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-user t-menu__operations-icon" style="">
             <use href="#t-icon-user"></use>
-          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon" style="">
+          </svg></a><a href="javascript:;"><svg class="t-icon t-icon-ellipsis t-menu__operations-icon" style="">
             <use href="#t-icon-ellipsis"></use>
           </svg></a>
         <!--]-->
@@ -21566,7 +21566,7 @@ exports[`ssr snapshot test renders ./examples/message/demos/type.vue correctly 1
 exports[`ssr snapshot test renders ./examples/notification/demos/base.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21578,7 +21578,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/base.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21596,7 +21596,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/base.vue correc
 exports[`ssr snapshot test renders ./examples/notification/demos/close.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21608,7 +21608,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/close.vue corre
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21620,7 +21620,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/close.vue corre
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21632,7 +21632,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/close.vue corre
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21656,7 +21656,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/close-all.vue c
 exports[`ssr snapshot test renders ./examples/notification/demos/content.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21668,7 +21668,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/content.vue cor
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21682,7 +21682,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/content.vue cor
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21715,7 +21715,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/fix-plugin.vue 
 exports[`ssr snapshot test renders ./examples/notification/demos/footer.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21727,7 +21727,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/footer.vue corr
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21746,7 +21746,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/footer.vue corr
 exports[`ssr snapshot test renders ./examples/notification/demos/icon.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21758,7 +21758,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/icon.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-error t-is-error" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-error" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21770,7 +21770,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/icon.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-warning t-is-warning" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-warning" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21782,7 +21782,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/icon.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success t-is-success" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21801,7 +21801,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/offset.vue corr
 exports[`ssr snapshot test renders ./examples/notification/demos/operation.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21813,7 +21813,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/operation.vue c
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21825,7 +21825,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/operation.vue c
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21863,7 +21863,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/placement.vue c
 exports[`ssr snapshot test renders ./examples/notification/demos/size.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21875,7 +21875,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/size.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21894,7 +21894,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/toggle.vue corr
 exports[`ssr snapshot test renders ./examples/notification/demos/type.vue correctly 1`] = `
 <div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info t-is-info" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-info" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21906,7 +21906,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/type.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success t-is-success" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-is-success" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21918,7 +21918,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/type.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-warning t-is-warning" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-warning" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -21930,7 +21930,7 @@ exports[`ssr snapshot test renders ./examples/notification/demos/type.vue correc
     </div>
   </div>
   <div class="t-notification">
-    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-error t-is-error" style="">
+    <div class="t-notification__icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-is-error" style="">
         <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
       </svg></div>
     <div class="t-notification__main">
@@ -22671,7 +22671,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/base.vue correctl
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                   <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">确认删除订单吗</div>
@@ -22694,7 +22694,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/base.vue correctl
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                   <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">是否提交审核？（自由控制浮层显示或隐藏）</div>
@@ -22725,7 +22725,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/button.vue correc
         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
           <!--[-->
           <div class="t-popconfirm__content">
-            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
               </svg>
               <div class="t-popconfirm__inner">您确定要提交吗</div>
@@ -22746,7 +22746,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/button.vue correc
         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
           <!--[-->
           <div class="t-popconfirm__content">
-            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
               </svg>
               <div class="t-popconfirm__inner">您确定要提交吗</div>
@@ -22767,7 +22767,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/button.vue correc
         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
           <!--[-->
           <div class="t-popconfirm__content">
-            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
               </svg>
               <div class="t-popconfirm__inner">您确定要提交吗</div>
@@ -22801,7 +22801,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/describe.vue corr
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                   <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">
@@ -22829,7 +22829,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/describe.vue corr
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning" style="">
                   <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">
@@ -22864,7 +22864,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/icon.vue correctl
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                   <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">普通事件通知类型偏向于确认</div>
@@ -22887,7 +22887,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/icon.vue correctl
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning" style="">
                   <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">事件通知类型偏向于提示</div>
@@ -22910,7 +22910,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/icon.vue correctl
           <div class="t-popup__content t-popup__content--arrow t-popconfirm">
             <!--[-->
             <div class="t-popconfirm__content">
-              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger t-popconfirm__icon--danger" style="">
+              <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger" style="">
                   <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
                 </svg>
                 <div class="t-popconfirm__inner">事件通知类型偏向于高危提醒</div>
@@ -22991,7 +22991,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/inherit.vue corre
         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
           <!--[-->
           <div class="t-popconfirm__content">
-            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
               </svg>
               <div class="t-popconfirm__inner">直接使用 placement 进行设置</div>
@@ -23012,7 +23012,7 @@ exports[`ssr snapshot test renders ./examples/popconfirm/demos/inherit.vue corre
         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
           <!--[-->
           <div class="t-popconfirm__content">
-            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
               </svg>
               <div class="t-popconfirm__inner">透传属性到 Popup 组件进行设置</div>
@@ -23449,7 +23449,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--success" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon" style="">
               <path fill="currentColor" d="M6.43 9.92l6.23-6.22.92.92-7.15 7.14L1.97 7.3l.92-.92 3.54 3.54z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23464,7 +23464,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--error" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon" style="">
               <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23479,7 +23479,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--warning" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon" style="">
               <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23668,7 +23668,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/line.vue correctly 
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:60%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -23681,7 +23681,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/line.vue correctly 
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:60%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -23694,7 +23694,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/line.vue correctly 
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:60%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -23844,7 +23844,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--error" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon" style="">
               <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23858,7 +23858,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--warning" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon" style="">
               <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23872,7 +23872,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
         <!---->
         <!---->
         <div class="t-progress--circle t-progress--status--success" style="width:112px;height:112px;font-size:20px;">
-          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon t-progress__icon" style="">
+          <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon" style="">
               <path fill="currentColor" d="M6.43 9.92l6.23-6.22.92.92-7.15 7.14L1.97 7.3l.92-.92 3.54 3.54z" fillopacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
             <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23919,7 +23919,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:80%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM4.5 8.2l.7-.7L7 9.3l3.8-3.8.7.7L7 10.7 4.5 8.2z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -23940,7 +23940,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
       <!---->
       <!---->
       <div class="t-progress--circle t-progress--status--warning" style="width:112px;height:112px;font-size:20px;">
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon" style="">
             <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fillopacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
           <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23956,7 +23956,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:80%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -23977,7 +23977,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
       <!---->
       <!---->
       <div class="t-progress--circle t-progress--status--error" style="width:112px;height:112px;font-size:20px;">
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon" style="">
             <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
           <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -23993,7 +23993,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:80%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -24015,7 +24015,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__bar" style="height:undefinedpx;background-color:;border-radius:undefinedpx;">
           <div class="t-progress__inner" style="width:80%;background:;"></div>
         </div>
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error-circle-filled t-progress__icon" style="">
             <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM8.5 4v5.5h-1V4h1zm-1.1 7h1.2v1.2H7.4V11z" fillopacity="0.9"></path>
           </svg></div>
       </div>
@@ -24026,7 +24026,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
       <!---->
       <!---->
       <div class="t-progress--circle t-progress--status--warning" style="width:112px;height:112px;font-size:20px;">
-        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon t-progress__icon" style="">
+        <div class="t-progress__info"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon" style="">
             <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fillopacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewbox="0 0 112 112">
           <circle cx="56" cy="56" r="53" stroke-width="6" stroke fill="none" class="t-progress__circle-outer"></circle>
@@ -24263,9 +24263,9 @@ exports[`ssr snapshot test renders ./examples/select/demos/collapsed.vue correct
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[-->+1<!--]--><!----></span>
@@ -24306,9 +24306,9 @@ exports[`ssr snapshot test renders ./examples/select/demos/collapsed.vue correct
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]-->
@@ -24361,9 +24361,9 @@ exports[`ssr snapshot test renders ./examples/select/demos/collapsed.vue correct
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="选项三"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项三<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]-->
@@ -24721,7 +24721,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/custom-selected.vue c
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项一(1)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项二(2)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项三(3)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项一(1)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项二(2)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项三(3)<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;"><!----><!--[-->+3<!--]--><!----></span>
         <!---->
         <!----><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="">
@@ -24767,7 +24767,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/custom-selected.vue c
         <!---->
         <!---->
         <!--[-->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项四(4) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项五(5) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项六(6) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项七(7) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项四(4) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项五(5) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项六(6) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->选项七(7) <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
         <!--]-->
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;"><!----><!--[-->+4<!--]--><!----></span>
         <!---->
@@ -25197,7 +25197,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/label-in-value.vue co
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="选项一"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->选项一<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;"><!----><!--[-->+1<!--]--><!----></span>
@@ -25292,9 +25292,9 @@ exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctl
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="架构云"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->架构云<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="架构云"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->架构云<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="区块链"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->区块链<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="区块链"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->区块链<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[-->+1<!--]--><!----></span>
@@ -25340,17 +25340,17 @@ exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctl
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="1"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->1<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="1"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->1<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="2"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->2<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="2"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->2<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="3"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->3<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="3"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->3<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="4"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->4<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="4"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->4<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="5"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->5<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="5"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->5<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="6"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->6<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="6"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->6<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;"><!----><!--[-->+6<!--]--><!----></span>
@@ -25396,13 +25396,13 @@ exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctl
       <div class="t-select t-size-m">
         <!---->
         <!---->
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="区块链"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->区块链<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="区块链"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->区块链<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="人工智能"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->人工智能<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;" title="人工智能"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->人工智能<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="计算场景"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->计算场景<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="计算场景"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->计算场景<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="大数据"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->大数据<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+        </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%px;max-width:100%;display:none;" title="大数据"><!----><span style="max-width:100%px;" class="t-tag--text"><!--[-->大数据<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
           <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
         </svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[-->+2<!--]--><!----></span>
@@ -26782,7 +26782,7 @@ exports[`ssr snapshot test renders ./examples/steps/demos/icon.vue correctly 1`]
   <!--[-->
   <div class="t-steps-item t-steps-item--finish">
     <div class="t-steps-item__inner">
-      <div class="t-steps-item__icon t-steps-item--finish"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-login icon-margin icon-margin" style="font-size:24;">
+      <div class="t-steps-item__icon t-steps-item--finish"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-login icon-margin" style="font-size:24;">
           <path fill="currentColor" d="M8.48 7.5L6.23 5.25l.7-.7 3.1 3.1c.2.2.2.5 0 .7l-3.1 3.1-.7-.7L8.48 8.5H1v-1h7.48z" fillopacity="0.9"></path>
           <path fill="currentColor" d="M4 5V3h8v10H4v-2H3v2.5c0 .28.22.5.5.5h9a.5.5 0 00.5-.5v-11a.5.5 0 00-.5-.5h-9a.5.5 0 00-.5.5V5h1z" fillopacity="0.9"></path>
         </svg></div>
@@ -26797,7 +26797,7 @@ exports[`ssr snapshot test renders ./examples/steps/demos/icon.vue correctly 1`]
   </div>
   <div class="t-steps-item t-steps-item--process">
     <div class="t-steps-item__inner">
-      <div class="t-steps-item__icon t-steps-item--process"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-cart icon-margin icon-margin" style="font-size:24;">
+      <div class="t-steps-item__icon t-steps-item--process"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-cart icon-margin" style="font-size:24;">
           <path fill="currentColor" d="M1 3h1.58l1.39 8.33c.06.39.4.67.78.67H14v-1H4.92L4.6 9h8.63a.8.8 0 00.78-.6l.85-3.4a.8.8 0 00-.78-1H3.76l-.23-1.33A.8.8 0 002.75 2H1v1zm12.07 5H4.42l-.5-3h9.9l-.75 3zM4.75 14.5a.75.75 0 100-1.5.75.75 0 000 1.5zM12.81 14.5a.75.75 0 100-1.5.75.75 0 000 1.5z" fillopacity="0.9"></path>
         </svg></div>
       <div class="t-steps-item__content">
@@ -26811,7 +26811,7 @@ exports[`ssr snapshot test renders ./examples/steps/demos/icon.vue correctly 1`]
   </div>
   <div class="t-steps-item t-steps-item--default">
     <div class="t-steps-item__inner">
-      <div class="t-steps-item__icon t-steps-item--default"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-wallet icon-margin icon-margin" style="font-size:24;">
+      <div class="t-steps-item__icon t-steps-item--default"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-wallet icon-margin" style="font-size:24;">
           <path fill="currentColor" d="M11.5 4.5h2a1 1 0 011 1V12a1 1 0 01-1 1h-11a1 1 0 01-1-1V3a1 1 0 011-1h8a1 1 0 011 1v1.5zm-1-1.5h-8v1.5h8V3zm3 2.5h-11V12h11V5.5z" fillopacity="0.9"></path>
         </svg></div>
       <div class="t-steps-item__content">
@@ -26825,7 +26825,7 @@ exports[`ssr snapshot test renders ./examples/steps/demos/icon.vue correctly 1`]
   </div>
   <div class="t-steps-item t-steps-item--default">
     <div class="t-steps-item__inner">
-      <div class="t-steps-item__icon t-steps-item--default"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle icon-margin icon-margin" style="font-size:24;">
+      <div class="t-steps-item__icon t-steps-item--default"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check-circle icon-margin" style="font-size:24;">
           <path fill="currentColor" d="M4.5 8.2L7 10.7l4.5-4.5-.7-.7L7 9.3 5.2 7.5l-.7.7z" fillopacity="0.9"></path>
           <path fill="currentColor" d="M4.11 2.18a7 7 0 117.78 11.64A7 7 0 014.1 2.18zm.56 10.8a6 6 0 106.66-9.97A6 6 0 004.67 13z" fillopacity="0.9"></path>
         </svg></div>
@@ -28217,9 +28217,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/data-sort.vue correctl
                               </div>
                             </div>
                             <!--[-->
-                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                             </svg>
                             <!--]-->
@@ -28241,9 +28241,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/data-sort.vue correctl
                               </div>
                             </div>
                             <!--[-->
-                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                             </svg>
                             <!--]-->
@@ -29003,7 +29003,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                             <div class="t-popup__arrow"></div>
                           </div>
                         </div>
-                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon" style="" name="filter">
+                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon" style="" name="filter">
                           <path fill="currentColor" d="M2 3a1 1 0 011-1h10a1 1 0 011 1v1.79l-4.25 2.5V14h-3.5V7.29L2 4.79V3zm11 0H3v1.21l4.25 2.5V13h1.5V6.71L13 4.21V3z" fillopacity="0.9"></path>
                         </svg>
                         <!--]-->
@@ -29031,7 +29031,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                             <div class="t-popup__arrow"></div>
                           </div>
                         </div>
-                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon" style="" name="filter">
+                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon" style="" name="filter">
                           <path fill="currentColor" d="M2 3a1 1 0 011-1h10a1 1 0 011 1v1.79l-4.25 2.5V14h-3.5V7.29L2 4.79V3zm11 0H3v1.21l4.25 2.5V13h1.5V6.71L13 4.21V3z" fillopacity="0.9"></path>
                         </svg>
                         <!--]-->
@@ -29061,7 +29061,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                             <div class="t-popup__arrow"></div>
                           </div>
                         </div>
-                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon" style="" name="filter">
+                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon" style="" name="filter">
                           <path fill="currentColor" d="M2 3a1 1 0 011-1h10a1 1 0 011 1v1.79l-4.25 2.5V14h-3.5V7.29L2 4.79V3zm11 0H3v1.21l4.25 2.5V13h1.5V6.71L13 4.21V3z" fillopacity="0.9"></path>
                         </svg>
                         <!--]-->
@@ -29169,7 +29169,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                             <div class="t-popup__arrow"></div>
                           </div>
                         </div>
-                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon" style="" name="filter">
+                        <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-filter t-table__filter-icon" style="" name="filter">
                           <path fill="currentColor" d="M2 3a1 1 0 011-1h10a1 1 0 011 1v1.79l-4.25 2.5V14h-3.5V7.29L2 4.79V3zm11 0H3v1.21l4.25 2.5V13h1.5V6.71L13 4.21V3z" fillopacity="0.9"></path>
                         </svg>
                         <!--]-->
@@ -30506,9 +30506,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/multiple-sort.vue corr
                               </div>
                             </div>
                             <!--[-->
-                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc t-table__sort-icon t-table__sort-icon--active t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                             </svg>
                             <!--]-->
@@ -30530,9 +30530,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/multiple-sort.vue corr
                               </div>
                             </div>
                             <!--[-->
-                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-asc t-table__sort-icon t-table__sort-icon--active t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                            <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                            </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                               <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                             </svg>
                             <!--]-->
@@ -31352,9 +31352,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/single-sort.vue correc
                             </div>
                           </div>
                           <!--[-->
-                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                             <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc t-table__sort-icon t-table__sort-icon--active t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                             <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                           </svg>
                           <!--]-->
@@ -31376,9 +31376,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/single-sort.vue correc
                             </div>
                           </div>
                           <!--[-->
-                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
+                          <!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc" style="font-size:16px;transform:rotate(-180deg);top:-1px;left:0px;">
                             <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
-                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
+                          </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc" style="font-size:16px;left:0px;bottom:-1px;">
                             <path fill="currentColor" d="M3.54 6.46l.92-.92L8 9.08l3.54-3.54.92.92L8 10.92 3.54 6.46z" fillopacity="0.9"></path>
                           </svg>
                           <!--]-->
@@ -31518,7 +31518,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
                         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
                           <!--[-->
                           <div class="t-popconfirm__content">
-                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                               </svg>
                               <div class="t-popconfirm__inner">确认删除吗</div>
@@ -31555,7 +31555,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
                         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
                           <!--[-->
                           <div class="t-popconfirm__content">
-                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                               </svg>
                               <div class="t-popconfirm__inner">确认删除吗</div>
@@ -31592,7 +31592,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
                         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
                           <!--[-->
                           <div class="t-popconfirm__content">
-                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                               </svg>
                               <div class="t-popconfirm__inner">确认删除吗</div>
@@ -31629,7 +31629,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
                         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
                           <!--[-->
                           <div class="t-popconfirm__content">
-                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                               </svg>
                               <div class="t-popconfirm__inner">确认删除吗</div>
@@ -31666,7 +31666,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
                         <div class="t-popup__content t-popup__content--arrow t-popconfirm">
                           <!--[-->
                           <div class="t-popconfirm__content">
-                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default" style="">
+                            <div class="t-popconfirm__body"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default" style="">
                                 <path fill="currentColor" d="M8 15A7 7 0 108 1a7 7 0 000 14zM7.4 4h1.2v1.2H7.4V4zm.1 2.5h1V12h-1V6.5z" fillopacity="0.9"></path>
                               </svg>
                               <div class="t-popconfirm__inner">确认删除吗</div>
@@ -32191,10 +32191,10 @@ exports[`ssr snapshot test renders ./examples/tabs/demos/custom.vue correctly 1`
             <div class="t-tabs__nav-wrap t-is-smooth" style="transform:translate3d(0px, 0, 0);">
               <!---->
               <!--[-->
-              <div class="t-tabs__nav-item t-tabs__nav--card t-is-active t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡1</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn remove-btn" style="">
+              <div class="t-tabs__nav-item t-tabs__nav--card t-is-active t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡1</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn" style="">
                   <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
                 </svg></div>
-              <div class="t-tabs__nav-item t-tabs__nav--card t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡2</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn remove-btn" style="">
+              <div class="t-tabs__nav-item t-tabs__nav--card t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡2</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn" style="">
                   <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
                 </svg></div>
               <!--]-->
@@ -32246,13 +32246,13 @@ exports[`ssr snapshot test renders ./examples/tabs/demos/icon.vue correctly 1`] 
               <div class="t-tabs__bar t-is-top" style=""></div>
               <!--[-->
               <div class="t-tabs__nav-item t-is-active t-size-m">
-                <div class="t-tabs__nav-item-wrapper t-is-active"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-home tabs-icon-margin tabs-icon-margin" style=""><use href="#t-icon-home"></use></svg> 首页 <!--]--></span></div>
+                <div class="t-tabs__nav-item-wrapper t-is-active"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-home tabs-icon-margin" style=""><use href="#t-icon-home"></use></svg> 首页 <!--]--></span></div>
               </div>
               <div class="t-tabs__nav-item t-size-m">
-                <div class="t-tabs__nav-item-wrapper"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-calendar tabs-icon-margin tabs-icon-margin" style=""><use href="#t-icon-calendar"></use></svg> 日程 <!--]--></span></div>
+                <div class="t-tabs__nav-item-wrapper"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-calendar tabs-icon-margin" style=""><use href="#t-icon-calendar"></use></svg> 日程 <!--]--></span></div>
               </div>
               <div class="t-tabs__nav-item t-size-m">
-                <div class="t-tabs__nav-item-wrapper"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-layers tabs-icon-margin tabs-icon-margin" style=""><use href="#t-icon-layers"></use></svg> 事项 <!--]--></span></div>
+                <div class="t-tabs__nav-item-wrapper"><span class="t-tabs__nav-item-text-wrapper"><!--[--><svg class="t-icon t-icon-layers tabs-icon-margin" style=""><use href="#t-icon-layers"></use></svg> 事项 <!--]--></span></div>
               </div>
               <!--]-->
             </div>
@@ -32304,7 +32304,7 @@ exports[`ssr snapshot test renders ./examples/tabs/demos/operation.vue correctly
               <div class="t-tabs__nav-item t-tabs__nav--card t-is-active t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡</span>
                 <!---->
               </div>
-              <div class="t-tabs__nav-item t-tabs__nav--card t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn remove-btn" style="">
+              <div class="t-tabs__nav-item t-tabs__nav--card t-size-m"><span class="t-tabs__nav-item-text-wrapper">原有选项卡</span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close remove-btn" style="">
                   <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
                 </svg></div>
               <!--]-->
@@ -32595,15 +32595,15 @@ exports[`ssr snapshot test renders ./examples/tag/demos/base.vue correctly 1`] =
 
 exports[`ssr snapshot test renders ./examples/tag/demos/delete.vue correctly 1`] = `
 <div class="tag-demo">
-  <div class="tag-block"><span class="t-tag t-tag--primary t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
-  <div class="tag-block light"><span class="t-tag t-tag--primary t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
-  <div class="tag-block plain"><span class="t-tag t-tag--primary t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
+  <div class="tag-block"><span class="t-tag t-tag--primary t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--dark t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
+  <div class="tag-block light"><span class="t-tag t-tag--primary t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--light t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
+  <div class="tag-block plain"><span class="t-tag t-tag--primary t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签一 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签二 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签三 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-size-m t-tag--plain t-tag--close" style=""><!----><!--[--> 标签四 <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span></div>
   <div class="tag-block">
-    <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100px;"><!----><span style="max-width:100px;" class="t-tag--text"><!--[-->可删除标签可删除标签<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+    <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100px;"><!----><span style="max-width:100px;" class="t-tag--text"><!--[-->可删除标签可删除标签<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-    </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100px;"><svg class="t-icon t-icon-discount" style=""><use href="#t-icon-discount"></use></svg><span style="max-width:100px;" class="t-tag--text"><!--[-->可删除标签可删除标签<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style="">
+    </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100px;"><svg class="t-icon t-icon-discount" style=""><use href="#t-icon-discount"></use></svg><span style="max-width:100px;" class="t-tag--text"><!--[-->可删除标签可删除标签<!--]--></span><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path>
-    </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close t-is-disabled t-tag--disabled" style=""><!----><!--[-->可删除标签<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+    </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close t-is-disabled t-tag--disabled" style=""><!----><!--[-->可删除标签<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
     <!--]-->
   </div>
   <div class="tag-block editable"><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-add" style=""><path fill="currentColor" d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z" fillopacity="0.9"></path></svg> 添加标签 <!--]--><!----></span></div>
@@ -38842,7 +38842,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/base.vue correct
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -38907,7 +38907,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
       <!--[-->
       <div class="t-select t-size-m t-select-selected">
         <!----><span class="t-select__placeholder" style="display:none;">请选择</span>
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style="display:none;"><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style="display:none;"><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[-->+1<!--]--><!----></span>
         <!---->
         <div class="t-input t-size-m t-select__input" modelvalue style="display:none;">
@@ -38917,7 +38917,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -38977,7 +38977,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
       <!--[-->
       <div class="t-select t-size-m t-select-selected">
         <!----><span class="t-select__placeholder" style="display:none;">请选择</span>
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style="display:none;"><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style="display:none;"><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
         <!--]-->
         <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark" style=""><!----><!--[-->更多...<!--]--><!----></span>
         <!--]-->
@@ -38989,7 +38989,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39070,7 +39070,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/filterable.vue c
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39129,7 +39129,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/lazy.vue correct
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39194,7 +39194,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/multiple.vue cor
       <!--[-->
       <div class="t-select t-size-m t-select-selected">
         <!----><span class="t-select__placeholder" style="display:none;">请选择</span>
-        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
+        <!--[--><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close" style=""><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fillopacity="0.9"></path></svg></span>
         <!--]--><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;"><!----><!--[-->+2<!--]--><!----></span>
         <!---->
         <div class="t-input t-size-m t-select__input" modelvalue style="display:none;">
@@ -39204,7 +39204,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/multiple.vue cor
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39278,7 +39278,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/prefix.vue corre
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39352,7 +39352,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/props.vue correc
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39426,7 +39426,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue co
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">
@@ -39496,7 +39496,7 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue co
           <!---->
         </div><svg class="t-fake-arrow t-select__right-icon" width="16" height="16" viewbox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="font-size:medium;">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
+        </svg><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear" style="font-size:medium;display:none;" name="close">
           <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fillopacity="0.9"></path>
         </svg>
         <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;" name="loading"><svg class="t-loading__gradient t-icon-loading" viewbox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small">

--- a/test/unit/comment/__snapshots__/demo.test.js.snap
+++ b/test/unit/comment/__snapshots__/demo.test.js.snap
@@ -720,7 +720,7 @@ exports[`Comment Comment replyVue demo works fine 1`] = `
                 评论作者名B
               </span>
               <svg
-                class="t-icon t-icon-caret-right-small t-size-s author-icon author-icon"
+                class="t-icon t-icon-caret-right-small t-size-s author-icon"
               >
                 <use
                   href="#t-icon-caret-right-small"

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -5648,7 +5648,7 @@ exports[`ConfigProvider ConfigProvider dialogVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+            class="t-icon t-icon-info-circle-filled t-is-info"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5729,7 +5729,7 @@ exports[`ConfigProvider ConfigProvider dialogVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning"
+            class="t-icon t-icon-error-circle-filled t-is-warning"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5810,7 +5810,7 @@ exports[`ConfigProvider ConfigProvider dialogVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-error t-is-error"
+            class="t-icon t-icon-error-circle-filled t-is-error"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5891,7 +5891,7 @@ exports[`ConfigProvider ConfigProvider dialogVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-check-circle-filled t-is-success t-is-success"
+            class="t-icon t-icon-check-circle-filled t-is-success"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -6051,7 +6051,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -7333,7 +7333,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           />
         </svg>
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"
@@ -7478,7 +7478,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </div>
         <!---->
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"
@@ -7802,7 +7802,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           />
         </svg>
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"
@@ -8684,7 +8684,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
     Fearure Tag
     
     <svg
-      class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close"
+      class="t-icon t-icon-close-circle t-tag__icon-close"
       fill="none"
       height="1em"
       viewBox="0 0 16 16"
@@ -8710,7 +8710,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
     Fearure Tag
     
     <svg
-      class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close"
+      class="t-icon t-icon-close-circle t-tag__icon-close"
       fill="none"
       height="1em"
       viewBox="0 0 16 16"
@@ -8736,7 +8736,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
     Fearure Tag
     
     <svg
-      class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close"
+      class="t-icon t-icon-close-circle t-tag__icon-close"
       fill="none"
       height="1em"
       viewBox="0 0 16 16"
@@ -8762,7 +8762,7 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
     Fearure Tag
     
     <svg
-      class="t-icon t-icon-close-circle t-tag__icon-close t-tag__icon-close"
+      class="t-icon t-icon-close-circle t-tag__icon-close"
       fill="none"
       height="1em"
       viewBox="0 0 16 16"
@@ -9331,7 +9331,7 @@ exports[`ConfigProvider ConfigProvider popconfirmVue demo works fine 1`] = `
               class="t-popconfirm__body"
             >
               <svg
-                class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -9420,7 +9420,7 @@ exports[`ConfigProvider ConfigProvider popconfirmVue demo works fine 1`] = `
               class="t-popconfirm__body"
             >
               <svg
-                class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning"
+                class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -9509,7 +9509,7 @@ exports[`ConfigProvider ConfigProvider popconfirmVue demo works fine 1`] = `
               class="t-popconfirm__body"
             >
               <svg
-                class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger t-popconfirm__icon--danger"
+                class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -9607,7 +9607,7 @@ exports[`ConfigProvider ConfigProvider popconfirmVue demo works fine 1`] = `
         class="t-drawer__close-btn"
       >
         <svg
-          class="t-icon t-icon-close t-submenu-icon t-submenu-icon"
+          class="t-icon t-icon-close t-submenu-icon"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"
@@ -9748,7 +9748,7 @@ exports[`ConfigProvider ConfigProvider tableVue demo works fine 1`] = `
                           
                           
                           <svg
-                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                             fill="none"
                             height="1em"
                             style="font-size: 18px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -9762,7 +9762,7 @@ exports[`ConfigProvider ConfigProvider tableVue demo works fine 1`] = `
                             />
                           </svg>
                           <svg
-                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                             fill="none"
                             height="1em"
                             style="font-size: 18px; left: 0px; bottom: -1px;"
@@ -9915,7 +9915,7 @@ exports[`ConfigProvider ConfigProvider tableVue demo works fine 1`] = `
                           
                           
                           <svg
-                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                             fill="none"
                             height="1em"
                             style="font-size: 18px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -9929,7 +9929,7 @@ exports[`ConfigProvider ConfigProvider tableVue demo works fine 1`] = `
                             />
                           </svg>
                           <svg
-                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                            class="t-icon t-icon-caret-down-small t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                             fill="none"
                             height="1em"
                             style="font-size: 18px; left: 0px; bottom: -1px;"

--- a/test/unit/dialog/__snapshots__/demo.test.js.snap
+++ b/test/unit/dialog/__snapshots__/demo.test.js.snap
@@ -965,7 +965,7 @@ exports[`Dialog Dialog iconVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+            class="t-icon t-icon-info-circle-filled t-is-info"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1047,7 +1047,7 @@ exports[`Dialog Dialog iconVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning"
+            class="t-icon t-icon-error-circle-filled t-is-warning"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1129,7 +1129,7 @@ exports[`Dialog Dialog iconVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-error t-is-error"
+            class="t-icon t-icon-error-circle-filled t-is-error"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1211,7 +1211,7 @@ exports[`Dialog Dialog iconVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-check-circle-filled t-is-success t-is-success"
+            class="t-icon t-icon-check-circle-filled t-is-success"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1864,7 +1864,7 @@ exports[`Dialog Dialog warningVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+            class="t-icon t-icon-info-circle-filled t-is-info"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1959,7 +1959,7 @@ exports[`Dialog Dialog warningVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-check-circle-filled t-is-success t-is-success"
+            class="t-icon t-icon-check-circle-filled t-is-success"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2054,7 +2054,7 @@ exports[`Dialog Dialog warningVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-warning t-is-warning"
+            class="t-icon t-icon-error-circle-filled t-is-warning"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2140,7 +2140,7 @@ exports[`Dialog Dialog warningVue demo works fine 1`] = `
           class="t-dialog__header"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-is-error t-is-error"
+            class="t-icon t-icon-error-circle-filled t-is-error"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"

--- a/test/unit/drawer/__snapshots__/demo.test.js.snap
+++ b/test/unit/drawer/__snapshots__/demo.test.js.snap
@@ -259,7 +259,7 @@ exports[`Drawer Drawer baseVue demo works fine 1`] = `
         class="t-drawer__close-btn"
       >
         <svg
-          class="t-icon t-icon-close t-submenu-icon t-submenu-icon"
+          class="t-icon t-icon-close t-submenu-icon"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"

--- a/test/unit/dropdown/__snapshots__/demo.test.js.snap
+++ b/test/unit/dropdown/__snapshots__/demo.test.js.snap
@@ -347,7 +347,7 @@ exports[`Dropdown Dropdown customVue demo works fine 1`] = `
                     </span>
                   </div>
                   <svg
-                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon"
+                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -1216,7 +1216,7 @@ exports[`Dropdown Dropdown multipleVue demo works fine 1`] = `
                     </span>
                   </div>
                   <svg
-                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon"
+                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -1248,7 +1248,7 @@ exports[`Dropdown Dropdown multipleVue demo works fine 1`] = `
                     </span>
                   </div>
                   <svg
-                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon"
+                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -1280,7 +1280,7 @@ exports[`Dropdown Dropdown multipleVue demo works fine 1`] = `
                     </span>
                   </div>
                   <svg
-                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon"
+                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -1312,7 +1312,7 @@ exports[`Dropdown Dropdown multipleVue demo works fine 1`] = `
                     </span>
                   </div>
                   <svg
-                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon t-dropdown__item__item-icon"
+                    class="t-icon t-icon-chevron-right t-dropdown__item__item-icon"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"

--- a/test/unit/form/__snapshots__/demo.test.js.snap
+++ b/test/unit/form/__snapshots__/demo.test.js.snap
@@ -167,7 +167,7 @@ exports[`Form Form alignVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -683,7 +683,7 @@ exports[`Form Form customValidatorVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -746,7 +746,7 @@ exports[`Form Form customValidatorVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -972,7 +972,7 @@ exports[`Form Form layoutVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"
@@ -1111,7 +1111,7 @@ exports[`Form Form loginVue demo works fine 1`] = `
               class="t-input__suffix t-input__suffix-icon"
             >
               <svg
-                class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+                class="t-icon t-icon-browse-off t-input__suffix-clear"
                 fill="none"
                 height="1em"
                 viewBox="0 0 16 16"

--- a/test/unit/input/__snapshots__/demo.test.js.snap
+++ b/test/unit/input/__snapshots__/demo.test.js.snap
@@ -445,7 +445,7 @@ exports[`Input Input passwordVue demo works fine 1`] = `
       class="t-input__suffix t-input__suffix-icon"
     >
       <svg
-        class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+        class="t-icon t-icon-browse-off t-input__suffix-clear"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -502,7 +502,7 @@ exports[`Input Input passwordVue demo works fine 1`] = `
       class="t-input__suffix t-input__suffix-icon"
     >
       <svg
-        class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+        class="t-icon t-icon-browse-off t-input__suffix-clear"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"

--- a/test/unit/input/__snapshots__/index.test.js.snap
+++ b/test/unit/input/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`Input $attrs input attrs should pass to input element 1`] = `
     class="t-input__suffix t-input__suffix-icon"
   >
     <svg
-      class="t-icon t-icon-browse-off t-input__suffix-clear t-input__suffix-clear"
+      class="t-icon t-icon-browse-off t-input__suffix-clear"
       fill="none"
       height="1em"
       viewBox="0 0 16 16"

--- a/test/unit/layout/__snapshots__/demo.test.js.snap
+++ b/test/unit/layout/__snapshots__/demo.test.js.snap
@@ -505,7 +505,7 @@ exports[`Layout Layout combineVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-search t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-search"
@@ -516,7 +516,7 @@ exports[`Layout Layout combineVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-notification-filled t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-notification-filled t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-notification-filled"
@@ -527,7 +527,7 @@ exports[`Layout Layout combineVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-home t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-home t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-home"
@@ -871,7 +871,7 @@ exports[`Layout Layout topVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-search t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-search"
@@ -882,7 +882,7 @@ exports[`Layout Layout topVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-notification-filled t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-notification-filled t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-notification-filled"
@@ -893,7 +893,7 @@ exports[`Layout Layout topVue demo works fine 1`] = `
               href="javascript:;"
             >
               <svg
-                class="t-icon t-icon-home t-menu__operations-icon t-menu__operations-icon"
+                class="t-icon t-icon-home t-menu__operations-icon"
               >
                 <use
                   href="#t-icon-home"

--- a/test/unit/menu/__snapshots__/demo.test.js.snap
+++ b/test/unit/menu/__snapshots__/demo.test.js.snap
@@ -181,7 +181,7 @@ exports[`Menu Menu closableSideVue demo works fine 1`] = `
     >
       
       <svg
-        class="t-icon t-icon-chevron-right t-menu__operations-icon t-menu__operations-icon"
+        class="t-icon t-icon-chevron-right t-menu__operations-icon"
       >
         <use
           href="#t-icon-chevron-right"
@@ -498,7 +498,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -509,7 +509,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -520,7 +520,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -531,7 +531,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"
@@ -689,7 +689,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -700,7 +700,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -711,7 +711,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -722,7 +722,7 @@ exports[`Menu Menu doubleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"
@@ -857,7 +857,7 @@ exports[`Menu Menu groupSideVue demo works fine 1`] = `
     >
       
       <svg
-        class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon"
+        class="t-icon t-icon-view-list t-menu__operations-icon"
       >
         <use
           href="#t-icon-view-list"
@@ -950,7 +950,7 @@ exports[`Menu Menu headMenuDarkVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-search t-menu__operations-icon"
         >
           <use
             href="#t-icon-search"
@@ -961,7 +961,7 @@ exports[`Menu Menu headMenuDarkVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-mail t-menu__operations-icon"
         >
           <use
             href="#t-icon-mail"
@@ -972,7 +972,7 @@ exports[`Menu Menu headMenuDarkVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-user t-menu__operations-icon"
         >
           <use
             href="#t-icon-user"
@@ -983,7 +983,7 @@ exports[`Menu Menu headMenuDarkVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-ellipsis t-menu__operations-icon"
         >
           <use
             href="#t-icon-ellipsis"
@@ -1146,7 +1146,7 @@ exports[`Menu Menu headMenuModeTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-search t-menu__operations-icon"
         >
           <use
             href="#t-icon-search"
@@ -1157,7 +1157,7 @@ exports[`Menu Menu headMenuModeTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-mail t-menu__operations-icon"
         >
           <use
             href="#t-icon-mail"
@@ -1168,7 +1168,7 @@ exports[`Menu Menu headMenuModeTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-user t-menu__operations-icon"
         >
           <use
             href="#t-icon-user"
@@ -1179,7 +1179,7 @@ exports[`Menu Menu headMenuModeTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-ellipsis t-menu__operations-icon"
         >
           <use
             href="#t-icon-ellipsis"
@@ -1441,7 +1441,7 @@ exports[`Menu Menu headMenuTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-search t-menu__operations-icon"
         >
           <use
             href="#t-icon-search"
@@ -1452,7 +1452,7 @@ exports[`Menu Menu headMenuTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-mail t-menu__operations-icon"
         >
           <use
             href="#t-icon-mail"
@@ -1463,7 +1463,7 @@ exports[`Menu Menu headMenuTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-user t-menu__operations-icon"
         >
           <use
             href="#t-icon-user"
@@ -1474,7 +1474,7 @@ exports[`Menu Menu headMenuTileVue demo works fine 1`] = `
         href="javascript:;"
       >
         <svg
-          class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-ellipsis t-menu__operations-icon"
         >
           <use
             href="#t-icon-ellipsis"
@@ -1876,7 +1876,7 @@ exports[`Menu Menu multiSideVue demo works fine 1`] = `
       >
         
         <svg
-          class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-view-list t-menu__operations-icon"
         >
           <use
             href="#t-icon-view-list"
@@ -2287,7 +2287,7 @@ exports[`Menu Menu multiSideVue demo works fine 1`] = `
       >
         
         <svg
-          class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon"
+          class="t-icon t-icon-view-list t-menu__operations-icon"
         >
           <use
             href="#t-icon-view-list"
@@ -2635,7 +2635,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -2646,7 +2646,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -2657,7 +2657,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -2668,7 +2668,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"
@@ -2868,7 +2868,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -2879,7 +2879,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -2890,7 +2890,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -2901,7 +2901,7 @@ exports[`Menu Menu multipleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"
@@ -3160,7 +3160,7 @@ exports[`Menu Menu popupSideVue demo works fine 1`] = `
     >
       
       <svg
-        class="t-icon t-icon-view-list t-menu__operations-icon t-menu__operations-icon"
+        class="t-icon t-icon-view-list t-menu__operations-icon"
       >
         <use
           href="#t-icon-view-list"
@@ -3884,7 +3884,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -3895,7 +3895,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -3906,7 +3906,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -3917,7 +3917,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"
@@ -3999,7 +3999,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-search t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-search t-menu__operations-icon"
           >
             <use
               href="#t-icon-search"
@@ -4010,7 +4010,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-mail t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-mail t-menu__operations-icon"
           >
             <use
               href="#t-icon-mail"
@@ -4021,7 +4021,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-user t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-user t-menu__operations-icon"
           >
             <use
               href="#t-icon-user"
@@ -4032,7 +4032,7 @@ exports[`Menu Menu singleVue demo works fine 1`] = `
           href="javascript:;"
         >
           <svg
-            class="t-icon t-icon-ellipsis t-menu__operations-icon t-menu__operations-icon"
+            class="t-icon t-icon-ellipsis t-menu__operations-icon"
           >
             <use
               href="#t-icon-ellipsis"

--- a/test/unit/notification/__snapshots__/demo.test.js.snap
+++ b/test/unit/notification/__snapshots__/demo.test.js.snap
@@ -9,7 +9,7 @@ exports[`Notification Notification baseVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -50,7 +50,7 @@ exports[`Notification Notification baseVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -127,7 +127,7 @@ exports[`Notification Notification closeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -168,7 +168,7 @@ exports[`Notification Notification closeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -215,7 +215,7 @@ exports[`Notification Notification closeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -264,7 +264,7 @@ exports[`Notification Notification closeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -344,7 +344,7 @@ exports[`Notification Notification contentVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -385,7 +385,7 @@ exports[`Notification Notification contentVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -428,7 +428,7 @@ exports[`Notification Notification contentVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -611,7 +611,7 @@ exports[`Notification Notification footerVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -661,7 +661,7 @@ exports[`Notification Notification footerVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -722,7 +722,7 @@ exports[`Notification Notification iconVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -763,7 +763,7 @@ exports[`Notification Notification iconVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-error t-is-error"
+        class="t-icon t-icon-info-circle-filled t-is-error"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -804,7 +804,7 @@ exports[`Notification Notification iconVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-warning t-is-warning"
+        class="t-icon t-icon-info-circle-filled t-is-warning"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -845,7 +845,7 @@ exports[`Notification Notification iconVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-check-circle-filled t-is-success t-is-success"
+        class="t-icon t-icon-check-circle-filled t-is-success"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -920,7 +920,7 @@ exports[`Notification Notification operationVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -977,7 +977,7 @@ exports[`Notification Notification operationVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1034,7 +1034,7 @@ exports[`Notification Notification operationVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1198,7 +1198,7 @@ exports[`Notification Notification sizeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1239,7 +1239,7 @@ exports[`Notification Notification sizeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1355,7 +1355,7 @@ exports[`Notification Notification typeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-info t-is-info"
+        class="t-icon t-icon-info-circle-filled t-is-info"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1396,7 +1396,7 @@ exports[`Notification Notification typeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-check-circle-filled t-is-success t-is-success"
+        class="t-icon t-icon-check-circle-filled t-is-success"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1437,7 +1437,7 @@ exports[`Notification Notification typeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-warning t-is-warning"
+        class="t-icon t-icon-info-circle-filled t-is-warning"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -1478,7 +1478,7 @@ exports[`Notification Notification typeVue demo works fine 1`] = `
       class="t-notification__icon"
     >
       <svg
-        class="t-icon t-icon-info-circle-filled t-is-error t-is-error"
+        class="t-icon t-icon-info-circle-filled t-is-error"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"

--- a/test/unit/popconfirm/__snapshots__/demo.test.js.snap
+++ b/test/unit/popconfirm/__snapshots__/demo.test.js.snap
@@ -32,7 +32,7 @@ exports[`Popconfirm Popconfirm baseVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -126,7 +126,7 @@ exports[`Popconfirm Popconfirm baseVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -229,7 +229,7 @@ exports[`Popconfirm Popconfirm buttonVue demo works fine 1`] = `
                 class="t-popconfirm__body"
               >
                 <svg
-                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -319,7 +319,7 @@ exports[`Popconfirm Popconfirm buttonVue demo works fine 1`] = `
                 class="t-popconfirm__body"
               >
                 <svg
-                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -409,7 +409,7 @@ exports[`Popconfirm Popconfirm buttonVue demo works fine 1`] = `
                 class="t-popconfirm__body"
               >
                 <svg
-                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -521,7 +521,7 @@ exports[`Popconfirm Popconfirm describeVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -625,7 +625,7 @@ exports[`Popconfirm Popconfirm describeVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning"
+                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -740,7 +740,7 @@ exports[`Popconfirm Popconfirm iconVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                    class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -833,7 +833,7 @@ exports[`Popconfirm Popconfirm iconVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning t-popconfirm__icon--warning"
+                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--warning"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -926,7 +926,7 @@ exports[`Popconfirm Popconfirm iconVue demo works fine 1`] = `
                   class="t-popconfirm__body"
                 >
                   <svg
-                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger t-popconfirm__icon--danger"
+                    class="t-icon t-icon-error-circle-filled t-popconfirm__icon--danger"
                     fill="none"
                     height="1em"
                     viewBox="0 0 16 16"
@@ -1222,7 +1222,7 @@ exports[`Popconfirm Popconfirm inheritVue demo works fine 1`] = `
                 class="t-popconfirm__body"
               >
                 <svg
-                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -1311,7 +1311,7 @@ exports[`Popconfirm Popconfirm inheritVue demo works fine 1`] = `
                 class="t-popconfirm__body"
               >
                 <svg
-                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"

--- a/test/unit/progress/__snapshots__/demo.test.js.snap
+++ b/test/unit/progress/__snapshots__/demo.test.js.snap
@@ -187,7 +187,7 @@ exports[`Progress Progress circleVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-check t-progress__icon t-progress__icon"
+              class="t-icon t-icon-check t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -250,7 +250,7 @@ exports[`Progress Progress circleVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-close t-progress__icon t-progress__icon"
+              class="t-icon t-icon-close t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -313,7 +313,7 @@ exports[`Progress Progress circleVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-error t-progress__icon t-progress__icon"
+              class="t-icon t-icon-error t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -905,7 +905,7 @@ exports[`Progress Progress lineVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-check-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-check-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -946,7 +946,7 @@ exports[`Progress Progress lineVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-close-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-close-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -987,7 +987,7 @@ exports[`Progress Progress lineVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-error-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1364,7 +1364,7 @@ exports[`Progress Progress sizeVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-close t-progress__icon t-progress__icon"
+              class="t-icon t-icon-close t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -1422,7 +1422,7 @@ exports[`Progress Progress sizeVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-error t-progress__icon t-progress__icon"
+              class="t-icon t-icon-error t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -1480,7 +1480,7 @@ exports[`Progress Progress sizeVue demo works fine 1`] = `
             class="t-progress__info"
           >
             <svg
-              class="t-icon t-icon-check t-progress__icon t-progress__icon"
+              class="t-icon t-icon-check t-progress__icon"
               fill="none"
               height="1em"
               viewBox="0 0 16 16"
@@ -1648,7 +1648,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-check-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-check-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1700,7 +1700,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-error t-progress__icon t-progress__icon"
+            class="t-icon t-icon-error t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1765,7 +1765,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-close-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-close-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1817,7 +1817,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-close t-progress__icon t-progress__icon"
+            class="t-icon t-icon-close t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1882,7 +1882,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-error-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1940,7 +1940,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon"
+            class="t-icon t-icon-error-circle-filled t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -1970,7 +1970,7 @@ exports[`Progress Progress statusVue demo works fine 1`] = `
           class="t-progress__info"
         >
           <svg
-            class="t-icon t-icon-error t-progress__icon t-progress__icon"
+            class="t-icon t-icon-error t-progress__icon"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"

--- a/test/unit/progress/__snapshots__/index.test.js.snap
+++ b/test/unit/progress/__snapshots__/index.test.js.snap
@@ -425,7 +425,7 @@ exports[`Progress :props :status :status is error 1`] = `
       class="t-progress__info"
     >
       <svg
-        class="t-icon t-icon-close-circle-filled t-progress__icon t-progress__icon"
+        class="t-icon t-icon-close-circle-filled t-progress__icon"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -464,7 +464,7 @@ exports[`Progress :props :status :status is success 1`] = `
       class="t-progress__info"
     >
       <svg
-        class="t-icon t-icon-check-circle-filled t-progress__icon t-progress__icon"
+        class="t-icon t-icon-check-circle-filled t-progress__icon"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -503,7 +503,7 @@ exports[`Progress :props :status :status is warning 1`] = `
       class="t-progress__info"
     >
       <svg
-        class="t-icon t-icon-error-circle-filled t-progress__icon t-progress__icon"
+        class="t-icon t-icon-error-circle-filled t-progress__icon"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -425,7 +425,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -453,7 +453,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -656,7 +656,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -684,7 +684,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -907,7 +907,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -935,7 +935,7 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2076,7 +2076,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           )
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2100,7 +2100,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           )
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2124,7 +2124,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           )
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2466,7 +2466,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           选项四(4) 
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2487,7 +2487,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           选项五(5) 
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2508,7 +2508,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           选项六(6) 
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -2529,7 +2529,7 @@ exports[`Select Select customSelectedVue demo works fine 1`] = `
           选项七(7) 
           
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -3827,7 +3827,7 @@ exports[`Select Select labelInValueVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4295,7 +4295,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4323,7 +4323,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4607,7 +4607,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4635,7 +4635,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4663,7 +4663,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4691,7 +4691,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4719,7 +4719,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -4747,7 +4747,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5026,7 +5026,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5054,7 +5054,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5082,7 +5082,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"
@@ -5110,7 +5110,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
             
           </span>
           <svg
-            class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+            class="t-icon t-icon-close t-tag__icon-close"
             fill="none"
             height="1em"
             viewBox="0 0 16 16"

--- a/test/unit/steps/__snapshots__/demo.test.js.snap
+++ b/test/unit/steps/__snapshots__/demo.test.js.snap
@@ -182,7 +182,7 @@ exports[`Steps Steps iconVue demo works fine 1`] = `
         class="t-steps-item__icon t-steps-item--finish"
       >
         <svg
-          class="t-icon t-icon-login icon-margin icon-margin"
+          class="t-icon t-icon-login icon-margin"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"
@@ -231,7 +231,7 @@ exports[`Steps Steps iconVue demo works fine 1`] = `
         class="t-steps-item__icon t-steps-item--process"
       >
         <svg
-          class="t-icon t-icon-cart icon-margin icon-margin"
+          class="t-icon t-icon-cart icon-margin"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"
@@ -275,7 +275,7 @@ exports[`Steps Steps iconVue demo works fine 1`] = `
         class="t-steps-item__icon t-steps-item--default"
       >
         <svg
-          class="t-icon t-icon-wallet icon-margin icon-margin"
+          class="t-icon t-icon-wallet icon-margin"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"
@@ -319,7 +319,7 @@ exports[`Steps Steps iconVue demo works fine 1`] = `
         class="t-steps-item__icon t-steps-item--default"
       >
         <svg
-          class="t-icon t-icon-check-circle icon-margin icon-margin"
+          class="t-icon t-icon-check-circle icon-margin"
           fill="none"
           height="1em"
           viewBox="0 0 16 16"

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -1318,7 +1318,7 @@ exports[`Table Table dataSortVue demo works fine 1`] = `
                             
                             
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -1332,7 +1332,7 @@ exports[`Table Table dataSortVue demo works fine 1`] = `
                               />
                             </svg>
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -1394,7 +1394,7 @@ exports[`Table Table dataSortVue demo works fine 1`] = `
                             
                             
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -1408,7 +1408,7 @@ exports[`Table Table dataSortVue demo works fine 1`] = `
                               />
                             </svg>
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -3941,7 +3941,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
                         </transition-stub>
                         
                         <svg
-                          class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon"
+                          class="t-icon t-icon-filter t-table__filter-icon"
                           fill="none"
                           height="1em"
                           name="filter"
@@ -4070,7 +4070,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
                         </transition-stub>
                         
                         <svg
-                          class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon"
+                          class="t-icon t-icon-filter t-table__filter-icon"
                           fill="none"
                           height="1em"
                           name="filter"
@@ -4147,7 +4147,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
                         </transition-stub>
                         
                         <svg
-                          class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon"
+                          class="t-icon t-icon-filter t-table__filter-icon"
                           fill="none"
                           height="1em"
                           name="filter"
@@ -4558,7 +4558,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
                         </transition-stub>
                         
                         <svg
-                          class="t-icon t-icon-filter t-table__filter-icon t-table__filter-icon"
+                          class="t-icon t-icon-filter t-table__filter-icon"
                           fill="none"
                           height="1em"
                           name="filter"
@@ -9414,7 +9414,7 @@ exports[`Table Table multipleSortVue demo works fine 1`] = `
                             
                             
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -9428,7 +9428,7 @@ exports[`Table Table multipleSortVue demo works fine 1`] = `
                               />
                             </svg>
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc t-table__sort-icon t-table__sort-icon--active t-table-sort-desc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -9490,7 +9490,7 @@ exports[`Table Table multipleSortVue demo works fine 1`] = `
                             
                             
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-asc t-table__sort-icon t-table__sort-icon--active t-table-sort-asc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-asc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -9504,7 +9504,7 @@ exports[`Table Table multipleSortVue demo works fine 1`] = `
                               />
                             </svg>
                             <svg
-                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                              class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                               fill="none"
                               height="1em"
                               style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -12258,7 +12258,7 @@ exports[`Table Table singleSortVue demo works fine 1`] = `
                           
                           
                           <svg
-                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                             fill="none"
                             height="1em"
                             style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -12272,7 +12272,7 @@ exports[`Table Table singleSortVue demo works fine 1`] = `
                             />
                           </svg>
                           <svg
-                            class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc t-table__sort-icon t-table__sort-icon--active t-table-sort-desc"
+                            class="t-icon t-icon-chevron-down t-table__sort-icon t-table__sort-icon--active t-table-sort-desc"
                             fill="none"
                             height="1em"
                             style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -12334,7 +12334,7 @@ exports[`Table Table singleSortVue demo works fine 1`] = `
                           
                           
                           <svg
-                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc t-table__sort-icon t-icon-sort--default t-table-sort-asc"
+                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-asc"
                             fill="none"
                             height="1em"
                             style="font-size: 16px; transform: rotate(-180deg); top: -1px; left: 0px;"
@@ -12348,7 +12348,7 @@ exports[`Table Table singleSortVue demo works fine 1`] = `
                             />
                           </svg>
                           <svg
-                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc t-table__sort-icon t-icon-sort--default t-table-sort-desc"
+                            class="t-icon t-icon-chevron-down t-table__sort-icon t-icon-sort--default t-table-sort-desc"
                             fill="none"
                             height="1em"
                             style="font-size: 16px; left: 0px; bottom: -1px;"
@@ -13665,7 +13665,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                                 class="t-popconfirm__body"
                               >
                                 <svg
-                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                                   fill="none"
                                   height="1em"
                                   viewBox="0 0 16 16"
@@ -13847,7 +13847,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                                 class="t-popconfirm__body"
                               >
                                 <svg
-                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                                   fill="none"
                                   height="1em"
                                   viewBox="0 0 16 16"
@@ -14029,7 +14029,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                                 class="t-popconfirm__body"
                               >
                                 <svg
-                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                                   fill="none"
                                   height="1em"
                                   viewBox="0 0 16 16"
@@ -14211,7 +14211,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                                 class="t-popconfirm__body"
                               >
                                 <svg
-                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                                   fill="none"
                                   height="1em"
                                   viewBox="0 0 16 16"
@@ -14393,7 +14393,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                                 class="t-popconfirm__body"
                               >
                                 <svg
-                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default t-popconfirm__icon--default"
+                                  class="t-icon t-icon-info-circle-filled t-popconfirm__icon--default"
                                   fill="none"
                                   height="1em"
                                   viewBox="0 0 16 16"

--- a/test/unit/tabs/__snapshots__/demo.test.js.snap
+++ b/test/unit/tabs/__snapshots__/demo.test.js.snap
@@ -871,7 +871,7 @@ exports[`Tabs Tabs customVue demo works fine 1`] = `
                   原有选项卡1
                 </span>
                 <svg
-                  class="t-icon t-icon-close remove-btn remove-btn"
+                  class="t-icon t-icon-close remove-btn"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -893,7 +893,7 @@ exports[`Tabs Tabs customVue demo works fine 1`] = `
                   原有选项卡2
                 </span>
                 <svg
-                  class="t-icon t-icon-close remove-btn remove-btn"
+                  class="t-icon t-icon-close remove-btn"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"
@@ -1050,7 +1050,7 @@ exports[`Tabs Tabs iconVue demo works fine 1`] = `
                   >
                     
                     <svg
-                      class="t-icon t-icon-home tabs-icon-margin tabs-icon-margin"
+                      class="t-icon t-icon-home tabs-icon-margin"
                     >
                       <use
                         href="#t-icon-home"
@@ -1072,7 +1072,7 @@ exports[`Tabs Tabs iconVue demo works fine 1`] = `
                   >
                     
                     <svg
-                      class="t-icon t-icon-calendar tabs-icon-margin tabs-icon-margin"
+                      class="t-icon t-icon-calendar tabs-icon-margin"
                     >
                       <use
                         href="#t-icon-calendar"
@@ -1094,7 +1094,7 @@ exports[`Tabs Tabs iconVue demo works fine 1`] = `
                   >
                     
                     <svg
-                      class="t-icon t-icon-layers tabs-icon-margin tabs-icon-margin"
+                      class="t-icon t-icon-layers tabs-icon-margin"
                     >
                       <use
                         href="#t-icon-layers"
@@ -1222,7 +1222,7 @@ exports[`Tabs Tabs operationVue demo works fine 1`] = `
                   原有选项卡
                 </span>
                 <svg
-                  class="t-icon t-icon-close remove-btn remove-btn"
+                  class="t-icon t-icon-close remove-btn"
                   fill="none"
                   height="1em"
                   viewBox="0 0 16 16"

--- a/test/unit/tag/__snapshots__/demo.test.js.snap
+++ b/test/unit/tag/__snapshots__/demo.test.js.snap
@@ -167,7 +167,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签一 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -188,7 +188,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签二 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -209,7 +209,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签三 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -230,7 +230,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签四 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -255,7 +255,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签一 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -276,7 +276,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签二 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -297,7 +297,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签三 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -318,7 +318,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签四 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -343,7 +343,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签一 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -364,7 +364,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签二 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -385,7 +385,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签三 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -406,7 +406,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
        标签四 
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -438,7 +438,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
         
       </span>
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -471,7 +471,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
         
       </span>
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"
@@ -492,7 +492,7 @@ exports[`Tag Tag deleteVue demo works fine 1`] = `
       可删除标签
       
       <svg
-        class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+        class="t-icon t-icon-close t-tag__icon-close"
         fill="none"
         height="1em"
         viewBox="0 0 16 16"

--- a/test/unit/tag/__snapshots__/index.test.js.snap
+++ b/test/unit/tag/__snapshots__/index.test.js.snap
@@ -18,7 +18,7 @@ exports[`Tag or CheckTag :Tag:props :closable 1`] = `
   <!---->
   <!---->
   <svg
-    class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+    class="t-icon t-icon-close t-tag__icon-close"
     fill="none"
     height="1em"
     viewBox="0 0 16 16"
@@ -360,7 +360,7 @@ exports[`Tag or CheckTag @event: Tag Event passthrough: close 1`] = `
   <!---->
   <!---->
   <svg
-    class="t-icon t-icon-close t-tag__icon-close t-tag__icon-close"
+    class="t-icon t-icon-close t-tag__icon-close"
     fill="none"
     height="1em"
     viewBox="0 0 16 16"

--- a/test/unit/tree-select/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/demo.test.js.snap
@@ -279,7 +279,7 @@ exports[`TreeSelect TreeSelect baseVue demo works fine 1`] = `
           />
         </svg>
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"
@@ -506,7 +506,7 @@ exports[`TreeSelect TreeSelect lazyVue demo works fine 1`] = `
           />
         </svg>
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"
@@ -843,7 +843,7 @@ exports[`TreeSelect TreeSelect prefixVue demo works fine 1`] = `
           />
         </svg>
         <svg
-          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear t-select__right-icon t-select__right-icon-clear"
+          class="t-icon t-icon-close-circle-filled t-select__right-icon t-select__right-icon-clear"
           fill="none"
           height="1em"
           name="close"


### PR DESCRIPTION
1. 修复props变更不触发重新渲染的问题
   - https://github.com/Tencent/tdesign-vue-next/issues/130 
   - https://github.com/Tencent/tdesign-vue-next/issues/41
2. 移除此前重复的class (这个变动会影响snapshot, 多余的class会移除）
3. icon版本改完`~` 针对后续一些问题修复 用户可以平滑升级。 