### PR TITLE
fix(calendar): fix: 修复日历组件monthChange事件在年只通过月份下拉框触发的问题

### DIFF
--- a/examples/calendar/demos/events.vue
+++ b/examples/calendar/demos/events.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <t-calendar
-      :value="value"
       @cell-click="cellClick"
       @cell-double-click="cellDoubleClick"
       @cell-right-click="cellRightClick"
@@ -12,12 +11,10 @@
 </template>
 
 <script>
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   setup() {
-    const value = null;
-
     const cellClick = (options) => {
       console.log(`鼠标左键单击单元格 ${options.cell.formattedDate}`);
     };
@@ -39,7 +36,6 @@ export default defineComponent({
     };
 
     return {
-      value,
       cellClick,
       cellDoubleClick,
       cellRightClick,

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -322,6 +322,19 @@ export default defineComponent({
       const p = this.curSelectedMode === 'month' ? 'currentDayButtonProps' : 'currentMonthButtonProps';
       return this.checkControllerDisabled('current', p);
     },
+
+    filterYearStr(): string {
+      return `${this.controllerOptions.filterDate.getFullYear()}`;
+    },
+    filterMonthStr(): string {
+      return `${this.controllerOptions.filterDate.getMonth() + 1}`;
+    },
+    filterYearMonth(): { month: string; year: string } {
+      return {
+        year: this.filterYearStr,
+        month: this.filterMonthStr,
+      };
+    },
   },
   watch: {
     value: {
@@ -341,6 +354,12 @@ export default defineComponent({
         this.isShowWeekend = v;
       },
       immediate: true,
+    },
+    filterYearMonth: {
+      handler(v: { month: string; year: string }) {
+        emitEvent<Parameters<TdCalendarProps['onMonthChange']>>(this, 'month-change', v);
+        this.controllerChange();
+      },
     },
   },
   methods: {
@@ -388,17 +407,6 @@ export default defineComponent({
       this.$nextTick(() => {
         const options = this.controllerOptions;
         emitEvent<Parameters<TdCalendarProps['onControllerChange']>>(this, 'controller-change', options);
-      });
-    },
-    // 月份切换响应事件（包括年和月下拉框变化）
-    monthChange(): void {
-      this.$nextTick(() => {
-        const options = {
-          year: `${this.controllerOptions.filterDate.getFullYear()}`,
-          month: `${this.controllerOptions.filterDate.getMonth() + 1}`,
-        };
-        emitEvent<Parameters<TdCalendarProps['onMonthChange']>>(this, 'month-change', options);
-        this.controllerChange();
       });
     },
     onWeekendToggleClick(): void {
@@ -469,7 +477,6 @@ export default defineComponent({
                   size={this.controlSize}
                   disabled={this.isYearDisabled}
                   {...this.controllerConfigData.year.selecteProps}
-                  onChange={this.monthChange}
                 >
                   {this.yearSelectOptionList.map((item) => (
                     <t-option key={item.value} value={item.value} label={item.label} disabled={item.disabled}>
@@ -486,7 +493,6 @@ export default defineComponent({
                   size={this.controlSize}
                   disabled={this.isMonthDisabled}
                   {...this.controllerConfigData.month.selecteProps}
-                  onChange={this.monthChange}
                 >
                   {this.monthSelectOptionList.map((item) => (
                     <t-option key={item.value} value={item.value} label={item.label} disabled={item.disabled}>


### PR DESCRIPTION
目前日历组件monthChange事件只通过右上角的年月份下拉框触发，实际上点击“今天”、“本月”，或者通过代码给value属性赋值等操作也可能触发月份变化