### PR TITLE
fix(textarea): 解决value未定义时初始长度为9

### DIFF
--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -57,7 +57,7 @@ export default defineComponent({
       });
     },
     characterNumber(): number {
-      const characterInfo = getCharacterLength(String(this.value));
+      const characterInfo = getCharacterLength(String(this.value || ''));
       if (typeof characterInfo === 'object') {
         return characterInfo.length;
       }


### PR DESCRIPTION
fix #387

日常 bug 修复 

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/387

- fix(textarea): 解决value未定义时初始长度为9

