### PR TITLE
faet: component migration prefix and commonclassnames

### DIFF
--- a/examples/config-provider/config-provider.md
+++ b/examples/config-provider/config-provider.md
@@ -6,6 +6,7 @@
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 alert | Object | - | 警告全局配置。TS 类型：`AlertConfig` | N
+anchor | Object | - | 锚点全局配置。TS 类型：`AnchorConfig` | N
 animation | Object | `{ include: ['ripple','expand','fade'], exclude: [] }` | 动画效果控制，`ripple`指波纹动画， `expand` 指展开动画，`fade` 指渐变动画。TS 类型：`Record<'include'|'exclude', Array<AnimationType>> ` `type AnimationType = 'ripple' | 'expand' | 'fade'`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 calendar | Object | - | 日历组件全局配置。TS 类型：`CalendarConfig` | N
 cascader | Object | - | 级联选择器全局配置。TS 类型：`CascaderConfig` | N
@@ -238,3 +239,17 @@ closeIcon | Function | - | 关闭图标，【注意】使用渲染函数输出�
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 errorIcon | Slot / Function | - | 错误步骤图标，【注意】使用渲染函数输出图标组件。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+
+### AlertConfig
+
+名称 | 类型 | 默认值 | 说明 | 必传
+-- | -- | -- | -- | --
+collapseText | String | 收起 | 收起提示文本 | N
+expandText | String | 展开更多 | 展开提示文本 | N
+
+### AnchorConfig
+
+名称 | 类型 | 默认值 | 说明 | 必传
+-- | -- | -- | -- | --
+copySuccessText | String | 链接复制成功 | 复制成功文字 | N
+copyText | String | 复制链接 | 复制提示文字 | N

--- a/examples/config-provider/config-provider.md
+++ b/examples/config-provider/config-provider.md
@@ -5,9 +5,11 @@
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
+alert | Object | - | 警告全局配置。TS 类型：`AlertConfig` | N
 animation | Object | `{ include: ['ripple','expand','fade'], exclude: [] }` | 动画效果控制，`ripple`指波纹动画， `expand` 指展开动画，`fade` 指渐变动画。TS 类型：`Record<'include'|'exclude', Array<AnimationType>> ` `type AnimationType = 'ripple' | 'expand' | 'fade'`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 calendar | Object | - | 日历组件全局配置。TS 类型：`CalendarConfig` | N
 cascader | Object | - | 级联选择器全局配置。TS 类型：`CascaderConfig` | N
+classPrefix | String | t | CSS 类名前缀 | N
 datePicker | Object | - | 日期选择器全局配置。TS 类型：`DatePickerConfig` | N
 dialog | Object | - | 对话框全局配置。TS 类型：`DialogConfig` | N
 drawer | Object | - | 抽屉全局配置。TS 类型：`DrawerConfig` | N
@@ -46,7 +48,7 @@ total | String | '共 {total} 项数据' | 数据总条数文本，示例：`'to
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 cellMonth | String | '一月,二月,三月,四月,五月,六月,七月,八月,九月,十月,十一月,十二月' | 语言配置，月份描述文本 | N
-controllerConfig | Object | - | 日历右上角控制器按钮配置。TS 类型：`CalendarController`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+controllerConfig | Object | - | 日历右上角控制器按钮配置。TS 类型：`CalendarController`，[Calendar API Documents](./calendar?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 fillWithZero | Boolean | true | 当日期数字小于 10 时，是否使用 '0' 填充 | N
 firstDayOfWeek | Number | 1 | 第一天从星期几开始。可选项：1/2/3/4/5/6/7 | N
 hideWeekend | String | '隐藏周末' | 语言配置，“隐藏周末”描述文本 | N
@@ -103,7 +105,7 @@ now | String | '此刻' | “now” 描述文本 | N
 placeholder | Object | - | 占位符文本提示，默认值：`{ date: '请选择日期',  month: '请选择月份',  year: '请选择年份' }`。TS 类型：`{ date?: string; month?: string; year?: string }` | N
 preDecade | String | '上个十年' | “上个十年” 描述文本 | N
 preMonth | String | '上个月' | “上个月” 描述文本 | N
-presets | Object | - | 【暂不支持，讨论确认中】预设快捷日期选择，示例：`{ '元旦': '2021-01-01', '昨天':  dayjs().subtract(1, 'day').format('YYYY-MM-DD'), '特定日期': () => ['2021-02-01'] }`。TS 类型：`ConfigPresetDate`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+presets | Object | - | 【暂不支持，讨论确认中】预设快捷日期选择，示例：`{ '元旦': '2021-01-01', '昨天':  dayjs().subtract(1, 'day').format('YYYY-MM-DD'), '特定日期': () => ['2021-02-01'] }`。TS 类型：`ConfigPresetDate` `interface ConfigPresetDate { [name: string]: DateConfigValue | (() => DateConfigValue) }` `type DateConfigValue = string | Date | Array<DateConfigValue>`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 preYear | String | '上一年' | “上一年” 描述文本 | N
 rangeSeparator | String | ' 至 ' | 范围分隔符描述文本，示例：' ~ ' | N
 selectDate | String | '选择日期' | “选择日期” 描述文本 | N
@@ -116,7 +118,7 @@ yearAriaLabel | String | '年' | “年” 描述文本 | N
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-cancel | Object | - | 取消按钮风格。TS 类型：`string | ButtonProps`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+cancel | Object | - | 取消按钮风格。TS 类型：`string | ButtonProps`，[Button API Documents](./button?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 confirm | Object | - | 确认按钮风格。TS 类型：`string | ButtonProps` | N
 confirmBtnTheme | Object | - | 确认按钮主题色，即 Dialog 的 `theme` 和 确认按钮的 `theme` 映射关系。示例：{ danger: 'danger' }。TS 类型：`{ default: string; info: string; warning: string; danger: string; success: string; }` | N
 
@@ -131,7 +133,7 @@ confirm | String | '确认' | “确认”描述文本。TS 类型：`string | B
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-cancel | String / Object | '取消' | “取消”描述文本。TS 类型：`string | ButtonProps`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+cancel | String / Object | '取消' | “取消”描述文本。TS 类型：`string | ButtonProps`，[Button API Documents](./button?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 confirm | String / Object | '确定' | “确定”描述文本。TS 类型：`string | ButtonProps` | N
 confirmBtnTheme | Object | - | 确认按钮主题色，即 Popconfirm 的 `theme` 和 确认按钮的 `theme` 映射关系。示例：{ danger: 'danger' }。TS 类型：`{ default: string; warning: string; danger: string; }` | N
 
@@ -139,15 +141,15 @@ confirmBtnTheme | Object | - | 确认按钮主题色，即 Popconfirm 的 `theme
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-empty | String | '暂无数据' | 语言配置，'暂无数据' 描述文本 | N
-expandIcon | Function | undefined | 展开和收起图标（配置传入收起图标即可），如果没有配置，组件会内置默认图标。【注意】使用渲染函数输出图标组件。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-filterInputPlaceholder | String | '输入关键词过滤' | 语言配置，'输入关键词过滤' 描述文本 | N
+empty | String / Slot / Function | '暂无数据' | 语言配置，'暂无数据' 描述文本。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+expandIcon | Slot / Function | undefined | 展开和收起图标（配置传入收起图标即可），如果没有配置，组件会内置默认图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+filterIcon | Slot / Function | undefined | 过滤图标，如果没有配置，组件会内置默认图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 loadingMoreText | String | '点击加载更多' | 语言配置，'点击加载更多' 描述文本 | N
 loadingText | String | '正在加载中，请稍后' | 语言配置，'正在加载中，请稍后' 描述文本 | N
 sortAscendingOperationText | String | '点击升序' | 语言配置，'点击升序' 描述文本 | N
 sortCancelOperationText | String | '点击取消排序' | 语言配置，'点击取消排序' 描述文本 | N
 sortDescendingOperationText | String | '点击降序' | 语言配置，'点击降序' 描述文本 | N
-sortIcon | Function | undefined | 排序图标（配置传入降序图标即可），如果没有配置，组件会内置默认图标。【注意】使用渲染函数输出图标组件。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+sortIcon | Slot / Function | undefined | 排序图标（配置传入降序图标即可），如果没有配置，组件会内置默认图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 
 ### SelectConfig
 
@@ -189,7 +191,7 @@ dragger | Object | - | 语言配置，拖拽相关。示例：{ dragDropText: '�
 file | Object | - | 语言配置，文件信息相关。示例：{  fileNameText: '文件名', fileSizeText: '文件尺寸', fileStatusText: '状态', fileOperationText: '操作', fileOperationDateText: '上传日期' }。TS 类型：`UploadConfigFileList` | N
 progress | Object | - | 语言配置，上传进度相关。示例：{ uploadText: '上传中', waitingText: '待上传', 'failText': '上传失败', successText: '上传成功' }。TS 类型：`UploadConfigProgress` | N
 sizeLimitMessage | String | '文件大小不能超过 {sizeLimit}' | 语言配置，文件大小超出限制时提醒文本 | N
-triggerUploadText | Object | - | 语言配置，上传功能触发文案。示例：{ image: '点击上传图片', normal: '点击上传',  fileInput: '选择文件',reupload: '重新上传',fileInput: '删除' }。TS 类型：`UploadTriggerUploadText`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+triggerUploadText | Object | - | 语言配置，上传功能触发文案。示例：{ image: '点击上传图片', normal: '点击上传',  fileInput: '选择文件',reupload: '重新上传',fileInput: '删除' }。TS 类型：`UploadTriggerUploadText` `interface UploadTriggerUploadText { image?: string, normal?: string,  fileInput?: string,  reupload?: string,  delete?: string }`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 
 ### UploadConfigProgress
 
@@ -212,17 +214,17 @@ draggingText | String | '拖拽到此区域' | 语言配置，'拖拽到此区�
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-fileNameText | String | '文件名' | 【开发中】语言配置，'文件名' 描述文本 | N
-fileOperationDateText | String | '上传日期' | 【开发中】语言配置，'上传日期' 描述文本 | N
-fileOperationText | String | '操作' | 【开发中】语言配置，'操作' 描述文本 | N
-fileSizeText | String | '文件尺寸' | 【开发中】语言配置，'文件尺寸' 描述文本 | N
-fileStatusText | String | '状态' | 【开发中】语言配置，'状态' 描述文本 | N
+fileNameText | String | '文件名' | 语言配置，'文件名' 描述文本 | N
+fileOperationDateText | String | '上传日期' | 语言配置，'上传日期' 描述文本 | N
+fileOperationText | String | '操作' | 语言配置，'操作' 描述文本 | N
+fileSizeText | String | '文件尺寸' | 语言配置，'文件尺寸' 描述文本 | N
+fileStatusText | String | '状态' | 语言配置，'状态' 描述文本 | N
 
 ### FormConfig
 
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
-errorMessage | Object | - | 表单错误信息配置，示例：`{ idcard: '请输入正确的身份证号码', max: '字符长度不能超过 ${max}' }`。TS 类型：`FormErrorMessage`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+errorMessage | Object | - | 表单错误信息配置，示例：`{ idcard: '请输入正确的身份证号码', max: '字符长度不能超过 ${max}' }`。TS 类型：`FormErrorMessage`，[Form API Documents](./form?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
 requiredMark | Boolean | true | 是否显示必填符号（*），默认显示 | N
 
 ### TagConfig

--- a/examples/config-provider/demos/calendar.vue
+++ b/examples/config-provider/demos/calendar.vue
@@ -2,12 +2,9 @@
   <t-config-provider :global-config="globalConfig" style="padding: 16px">
     <t-calendar></t-calendar>
   </t-config-provider>
-  <t-input v-model="val"></t-input>
 </template>
 
 <script setup>
-import { ref } from 'vue';
-
 const MONTHS = [
   'January',
   'February',
@@ -22,10 +19,8 @@ const MONTHS = [
   'November',
   'December',
 ];
-const val = ref('t');
 
-const globalConfig = ref({
-  classPrefix: val,
+const globalConfig = {
   calendar: {
     yearSelection: '{year}',
     // 1 表示周一；7 表示周日
@@ -81,7 +76,7 @@ const globalConfig = ref({
       },
     },
   },
-});
+};
 </script>
 
 <style scoped>

--- a/examples/config-provider/demos/calendar.vue
+++ b/examples/config-provider/demos/calendar.vue
@@ -2,9 +2,12 @@
   <t-config-provider :global-config="globalConfig" style="padding: 16px">
     <t-calendar></t-calendar>
   </t-config-provider>
+  <t-input v-model="val"></t-input>
 </template>
 
 <script setup>
+import { ref } from 'vue';
+
 const MONTHS = [
   'January',
   'February',
@@ -19,8 +22,10 @@ const MONTHS = [
   'November',
   'December',
 ];
+const val = ref('t');
 
-const globalConfig = {
+const globalConfig = ref({
+  classPrefix: val,
   calendar: {
     yearSelection: '{year}',
     // 1 表示周一；7 表示周日
@@ -76,7 +81,7 @@ const globalConfig = {
       },
     },
   },
-};
+});
 </script>
 
 <style scoped>

--- a/src/affix/affix.tsx
+++ b/src/affix/affix.tsx
@@ -4,14 +4,14 @@ import { on, off, getScrollContainer } from '../utils/dom';
 import props from './props';
 import { ScrollContainerElement } from '../common';
 import { renderTNodeJSX } from '../utils/render-tnode';
-import { useConfig, useComponentName } from '../config-provider';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TAffix',
   props,
   emits: ['fixedChange'],
   setup(props, context) {
-    const COMPONENT_NAME = useComponentName('affix');
+    const COMPONENT_NAME = usePrefixClass('affix');
 
     const { emit } = context;
     const affixRef = ref(null);

--- a/src/affix/affix.tsx
+++ b/src/affix/affix.tsx
@@ -1,18 +1,18 @@
 import { ref, watch, nextTick, onMounted, onBeforeUnmount, defineComponent } from 'vue';
 import isFunction from 'lodash/isFunction';
-import { prefix } from '../config';
 import { on, off, getScrollContainer } from '../utils/dom';
 import props from './props';
 import { ScrollContainerElement } from '../common';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-affix`;
+import { useConfig, useComponentName } from '../config-provider';
 
 export default defineComponent({
   name: 'TAffix',
   props,
   emits: ['fixedChange'],
   setup(props, context) {
+    const COMPONENT_NAME = useComponentName('affix');
+
     const { emit } = context;
     const affixRef = ref(null);
     const fixedTop = ref<false | number>(false);
@@ -102,6 +102,7 @@ export default defineComponent({
     });
 
     return {
+      COMPONENT_NAME,
       affixRef,
       fixedTop,
       scrollContainer,
@@ -114,7 +115,7 @@ export default defineComponent({
     return (
       <div style={fixedTop !== false ? contentStyle : {}} ref="affixRef">
         {fixedTop !== false ? (
-          <div class={name} style={{ zIndex, top: `${fixedTop}px` }}>
+          <div class={this.COMPONENT_NAME} style={{ zIndex, top: `${fixedTop}px` }}>
             {renderTNodeJSX(this, 'default')}
           </div>
         ) : (

--- a/src/alert/alert.tsx
+++ b/src/alert/alert.tsx
@@ -6,20 +6,19 @@ import {
   HelpCircleFilledIcon,
   InfoCircleFilledIcon,
 } from 'tdesign-icons-vue-next';
-import { prefix } from '../config';
 import { on, off, addClass } from '../utils/dom';
 import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { SlotReturnValue } from '../common';
 import { useIcon } from '../hooks/icon';
-import { useConfig, useComponentName } from '../config-provider';
+import { useConfig, usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TAlert',
   props,
   setup(props) {
-    const { global } = useConfig('alert');
-    const COMPONENT_NAME = useComponentName('affix');
+    const { global, classPrefix } = useConfig('alert');
+    const COMPONENT_NAME = usePrefixClass('alert');
 
     const renderIconTNode = useIcon();
     // alert的dom引用
@@ -144,6 +143,7 @@ export default defineComponent({
     });
     return {
       COMPONENT_NAME,
+      classPrefix,
       ele,
       description,
       visible,
@@ -159,12 +159,12 @@ export default defineComponent({
     };
   },
   render() {
-    const { theme, visible, $attrs, renderIcon, renderContent, renderClose } = this;
+    const { theme, visible, $attrs, renderIcon, renderContent, renderClose, classPrefix } = this;
     const CLASS = [
       `${this.COMPONENT_NAME}`,
       `${this.COMPONENT_NAME}--${theme}`,
       {
-        [`${prefix}-is-hidden`]: !visible,
+        [`${classPrefix}-is-hidden`]: !visible,
       },
     ];
     return (

--- a/src/alert/alert.tsx
+++ b/src/alert/alert.tsx
@@ -12,13 +12,15 @@ import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { SlotReturnValue } from '../common';
 import { useIcon } from '../hooks/icon';
-
-const name = `${prefix}-alert`;
+import { useConfig, useComponentName } from '../config-provider';
 
 export default defineComponent({
   name: 'TAlert',
   props,
   setup(props) {
+    const { global } = useConfig('alert');
+    const COMPONENT_NAME = useComponentName('affix');
+
     const renderIconTNode = useIcon();
     // alert的dom引用
     const ele = ref<HTMLElement | null>(null);
@@ -40,7 +42,7 @@ export default defineComponent({
         question: HelpCircleFilledIcon,
       };
       const iconContent = renderIconTNode('icon', Component);
-      return iconContent ? <div class={`${name}__icon`}>{iconContent}</div> : null;
+      return iconContent ? <div class={`${COMPONENT_NAME.value}__icon`}>{iconContent}</div> : null;
     };
 
     const renderClose = () => {
@@ -54,7 +56,7 @@ export default defineComponent({
         closeContent = renderIconTNode('close');
       }
       return closeContent ? (
-        <div class={`${name}__close`} onClick={handleClose}>
+        <div class={`${COMPONENT_NAME.value}__close`} onClick={handleClose}>
           {closeContent}
         </div>
       ) : null;
@@ -62,15 +64,15 @@ export default defineComponent({
 
     const renderTitle = (context: ComponentPublicInstance) => {
       const titleContent = renderTNodeJSX(context, 'title');
-      return titleContent ? <div class={`${name}__title`}> {titleContent}</div> : null;
+      return titleContent ? <div class={`${COMPONENT_NAME.value}__title`}> {titleContent}</div> : null;
     };
 
     const renderMessage = (context: ComponentPublicInstance) => {
       const operationContent = renderTNodeJSX(context, 'operation');
       return (
-        <div class={`${name}__message`}>
+        <div class={`${COMPONENT_NAME.value}__message`}>
           {renderDescription(context)}
-          {operationContent ? <div class={`${name}__operation`}>{operationContent}</div> : null}
+          {operationContent ? <div class={`${COMPONENT_NAME.value}__operation`}>{operationContent}</div> : null}
         </div>
       );
     };
@@ -96,7 +98,7 @@ export default defineComponent({
 
       // 如果需要折叠，则元素之间补<br/>；否则不补
       return (
-        <div class={`${name}__description`} ref="description">
+        <div class={`${COMPONENT_NAME.value}__description`} ref="description">
           {hasCollapse
             ? (messageContent as Array<string | VNode>).map((content) => <div>{content}</div>)
             : messageContent}
@@ -107,7 +109,7 @@ export default defineComponent({
                 collapsed.value = !collapsed.value;
               }}
             >
-              {collapsed.value ? '展开全部' : '收起'}
+              {collapsed.value ? global.value.expandText : global.value.collapseText}
             </div>
           ) : null}
         </div>
@@ -115,7 +117,7 @@ export default defineComponent({
     };
     const renderContent = (context: ComponentPublicInstance) => {
       return (
-        <div class={`${name}__content`}>
+        <div class={`${COMPONENT_NAME.value}__content`}>
           {renderTitle(context)}
           {renderMessage(context)}
         </div>
@@ -123,7 +125,7 @@ export default defineComponent({
     };
     const handleClose = (e: MouseEvent) => {
       props.onClose?.({ e });
-      addClass(ele.value, `${name}--closing`);
+      addClass(ele.value, `${COMPONENT_NAME.value}--closing`);
     };
 
     const handleCloseEnd = (e: TransitionEvent) => {
@@ -141,6 +143,7 @@ export default defineComponent({
       off(ele.value, 'transitionend', handleCloseEnd);
     });
     return {
+      COMPONENT_NAME,
       ele,
       description,
       visible,
@@ -158,8 +161,8 @@ export default defineComponent({
   render() {
     const { theme, visible, $attrs, renderIcon, renderContent, renderClose } = this;
     const CLASS = [
-      `${name}`,
-      `${name}--${theme}`,
+      `${this.COMPONENT_NAME}`,
+      `${this.COMPONENT_NAME}--${theme}`,
       {
         [`${prefix}-is-hidden`]: !visible,
       },

--- a/src/anchor/anchor-item.tsx
+++ b/src/anchor/anchor-item.tsx
@@ -2,7 +2,7 @@ import { defineComponent, h, VNodeChild, computed } from 'vue';
 import CLASSNAMES from '../utils/classnames';
 import { ANCHOR_SHARP_REGEXP } from './utils';
 import props from './anchor-item-props';
-import { useComponentName } from '../config-provider';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TAnchorItem',
@@ -20,7 +20,7 @@ export default defineComponent({
     },
   },
   setup() {
-    const CLASSNAME_PREFIX = useComponentName('anchor__item');
+    const CLASSNAME_PREFIX = usePrefixClass('anchor__item');
 
     return {
       CLASSNAME_PREFIX,

--- a/src/anchor/anchor-item.tsx
+++ b/src/anchor/anchor-item.tsx
@@ -1,8 +1,7 @@
-import { defineComponent, h, VNodeChild, computed } from 'vue';
-import CLASSNAMES from '../utils/classnames';
+import { defineComponent, h, VNodeChild } from 'vue';
 import { ANCHOR_SHARP_REGEXP } from './utils';
 import props from './anchor-item-props';
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 export default defineComponent({
   name: 'TAnchorItem',
@@ -21,8 +20,10 @@ export default defineComponent({
   },
   setup() {
     const CLASSNAME_PREFIX = usePrefixClass('anchor__item');
+    const { STATUS } = useCommonClassName();
 
     return {
+      STATUS,
       CLASSNAME_PREFIX,
     };
   },
@@ -76,14 +77,14 @@ export default defineComponent({
     },
   },
   render() {
-    const { href, target, $slots, tAnchor, CLASSNAME_PREFIX } = this;
+    const { href, target, $slots, tAnchor, CLASSNAME_PREFIX, STATUS } = this;
     const { default: children, title: titleSlot } = $slots;
     const title = this.renderTitle();
     const titleAttr = typeof title === 'string' ? title : null;
     const active = tAnchor.active === href;
     const wrapperClass = {
       [CLASSNAME_PREFIX]: true,
-      [CLASSNAMES.STATUS.active]: active,
+      [STATUS.active]: active,
     };
     const titleClass = {
       [`${CLASSNAME_PREFIX}-link`]: true,

--- a/src/anchor/anchor-item.tsx
+++ b/src/anchor/anchor-item.tsx
@@ -1,11 +1,8 @@
-import { defineComponent, h, VNodeChild } from 'vue';
-import { prefix } from '../config';
+import { defineComponent, h, VNodeChild, computed } from 'vue';
 import CLASSNAMES from '../utils/classnames';
 import { ANCHOR_SHARP_REGEXP } from './utils';
 import props from './anchor-item-props';
-import { COMPONENT_NAME } from './constant';
-
-const CLASSNAME_PREFIX = `${COMPONENT_NAME}__item`;
+import { useComponentName } from '../config-provider';
 
 export default defineComponent({
   name: 'TAnchorItem',
@@ -21,6 +18,13 @@ export default defineComponent({
         return ANCHOR_SHARP_REGEXP.test(v);
       },
     },
+  },
+  setup() {
+    const CLASSNAME_PREFIX = useComponentName('anchor__item');
+
+    return {
+      CLASSNAME_PREFIX,
+    };
   },
   watch: {
     href: {
@@ -72,7 +76,7 @@ export default defineComponent({
     },
   },
   render() {
-    const { href, target, $slots, tAnchor } = this;
+    const { href, target, $slots, tAnchor, CLASSNAME_PREFIX } = this;
     const { default: children, title: titleSlot } = $slots;
     const title = this.renderTitle();
     const titleAttr = typeof title === 'string' ? title : null;

--- a/src/anchor/anchor-target.tsx
+++ b/src/anchor/anchor-target.tsx
@@ -40,12 +40,13 @@ export default defineComponent({
   },
   render() {
     const {
+      COMPONENT_NAME,
       classPrefix,
       tag: TAG,
       $slots: { default: children },
       id,
     } = this;
-    const className = [`${this.COMPONENT_NAME}__target`];
+    const className = [`${COMPONENT_NAME}__target`];
     const iconClassName = `${classPrefix}-copy`;
     return (
       <TAG id={id} class={className}>

--- a/src/anchor/anchor-target.tsx
+++ b/src/anchor/anchor-target.tsx
@@ -1,11 +1,10 @@
 import { defineComponent } from 'vue';
 import { FileCopyIcon } from 'tdesign-icons-vue-next';
-import { prefix } from '../config';
 import { copyText } from '../utils/clipboard';
 import Message from '../message/plugin';
 import props from './anchor-target-props';
 import TPopup from '../popup';
-import { useConfig, useComponentName } from '../config-provider';
+import { useConfig, usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TAnchorTarget',
@@ -18,11 +17,12 @@ export default defineComponent({
   props: { ...props },
 
   setup() {
-    const { global } = useConfig('anchor');
-    const COMPONENT_NAME = useComponentName('anchor');
+    const { global, classPrefix } = useConfig('anchor');
+    const COMPONENT_NAME = usePrefixClass('anchor');
     return {
       COMPONENT_NAME,
       global,
+      classPrefix,
     };
   },
   methods: {
@@ -35,21 +35,22 @@ export default defineComponent({
       const a = document.createElement('a');
       a.href = `#${this.id}`;
       copyText(a.href);
-      Message.success(this.global.anchorCopySuccessText, 1000);
+      Message.success(this.global.copySuccessText, 1000);
     },
   },
   render() {
     const {
+      classPrefix,
       tag: TAG,
       $slots: { default: children },
       id,
     } = this;
     const className = [`${this.COMPONENT_NAME}__target`];
-    const iconClassName = `${prefix}-copy`;
+    const iconClassName = `${classPrefix}-copy`;
     return (
       <TAG id={id} class={className}>
         {children && children(null)}
-        <t-popup content={this.global.anchorCopyText} placement="top" showArrow class={iconClassName}>
+        <t-popup content={this.global.copyText} placement="top" showArrow class={iconClassName}>
           <FileCopyIcon onClick={this.copyText} />
         </t-popup>
       </TAG>

--- a/src/anchor/anchor-target.tsx
+++ b/src/anchor/anchor-target.tsx
@@ -5,9 +5,8 @@ import { copyText } from '../utils/clipboard';
 import Message from '../message/plugin';
 import props from './anchor-target-props';
 import TPopup from '../popup';
-import { COMPONENT_NAME } from './constant';
+import { useConfig, useComponentName } from '../config-provider';
 
-const name = `${COMPONENT_NAME}-target`;
 export default defineComponent({
   name: 'TAnchorTarget',
 
@@ -18,6 +17,14 @@ export default defineComponent({
 
   props: { ...props },
 
+  setup() {
+    const { global } = useConfig('anchor');
+    const COMPONENT_NAME = useComponentName('anchor');
+    return {
+      COMPONENT_NAME,
+      global,
+    };
+  },
   methods: {
     /**
      * 复制当前target的链接
@@ -28,7 +35,7 @@ export default defineComponent({
       const a = document.createElement('a');
       a.href = `#${this.id}`;
       copyText(a.href);
-      Message.success('链接复制成功', 1000);
+      Message.success(this.global.anchorCopySuccessText, 1000);
     },
   },
   render() {
@@ -37,12 +44,12 @@ export default defineComponent({
       $slots: { default: children },
       id,
     } = this;
-    const className = [`${COMPONENT_NAME}__target`];
+    const className = [`${this.COMPONENT_NAME}__target`];
     const iconClassName = `${prefix}-copy`;
     return (
       <TAG id={id} class={className}>
         {children && children(null)}
-        <t-popup content="复制链接" placement="top" showArrow class={iconClassName}>
+        <t-popup content={this.global.anchorCopyText} placement="top" showArrow class={iconClassName}>
           <FileCopyIcon onClick={this.copyText} />
         </t-popup>
       </TAG>

--- a/src/anchor/anchor.tsx
+++ b/src/anchor/anchor.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick, ComponentPublicInstance } from 'vue';
+import { defineComponent, nextTick, ComponentPublicInstance, computed } from 'vue';
 import CLASSNAMES from '../utils/classnames';
 import { ANCHOR_SHARP_REGEXP, ANCHOR_CONTAINER, getOffsetTop } from './utils';
 import { on, off, getScroll, scrollTo, getScrollContainer } from '../utils/dom';
@@ -6,11 +6,8 @@ import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { SlotReturnValue } from '../common';
 import Affix from '../affix';
-import { COMPONENT_NAME } from './constant';
 import { emitEvent } from '../utils/event';
-
-const ANCHOR_LINE_CLASSNAME = `${COMPONENT_NAME}__line`;
-const ANCHOR_LINE_CURSOR_CLASSNAME = `${COMPONENT_NAME}__line-cursor`;
+import { useComponentName } from '../config-provider';
 
 export interface Anchor extends ComponentPublicInstance {
   scrollContainer: ANCHOR_CONTAINER;
@@ -31,6 +28,17 @@ export default defineComponent({
 
   emits: ['change', 'click'],
 
+  setup() {
+    const COMPONENT_NAME = useComponentName('anchor');
+    const ANCHOR_LINE_CLASSNAME = useComponentName('anchor__line');
+    const ANCHOR_LINE_CURSOR_CLASSNAME = useComponentName('anchor__line-cursor');
+
+    return {
+      COMPONENT_NAME,
+      ANCHOR_LINE_CLASSNAME,
+      ANCHOR_LINE_CURSOR_CLASSNAME,
+    };
+  },
   data() {
     return {
       links: [] as string[],
@@ -210,7 +218,7 @@ export default defineComponent({
     },
     renderCursor() {
       const titleContent: SlotReturnValue = renderTNodeJSX(this, 'cursor');
-      return titleContent || <div class={ANCHOR_LINE_CURSOR_CLASSNAME}></div>;
+      return titleContent || <div class={this.ANCHOR_LINE_CURSOR_CLASSNAME}></div>;
     },
   },
 
@@ -222,12 +230,12 @@ export default defineComponent({
       activeLineStyle,
       $attrs,
     } = this;
-    const className = [COMPONENT_NAME, CLASSNAMES.SIZE[size]];
+    const className = [this.COMPONENT_NAME, CLASSNAMES.SIZE[size]];
 
     const content = (
       <div class={className} {...$attrs}>
-        <div class={ANCHOR_LINE_CLASSNAME}>
-          <div class={`${ANCHOR_LINE_CURSOR_CLASSNAME}-wrapper`} style={activeLineStyle}>
+        <div class={this.ANCHOR_LINE_CLASSNAME}>
+          <div class={`${this.ANCHOR_LINE_CURSOR_CLASSNAME}-wrapper`} style={activeLineStyle}>
             {this.renderCursor()}
           </div>
         </div>

--- a/src/anchor/anchor.tsx
+++ b/src/anchor/anchor.tsx
@@ -7,7 +7,7 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 import { SlotReturnValue } from '../common';
 import Affix from '../affix';
 import { emitEvent } from '../utils/event';
-import { useComponentName } from '../config-provider';
+import { usePrefixClass } from '../config-provider';
 
 export interface Anchor extends ComponentPublicInstance {
   scrollContainer: ANCHOR_CONTAINER;
@@ -29,9 +29,9 @@ export default defineComponent({
   emits: ['change', 'click'],
 
   setup() {
-    const COMPONENT_NAME = useComponentName('anchor');
-    const ANCHOR_LINE_CLASSNAME = useComponentName('anchor__line');
-    const ANCHOR_LINE_CURSOR_CLASSNAME = useComponentName('anchor__line-cursor');
+    const COMPONENT_NAME = usePrefixClass('anchor');
+    const ANCHOR_LINE_CLASSNAME = usePrefixClass('anchor__line');
+    const ANCHOR_LINE_CURSOR_CLASSNAME = usePrefixClass('anchor__line-cursor');
 
     return {
       COMPONENT_NAME,

--- a/src/anchor/anchor.tsx
+++ b/src/anchor/anchor.tsx
@@ -1,5 +1,4 @@
-import { defineComponent, nextTick, ComponentPublicInstance, computed } from 'vue';
-import CLASSNAMES from '../utils/classnames';
+import { defineComponent, nextTick, ComponentPublicInstance } from 'vue';
 import { ANCHOR_SHARP_REGEXP, ANCHOR_CONTAINER, getOffsetTop } from './utils';
 import { on, off, getScroll, scrollTo, getScrollContainer } from '../utils/dom';
 import props from './props';
@@ -7,7 +6,7 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 import { SlotReturnValue } from '../common';
 import Affix from '../affix';
 import { emitEvent } from '../utils/event';
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 export interface Anchor extends ComponentPublicInstance {
   scrollContainer: ANCHOR_CONTAINER;
@@ -33,10 +32,13 @@ export default defineComponent({
     const ANCHOR_LINE_CLASSNAME = usePrefixClass('anchor__line');
     const ANCHOR_LINE_CURSOR_CLASSNAME = usePrefixClass('anchor__line-cursor');
 
+    const { STATUS, SIZE } = useCommonClassName();
     return {
       COMPONENT_NAME,
       ANCHOR_LINE_CLASSNAME,
       ANCHOR_LINE_CURSOR_CLASSNAME,
+      STATUS,
+      SIZE,
     };
   },
   data() {
@@ -140,7 +142,7 @@ export default defineComponent({
      * 当前active-item的top + height, 以及ANCHOR_ITEM_PADDING修正
      */
     updateActiveLine(): void {
-      const ele = this.$el.querySelector(`.${CLASSNAMES.STATUS.active}>a`) as HTMLAnchorElement;
+      const ele = this.$el.querySelector(`.${this.STATUS.active}>a`) as HTMLAnchorElement;
       if (!ele) {
         this.activeLineStyle = null;
         return;
@@ -230,7 +232,7 @@ export default defineComponent({
       activeLineStyle,
       $attrs,
     } = this;
-    const className = [this.COMPONENT_NAME, CLASSNAMES.SIZE[size]];
+    const className = [this.COMPONENT_NAME, this.SIZE[size]];
 
     const content = (
       <div class={className} {...$attrs}>

--- a/src/anchor/constant.ts
+++ b/src/anchor/constant.ts
@@ -1,3 +1,0 @@
-import { prefix } from '../config';
-
-export const COMPONENT_NAME = `${prefix}-anchor`;

--- a/src/avatar/avatar.tsx
+++ b/src/avatar/avatar.tsx
@@ -1,17 +1,15 @@
 import { computed, defineComponent, inject, nextTick, onMounted, onUpdated, ref } from 'vue';
-import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
 import props from './props';
 import { TdAvatarProps } from './type';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
-import { Styles } from '../common';
-
-const name = `${prefix}-avatar`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TAvatar',
   props,
   setup(props: TdAvatarProps) {
+    const COMPONENT_NAME = usePrefixClass('avatar');
     const avatarGroup = inject('avatarGroup', undefined);
     const avatar = ref<HTMLElement | null>(null);
     const avatarChild = ref<HTMLElement | null>(null);
@@ -23,7 +21,7 @@ export default defineComponent({
 
     const isCustomSize = computed(() => sizeValue.value && !CLASSNAMES.SIZE[sizeValue.value]);
 
-    const customAvatarSize = computed<Styles>(() => {
+    const customAvatarSize = computed(() => {
       return isCustomSize.value
         ? {
             width: sizeValue.value,
@@ -32,7 +30,7 @@ export default defineComponent({
           }
         : {};
     });
-    const customImageSize = computed<Styles>(() => {
+    const customImageSize = computed(() => {
       return isCustomSize.value
         ? {
             height: sizeValue.value,
@@ -40,7 +38,7 @@ export default defineComponent({
           }
         : {};
     });
-    const customCharacterSize = computed<Styles>(() => {
+    const customCharacterSize = computed(() => {
       return {
         transform: scale.value,
       };
@@ -79,6 +77,7 @@ export default defineComponent({
     });
 
     return {
+      COMPONENT_NAME,
       avatar,
       avatarChild,
       isImgExist,
@@ -95,17 +94,18 @@ export default defineComponent({
   },
 
   render() {
+    const { COMPONENT_NAME } = this;
     let content = renderContent(this, 'default', 'content');
     const icon = renderTNodeJSX(this, 'icon');
     const isIconOnly = icon && !content;
     const { shape, image, alt } = this.$props;
     const avatarClass = [
-      `${name}`,
+      `${COMPONENT_NAME}`,
       CLASSNAMES.SIZE[this.sizeValue],
       {
-        [`${name}--circle`]: shape === 'circle',
-        [`${name}--round`]: shape === 'round',
-        [`${name}__icon`]: !!isIconOnly,
+        [`${COMPONENT_NAME}--circle`]: shape === 'circle',
+        [`${COMPONENT_NAME}--round`]: shape === 'round',
+        [`${COMPONENT_NAME}__icon`]: !!isIconOnly,
       },
     ];
     content = (

--- a/src/avatar/avatar.tsx
+++ b/src/avatar/avatar.tsx
@@ -1,15 +1,15 @@
 import { computed, defineComponent, inject, nextTick, onMounted, onUpdated, ref } from 'vue';
-import CLASSNAMES from '../utils/classnames';
 import props from './props';
 import { TdAvatarProps } from './type';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 export default defineComponent({
   name: 'TAvatar',
   props,
   setup(props: TdAvatarProps) {
     const COMPONENT_NAME = usePrefixClass('avatar');
+    const { SIZE } = useCommonClassName();
     const avatarGroup = inject('avatarGroup', undefined);
     const avatar = ref<HTMLElement | null>(null);
     const avatarChild = ref<HTMLElement | null>(null);
@@ -19,7 +19,7 @@ export default defineComponent({
     const sizeValue = ref('');
     const scale = ref('');
 
-    const isCustomSize = computed(() => sizeValue.value && !CLASSNAMES.SIZE[sizeValue.value]);
+    const isCustomSize = computed(() => sizeValue.value && !SIZE.value[sizeValue.value]);
 
     const customAvatarSize = computed(() => {
       return isCustomSize.value
@@ -78,6 +78,7 @@ export default defineComponent({
 
     return {
       COMPONENT_NAME,
+      SIZE,
       avatar,
       avatarChild,
       isImgExist,
@@ -94,14 +95,14 @@ export default defineComponent({
   },
 
   render() {
-    const { COMPONENT_NAME } = this;
+    const { COMPONENT_NAME, SIZE } = this;
     let content = renderContent(this, 'default', 'content');
     const icon = renderTNodeJSX(this, 'icon');
     const isIconOnly = icon && !content;
     const { shape, image, alt } = this.$props;
     const avatarClass = [
       `${COMPONENT_NAME}`,
-      CLASSNAMES.SIZE[this.sizeValue],
+      SIZE[this.sizeValue],
       {
         [`${COMPONENT_NAME}--circle`]: shape === 'circle',
         [`${COMPONENT_NAME}--round`]: shape === 'round',

--- a/src/avatar/group.tsx
+++ b/src/avatar/group.tsx
@@ -1,11 +1,9 @@
 import { ComponentPublicInstance, defineComponent, provide } from 'vue';
-import { prefix } from '../config';
 import props from './avatar-group-props';
 import { SlotReturnValue, TNodeReturnValue } from '../common';
 import Avatar from './avatar';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-avatar-group`;
+import { usePrefixClass, useConfig } from '../config-provider';
 
 export default defineComponent({
   name: 'TAvatarGroup',
@@ -16,6 +14,9 @@ export default defineComponent({
 
   setup(props) {
     provide('avatarGroup', { ...props });
+
+    const AVATAR_NAME = usePrefixClass('avatar');
+    const COMPONENT_NAME = usePrefixClass('avatar-group');
 
     const renderIcon = (context: ComponentPublicInstance) => {
       return isIcon(context) && typeof props.collapseAvatar !== 'string' ? props.collapseAvatar : null;
@@ -56,19 +57,22 @@ export default defineComponent({
     };
 
     return {
+      AVATAR_NAME,
+      COMPONENT_NAME,
       renderEllipsisAvatar,
       isIcon,
       setEllipsisContent,
     };
   },
   render() {
+    const { AVATAR_NAME } = this;
     const children: TNodeReturnValue = renderTNodeJSX(this, 'default');
     const { cascading, max } = this.$props;
     const groupClass = [
-      `${name}`,
+      `${this.COMPONENT_NAME}`,
       {
-        [`${prefix}-avatar--offset-right`]: cascading === 'right-up',
-        [`${prefix}-avatar--offset-left`]: cascading === 'left-up',
+        [`${AVATAR_NAME}--offset-right`]: cascading === 'right-up',
+        [`${AVATAR_NAME}--offset-left`]: cascading === 'left-up',
       },
     ];
     let content = [children];

--- a/src/breadcrumb/breadcrumb-item.tsx
+++ b/src/breadcrumb/breadcrumb-item.tsx
@@ -1,7 +1,6 @@
 import { defineComponent, ComponentPublicInstance, VNode } from 'vue';
 import { ChevronRightIcon } from 'tdesign-icons-vue-next';
 
-import { prefix } from '../config';
 import props from './breadcrumb-item-props';
 import Tooltip from '../tooltip/index';
 import { isNodeOverflow } from '../utils/dom';
@@ -39,12 +38,14 @@ export default defineComponent({
 
   emits: ['click'],
   setup() {
+    const COMPONENT_NAME = usePrefixClass('breadcrumb__item');
     const separatorClass = usePrefixClass('breadcrumb__separator');
     const disableClass = usePrefixClass('is-disabled');
     const linkClass = usePrefixClass('link');
     const maxLengthClass = usePrefixClass('breadcrumb__inner');
     const textFlowClass = usePrefixClass('breadcrumb--text-overflow');
     return {
+      COMPONENT_NAME,
       separatorClass,
       disableClass,
       linkClass,
@@ -112,7 +113,7 @@ export default defineComponent({
     const separatorContent = separatorPropContent || separatorSlot || (
       <ChevronRightIcon {...{ color: 'rgba(0,0,0,.3)' }} />
     );
-    const itemClass = [`${prefix}-breadcrumb__item`, this.themeClassName];
+    const itemClass = [this.COMPONENT_NAME, this.themeClassName];
     const textClass = [textFlowClass];
 
     if (this.disabled) {

--- a/src/breadcrumb/breadcrumb-item.tsx
+++ b/src/breadcrumb/breadcrumb-item.tsx
@@ -7,12 +7,7 @@ import Tooltip from '../tooltip/index';
 import { isNodeOverflow } from '../utils/dom';
 import { emitEvent } from '../utils/event';
 import { getPropsApiByEvent } from '../utils/helper';
-
-const separatorClass = `${prefix}-breadcrumb__separator`;
-const disableClass = `${prefix}-is-disabled`;
-const linkClass = `${prefix}-link`;
-const maxLengthClass = `${prefix}-breadcrumb__inner`;
-const textFlowClass = `${prefix}-breadcrumb--text-overflow`;
+import { usePrefixClass } from '../config-provider';
 
 export const EVENT_NAME_WITH_KEBAB = ['click'];
 interface LocalTBreadcrumb {
@@ -30,11 +25,6 @@ const localTBreadcrumbOrigin: LocalTBreadcrumb = {
   maxItemWidth: undefined,
 };
 
-const isEventProps = (propName: string): boolean => {
-  const pre = /on[A-Z].+/;
-  return pre.test(propName);
-};
-
 export default defineComponent({
   name: 'TBreadcrumbItem',
   components: {
@@ -48,7 +38,20 @@ export default defineComponent({
   },
 
   emits: ['click'],
-
+  setup() {
+    const separatorClass = usePrefixClass('breadcrumb__separator');
+    const disableClass = usePrefixClass('is-disabled');
+    const linkClass = usePrefixClass('link');
+    const maxLengthClass = usePrefixClass('breadcrumb__inner');
+    const textFlowClass = usePrefixClass('breadcrumb--text-overflow');
+    return {
+      separatorClass,
+      disableClass,
+      linkClass,
+      maxLengthClass,
+      textFlowClass,
+    };
+  },
   data() {
     return {
       localTBreadcrumb: localTBreadcrumbOrigin,
@@ -102,6 +105,7 @@ export default defineComponent({
   },
 
   render() {
+    const { separatorClass, disableClass, linkClass, maxLengthClass, textFlowClass } = this;
     const { localTBreadcrumb, maxWithStyle } = this;
     const { separator: separatorPropContent } = localTBreadcrumb;
     const separatorSlot = localTBreadcrumb.$slots.separator;

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -1,21 +1,18 @@
 import { computed, defineComponent, ref } from 'vue';
-import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
 import TLoading from '../loading';
 import props from './props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import useRipple from '../hooks/useRipple';
-
-// hooks
 import { useFormDisabled } from '../form/hooks';
-
-const name = `${prefix}-button`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TButton',
   inheritAttrs: false,
   props,
   setup(props) {
+    const COMPONENT_NAME = usePrefixClass('button');
     const disabled = useFormDisabled();
     const btnRef = ref<HTMLElement>();
 
@@ -29,20 +26,21 @@ export default defineComponent({
       return 'default';
     });
     const buttonClass = computed(() => [
-      `${name}`,
+      `${COMPONENT_NAME.value}`,
       CLASSNAMES.SIZE[props.size],
-      `${name}--variant-${props.variant}`,
-      `${name}--theme-${mergeTheme.value}`,
+      `${COMPONENT_NAME.value}--variant-${props.variant}`,
+      `${COMPONENT_NAME.value}--theme-${mergeTheme.value}`,
       {
         [CLASSNAMES.STATUS.disabled]: isDisabled.value,
         [CLASSNAMES.STATUS.loading]: props.loading,
-        [`${name}--shape-${props.shape}`]: props.shape !== 'rectangle',
-        [`${name}--ghost`]: props.ghost,
+        [`${COMPONENT_NAME.value}--shape-${props.shape}`]: props.shape !== 'rectangle',
+        [`${COMPONENT_NAME.value}--ghost`]: props.ghost,
         [CLASSNAMES.SIZE.block]: props.block,
       },
     ]);
 
     return {
+      COMPONENT_NAME,
       disabled: isDisabled,
       mergeTheme,
       buttonClass,
@@ -50,11 +48,12 @@ export default defineComponent({
     };
   },
   render() {
+    const { COMPONENT_NAME } = this;
     let buttonContent = renderContent(this, 'default', 'content');
     const icon = this.loading ? <TLoading inheritColor={true} /> : renderTNodeJSX(this, 'icon');
     const iconOnly = icon && !buttonContent;
 
-    buttonContent = buttonContent ? <span class={`${name}__text`}>{buttonContent}</span> : '';
+    buttonContent = buttonContent ? <span class={`${COMPONENT_NAME}__text`}>{buttonContent}</span> : '';
     if (icon) {
       buttonContent = [icon, buttonContent];
     }
@@ -62,7 +61,7 @@ export default defineComponent({
     return (
       <button
         ref="btnRef"
-        class={[...this.buttonClass, { [`${name}--icon-only`]: iconOnly }]}
+        class={[...this.buttonClass, { [`${COMPONENT_NAME}--icon-only`]: iconOnly }]}
         type={this.type}
         disabled={this.disabled}
         {...this.$attrs}

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -1,11 +1,10 @@
 import { computed, defineComponent, ref } from 'vue';
-import CLASSNAMES from '../utils/classnames';
 import TLoading from '../loading';
 import props from './props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import useRipple from '../hooks/useRipple';
 import { useFormDisabled } from '../form/hooks';
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 export default defineComponent({
   name: 'TButton',
@@ -13,6 +12,7 @@ export default defineComponent({
   props,
   setup(props) {
     const COMPONENT_NAME = usePrefixClass('button');
+    const { STATUS, SIZE } = useCommonClassName();
     const disabled = useFormDisabled();
     const btnRef = ref<HTMLElement>();
 
@@ -27,15 +27,15 @@ export default defineComponent({
     });
     const buttonClass = computed(() => [
       `${COMPONENT_NAME.value}`,
-      CLASSNAMES.SIZE[props.size],
+      SIZE.value[props.size],
       `${COMPONENT_NAME.value}--variant-${props.variant}`,
       `${COMPONENT_NAME.value}--theme-${mergeTheme.value}`,
       {
-        [CLASSNAMES.STATUS.disabled]: isDisabled.value,
-        [CLASSNAMES.STATUS.loading]: props.loading,
+        [STATUS.value.disabled]: isDisabled.value,
+        [STATUS.value.loading]: props.loading,
         [`${COMPONENT_NAME.value}--shape-${props.shape}`]: props.shape !== 'rectangle',
         [`${COMPONENT_NAME.value}--ghost`]: props.ghost,
-        [CLASSNAMES.SIZE.block]: props.block,
+        [SIZE.value.block]: props.block,
       },
     ]);
 

--- a/src/calendar/calendar-cell.tsx
+++ b/src/calendar/calendar-cell.tsx
@@ -1,12 +1,8 @@
 import { defineComponent } from 'vue';
 import dayjs from 'dayjs';
-import { prefix } from '../config';
 import { emitEvent } from '../utils/event';
 
-// 通用库
-
-// 组件的一些常量
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useConfig, useCommonClassName } from '../config-provider';
 
 // 组件相关的自定义类型
 import { CalendarCell } from './type';
@@ -41,8 +37,12 @@ export default defineComponent({
   emits: ['click', 'dblclick', 'rightclick'],
   setup() {
     const COMPONENT_NAME = usePrefixClass('calendar');
+    const { STATUS } = useCommonClassName();
+    const { classPrefix } = useConfig('classPrefix');
     return {
+      STATUS,
       COMPONENT_NAME,
+      classPrefix,
     };
   },
   computed: {
@@ -66,10 +66,10 @@ export default defineComponent({
       const isNow =
         mode === 'year' ? new Date().getMonth() === date.getMonth() : formattedDate === dayjs().format('YYYY-MM-DD');
       return [
-        `${prefix}-calendar__table-body-cell`,
+        `${this.COMPONENT_NAME}__table-body-cell`,
         {
-          [`${prefix}-is-disabled`]: this.disabled,
-          [`${prefix}-is-checked`]: isCurrent,
+          [this.STATUS.disabled]: this.disabled,
+          [this.STATUS.checked]: isCurrent,
           [`${this.COMPONENT_NAME}__table-body-cell--now`]: isNow,
         },
       ];
@@ -87,8 +87,8 @@ export default defineComponent({
 
     const defaultNode = () => (
       <span>
-        <div class={`${prefix}-calendar__table-body-cell-display`}>{valueDisplay}</div>
-        <div class={`${prefix}-calendar__table-body-cell-content`}>
+        <div class={`${this.COMPONENT_NAME}__table-body-cell-display`}>{valueDisplay}</div>
+        <div class={`${this.COMPONENT_NAME}__table-body-cell-content`}>
           {allowSlot &&
             renderTNodeJSX(this, 'cellAppend', {
               params: item,

--- a/src/calendar/calendar-cell.tsx
+++ b/src/calendar/calendar-cell.tsx
@@ -6,7 +6,7 @@ import { emitEvent } from '../utils/event';
 // 通用库
 
 // 组件的一些常量
-import { COMPONENT_NAME } from './const';
+import { usePrefixClass } from '../config-provider';
 
 // 组件相关的自定义类型
 import { CalendarCell } from './type';
@@ -19,7 +19,7 @@ const clickTypeEmitEventMap = {
 };
 
 export default defineComponent({
-  name: `${COMPONENT_NAME}-cell`,
+  name: `TCalendarCell`,
   inheritAttrs: false,
   props: {
     item: {
@@ -39,6 +39,12 @@ export default defineComponent({
     cell: Function,
   },
   emits: ['click', 'dblclick', 'rightclick'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('calendar');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   computed: {
     allowSlot(): boolean {
       return this.theme === 'full';
@@ -64,7 +70,7 @@ export default defineComponent({
         {
           [`${prefix}-is-disabled`]: this.disabled,
           [`${prefix}-is-checked`]: isCurrent,
-          [`${COMPONENT_NAME}__table-body-cell--now`]: isNow,
+          [`${this.COMPONENT_NAME}__table-body-cell--now`]: isNow,
         },
       ];
     },

--- a/src/calendar/calendar-cell.tsx
+++ b/src/calendar/calendar-cell.tsx
@@ -2,7 +2,7 @@ import { defineComponent } from 'vue';
 import dayjs from 'dayjs';
 import { emitEvent } from '../utils/event';
 
-import { usePrefixClass, useConfig, useCommonClassName } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 // 组件相关的自定义类型
 import { CalendarCell } from './type';
@@ -37,8 +37,8 @@ export default defineComponent({
   emits: ['click', 'dblclick', 'rightclick'],
   setup() {
     const COMPONENT_NAME = usePrefixClass('calendar');
+    const classPrefix = usePrefixClass();
     const { STATUS } = useCommonClassName();
-    const { classPrefix } = useConfig('classPrefix');
     return {
       STATUS,
       COMPONENT_NAME,

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -9,7 +9,7 @@ import * as utils from './utils';
 import { emitEvent } from '../utils/event';
 
 // 组件的一些常量
-import { COMPONENT_NAME, MIN_YEAR, FIRST_MONTH_OF_YEAR, LAST_MONTH_OF_YEAR, DEFAULT_YEAR_CELL_NUMINROW } from './const';
+import { MIN_YEAR, FIRST_MONTH_OF_YEAR, LAST_MONTH_OF_YEAR, DEFAULT_YEAR_CELL_NUMINROW } from './const';
 
 // 子组件
 import { Select as TSelect, Option as TOption } from '../select';
@@ -18,6 +18,7 @@ import { Button as TButton } from '../button';
 import { CheckTag as TCheckTag } from '../tag';
 import CalendarCellItem from './calendar-cell';
 import { renderTNodeJSX, renderTNodeJSXDefault } from '../utils/render-tnode';
+import { usePrefixClass } from '../config-provider';
 
 // 组件相关的自定义类型
 import {
@@ -85,6 +86,12 @@ export default defineComponent({
   },
   props: { ...props },
   emits: ['cell-click', 'cell-double-click', 'cell-right-click', 'controller-change'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('calendar');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   data() {
     return {
       curDate: null,
@@ -118,11 +125,11 @@ export default defineComponent({
     },
     // 组件最外层的class名（除去前缀，class名和theme参数一致）
     calendarCls(): Record<string, any> {
-      return [`${COMPONENT_NAME}`, `${COMPONENT_NAME}--${this.theme}`];
+      return [`${this.COMPONENT_NAME}`, `${this.COMPONENT_NAME}--${this.theme}`];
     },
 
     calendarPanelCls(): Record<string, any> {
-      return [`${COMPONENT_NAME}__panel`, `${COMPONENT_NAME}__panel--${this.curSelectedMode}`];
+      return [`${this.COMPONENT_NAME}__panel`, `${this.COMPONENT_NAME}__panel--${this.curSelectedMode}`];
     },
 
     isWeekRender(): boolean {
@@ -461,7 +468,7 @@ export default defineComponent({
       return disabled;
     },
     renderControl() {
-      const { controllerOptions } = this;
+      const { controllerOptions, COMPONENT_NAME } = this;
       return (
         <div class={`${COMPONENT_NAME}__control`}>
           <div class={`${COMPONENT_NAME}__title`}>
@@ -554,8 +561,14 @@ export default defineComponent({
     },
   },
   render() {
-    const { calendarCls, calendarPanelCls, isControllerVisible, cellColHeaders, checkMonthCellColHeaderVisibled } =
-      this;
+    const {
+      COMPONENT_NAME,
+      calendarCls,
+      calendarPanelCls,
+      isControllerVisible,
+      cellColHeaders,
+      checkMonthCellColHeaderVisibled,
+    } = this;
 
     const monthBody = () => {
       return (

--- a/src/calendar/const.ts
+++ b/src/calendar/const.ts
@@ -8,8 +8,6 @@ interface ModeOption {
 }
 
 /** 常量 */
-// 组件名
-export const COMPONENT_NAME = `${prefix}-calendar`;
 // 非法日期的标识
 export const INVALID_DATE = 'Invalid Date';
 // 最小年份
@@ -79,7 +77,6 @@ export const MONTH_CN_MAP: Record<string, string> = {
 };
 
 export default {
-  COMPONENT_NAME,
   INVALID_DATE,
   MIN_YEAR,
   FIRST_MONTH_OF_YEAR,

--- a/src/calendar/const.ts
+++ b/src/calendar/const.ts
@@ -1,5 +1,3 @@
-import { prefix } from '../config';
-
 interface ModeOption {
   // 选项值
   value: string;

--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -2,7 +2,6 @@ import { defineComponent, VNode, Transition } from 'vue';
 
 // utils
 import isEqual from 'lodash/isEqual';
-import { prefix } from '../config';
 import TreeStore from '../_common/js/tree/tree-store';
 import { emitEvent } from '../utils/event';
 import { getPropsApiByEvent } from '../utils/helper';
@@ -32,8 +31,7 @@ import { CascaderChangeSource, CascaderValue, CascaderChangeContext } from './ty
 
 // hooks
 import { useFormDisabled } from '../form/hooks';
-
-const name = `${prefix}-cascader`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TCascader',
@@ -44,7 +42,6 @@ export default defineComponent({
     Transition,
     InputContent,
   },
-
   props: {
     ...props,
   },
@@ -53,7 +50,9 @@ export default defineComponent({
 
   setup() {
     const disabled = useFormDisabled();
+    const COMPONENT_NAME = usePrefixClass('cascader');
     return {
+      COMPONENT_NAME,
       disabled,
     };
   },
@@ -251,7 +250,8 @@ export default defineComponent({
     },
   },
   render(): VNode {
-    const { visible, trigger, empty, $attrs, cascaderContext, $slots, placeholder, collapsedItems } = this;
+    const { visible, trigger, empty, $attrs, cascaderContext, $slots, placeholder, collapsedItems, COMPONENT_NAME } =
+      this;
 
     const popupProps = this.popupProps as PopupProps;
 
@@ -265,8 +265,8 @@ export default defineComponent({
 
     return (
       <Popup
-        class={`${name}__popup`}
-        overlayClassName={`${name}__dropdown`}
+        class={`${COMPONENT_NAME}__popup`}
+        overlayClassName={`${COMPONENT_NAME}__dropdown`}
         placement="bottom-left"
         visible={visible}
         expandAnimation={true}

--- a/src/cascader/components/InputContent.tsx
+++ b/src/cascader/components/InputContent.tsx
@@ -34,7 +34,7 @@ import { TreeNode, InputContentProps } from '../interface';
 import CascaderProps from '../props';
 
 // hooks
-import { usePrefixClass, useConfig } from '../../config-provider';
+import { usePrefixClass } from '../../config-provider';
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<CascaderConfig>('cascader')),
@@ -58,7 +58,7 @@ export default defineComponent({
   emits: ['change'],
   setup() {
     const COMPONENT_NAME = usePrefixClass('cascader');
-    const { classPrefix } = useConfig('classPrefix');
+    const classPrefix = usePrefixClass();
     return {
       COMPONENT_NAME,
       classPrefix,

--- a/src/cascader/components/InputContent.tsx
+++ b/src/cascader/components/InputContent.tsx
@@ -1,7 +1,6 @@
 import { defineComponent, PropType } from 'vue';
 import isFunction from 'lodash/isFunction';
 import { CloseCircleFilledIcon } from 'tdesign-icons-vue-next';
-import { prefix } from '../../config';
 import CLASSNAMES from '../../utils/classnames';
 import getConfigReceiverMixins, { CascaderConfig } from '../../config-provider/config-receiver';
 import mixins from '../../utils/mixins';
@@ -34,7 +33,8 @@ import { ClassName } from '../../common';
 import { TreeNode, InputContentProps } from '../interface';
 import CascaderProps from '../props';
 
-const name = `${prefix}-cascader`;
+// hooks
+import { usePrefixClass, useConfig } from '../../config-provider';
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<CascaderConfig>('cascader')),
@@ -56,6 +56,14 @@ export default defineComponent({
     collapsedItems: CascaderProps.collapsedItems,
   },
   emits: ['change'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('cascader');
+    const { classPrefix } = useConfig('classPrefix');
+    return {
+      COMPONENT_NAME,
+      classPrefix,
+    };
+  },
   data() {
     return {
       isHover: false,
@@ -63,13 +71,13 @@ export default defineComponent({
   },
   computed: {
     closeIconClass(): ClassName {
-      return getCloseIconClass(prefix, CLASSNAMES, this.cascaderContext);
+      return getCloseIconClass(this.classPrefix, CLASSNAMES, this.cascaderContext);
     },
     fakeArrowIconClass(): ClassName {
-      return getFakeArrowIconClass(prefix, CLASSNAMES, this.cascaderContext);
+      return getFakeArrowIconClass(this.classPrefix, CLASSNAMES, this.cascaderContext);
     },
     cascaderInnerClasses(): ClassName {
-      return getCascaderInnerClasses(prefix, CLASSNAMES, this.cascaderContext);
+      return getCascaderInnerClasses(this.classPrefix, CLASSNAMES, this.cascaderContext);
     },
     closeShow() {
       return getCloseShow(this.isHover, this.cascaderContext);
@@ -113,7 +121,9 @@ export default defineComponent({
       const content = !showPlaceholder ? (
         this.InnerContent()
       ) : (
-        <span class={`${prefix}-cascader__placeholder`}>{placeholder || this.t(this.global.placeholder)}</span>
+        <span class={`${this.classPrefix}-cascader__placeholder`}>
+          {placeholder || this.t(this.global.placeholder)}
+        </span>
       );
       return content;
     },
@@ -159,7 +169,7 @@ export default defineComponent({
       };
 
       const generalContent = !multiple ? (
-        <span class={`${prefix}-cascader__content`}>{singleContent}</span>
+        <span class={`${this.classPrefix}-cascader__content`}>{singleContent}</span>
       ) : (
         <span>
           {minCollapsedNum > 0 && multipleContent.length > minCollapsedNum ? (
@@ -227,7 +237,7 @@ export default defineComponent({
 
       if (loading) {
         return (
-          <span class={`${prefix}-cascader__icon`}>
+          <span class={`${this.classPrefix}-cascader__icon`}>
             <TLoading size="small" />
           </span>
         );

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -39,7 +39,7 @@ export default defineComponent({
     useRipple(liRef);
 
     const ComponentClassName = usePrefixClass('cascader__item');
-    const { classPrefix } = useConfig('classPrefix');
+    const classPrefix = usePrefixClass();
 
     return { liRef, ComponentClassName, classPrefix };
   },

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, PropType, ref } from 'vue';
 import { ChevronRightIcon } from 'tdesign-icons-vue-next';
-import { prefix } from '../../config';
 
 // utils
 import CLASSNAMES from '../../utils/classnames';
@@ -18,8 +17,7 @@ import TLoading from '../../loading';
 // type
 import { ClassName } from '../../common';
 import { ContextType, CascaderContextType, CascaderItemPropsType, TreeNodeValue, TreeNode } from '../interface';
-
-import { usePrefixClass } from '../../config-provider';
+import { usePrefixClass, useConfig } from '../../config-provider';
 
 export default defineComponent({
   name: 'TCascaderItem',
@@ -41,15 +39,16 @@ export default defineComponent({
     useRipple(liRef);
 
     const ComponentClassName = usePrefixClass('cascader__item');
+    const { classPrefix } = useConfig('classPrefix');
 
-    return { liRef, ComponentClassName };
+    return { liRef, ComponentClassName, classPrefix };
   },
   computed: {
     itemClass(): ClassName {
-      return getCascaderItemClass(prefix, this.node, CLASSNAMES, this.cascaderContext);
+      return getCascaderItemClass(this.classPrefix, this.node, CLASSNAMES, this.cascaderContext);
     },
     iconClass(): ClassName {
-      return getCascaderItemIconClass(prefix, this.node, CLASSNAMES, this.cascaderContext);
+      return getCascaderItemIconClass(this.classPrefix, this.node, CLASSNAMES, this.cascaderContext);
     },
   },
   render() {

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -19,11 +19,10 @@ import TLoading from '../../loading';
 import { ClassName } from '../../common';
 import { ContextType, CascaderContextType, CascaderItemPropsType, TreeNodeValue, TreeNode } from '../interface';
 
-const name = `${prefix}-cascader-item`;
-const ComponentClassName = `${prefix}-cascader__item`;
+import { usePrefixClass } from '../../config-provider';
 
 export default defineComponent({
-  name,
+  name: 'TCascaderItem',
   props: {
     node: {
       type: Object as PropType<CascaderItemPropsType['node']>,
@@ -40,7 +39,10 @@ export default defineComponent({
   setup() {
     const liRef = ref<HTMLElement>();
     useRipple(liRef);
-    return { liRef };
+
+    const ComponentClassName = usePrefixClass('cascader__item');
+
+    return { liRef, ComponentClassName };
   },
   computed: {
     itemClass(): ClassName {
@@ -51,7 +53,7 @@ export default defineComponent({
     },
   },
   render() {
-    const { node, itemClass, iconClass, cascaderContext } = this;
+    const { node, itemClass, iconClass, cascaderContext, ComponentClassName } = this;
 
     const handleClick = (e: Event) => {
       e.stopPropagation();
@@ -89,7 +91,7 @@ export default defineComponent({
           doms.push(<span key={index}>{texts[index]}</span>);
           if (index === texts.length - 1) break;
           doms.push(
-            <span key={`${index}filter`} className={`${name}-label--filter`}>
+            <span key={`${index}filter`} class={`${ComponentClassName}__label--filter`}>
               {inputVal}
             </span>,
           );

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -1,5 +1,4 @@
 import { defineComponent, PropType } from 'vue';
-import { prefix } from '../../config';
 
 // utils
 import { renderTNodeJSXDefault } from '../../utils/render-tnode';
@@ -15,13 +14,11 @@ import Item from './Item';
 // type
 import { ContextType, TreeNode, CascaderContextType } from '../interface';
 import CascaderProps from '../props';
-
-const name = `${prefix}-cascader`;
+import { usePrefixClass, useConfig } from '../../config-provider';
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<CascaderConfig>('cascader')),
-
-  name: `${name}-panel`,
+  name: 'TCascaderPanel',
   props: {
     empty: CascaderProps.empty,
     trigger: CascaderProps.trigger,
@@ -32,14 +29,21 @@ export default defineComponent({
   },
   emits: ['change'],
 
+  setup() {
+    const ComponentClassName = usePrefixClass('cascader');
+    const { classPrefix } = useConfig('classPrefix');
+
+    return { ComponentClassName, classPrefix };
+  },
+
   computed: {
     panels() {
       return getPanels(this.cascaderContext.treeNodes);
     },
   },
-
   render() {
     const {
+      ComponentClassName,
       cascaderContext: { filterActive, treeNodes, inputWidth },
       cascaderContext,
       panels,
@@ -63,7 +67,7 @@ export default defineComponent({
     const renderEmpty = renderTNodeJSXDefault(
       this,
       'empty',
-      <div class={`${name}__panel--empty`}>{this.t(this.global.empty)}</div>,
+      <div class={`${ComponentClassName}__panel--empty`}>{this.t(this.global.empty)}</div>,
     );
 
     const renderItem = (node: TreeNode) => (
@@ -83,7 +87,11 @@ export default defineComponent({
 
     const panelsContainer = panels.map((panel: TreeNode[], index: number) => (
       <ul
-        class={[`${name}__menu`, 'narrow-scrollbar', { [`${name}__menu--segment`]: index !== panels.length - 1 }]}
+        class={[
+          `${ComponentClassName}__menu`,
+          'narrow-scrollbar',
+          { [`${ComponentClassName}__menu--segment`]: index !== panels.length - 1 },
+        ]}
         key={index}
       >
         {panel.map((node: TreeNode) => renderItem(node))}
@@ -91,7 +99,14 @@ export default defineComponent({
     ));
 
     const filterPanelsContainer = (
-      <ul class={[`${name}__menu`, 'narrow-scrollbar', `${name}__menu--segment`, `${name}__menu--filter`]}>
+      <ul
+        class={[
+          `${ComponentClassName}__menu`,
+          'narrow-scrollbar',
+          `${ComponentClassName}__menu--segment`,
+          `${ComponentClassName}__menu--filter`,
+        ]}
+      >
         {treeNodes.map((node: TreeNode) => renderItem(node))}
       </ul>
     );
@@ -100,7 +115,7 @@ export default defineComponent({
 
     return (
       <div
-        class={[`${name}__panel`, { [`${name}--normal`]: panels.length }]}
+        class={[`${ComponentClassName}__panel`, { [`${ComponentClassName}--normal`]: panels.length }]}
         style={{
           width: panels.length === 0 ? `${inputWidth}px` : null,
         }}

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -14,7 +14,7 @@ import Item from './Item';
 // type
 import { ContextType, TreeNode, CascaderContextType } from '../interface';
 import CascaderProps from '../props';
-import { usePrefixClass, useConfig } from '../../config-provider';
+import { usePrefixClass } from '../../config-provider';
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<CascaderConfig>('cascader')),
@@ -31,7 +31,7 @@ export default defineComponent({
 
   setup() {
     const ComponentClassName = usePrefixClass('cascader');
-    const { classPrefix } = useConfig('classPrefix');
+    const classPrefix = usePrefixClass();
 
     return { ComponentClassName, classPrefix };
   },

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, ref } from 'vue';
 import { renderContent } from '../utils/render-tnode';
-import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
 import checkboxProps from './props';
 import { ClassName } from '../common';
@@ -10,8 +9,7 @@ import { TdCheckboxProps } from './type';
 // hooks
 import { useFormDisabled } from '../form/hooks';
 import useRipple from '../hooks/useRipple';
-
-const name = `${prefix}-checkbox`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TCheckbox',
@@ -26,10 +24,13 @@ export default defineComponent({
   setup(props) {
     const formDisabled = useFormDisabled();
     const labelRef = ref<HTMLElement>();
+    const COMPONENT_NAME = usePrefixClass('checkbox');
+
     if (props.needRipple) {
       useRipple(labelRef);
     }
     return {
+      COMPONENT_NAME,
       formDisabled,
       labelRef,
     };
@@ -38,7 +39,7 @@ export default defineComponent({
   computed: {
     labelClasses(): ClassName {
       return [
-        `${name}`,
+        `${this.COMPONENT_NAME}`,
         {
           [CLASSNAMES.STATUS.checked]: this.checked$,
           [CLASSNAMES.STATUS.disabled]: this.disabled$,
@@ -79,11 +80,12 @@ export default defineComponent({
   },
 
   render() {
+    const { COMPONENT_NAME } = this;
     return (
       <label class={this.labelClasses} {...this.$attrs} ref="labelRef">
         <input
           type="checkbox"
-          class={`${name}__former`}
+          class={`${COMPONENT_NAME}__former`}
           disabled={this.disabled$}
           readonly={this.readonly}
           indeterminate={this.indeterminate}
@@ -92,8 +94,8 @@ export default defineComponent({
           checked={this.checked$}
           onChange={this.handleChange}
         ></input>
-        <span class={`${name}__input`}></span>
-        <span class={`${name}__label`}>{renderContent(this, 'default', 'label')}</span>
+        <span class={`${COMPONENT_NAME}__input`}></span>
+        <span class={`${COMPONENT_NAME}__label`}>{renderContent(this, 'default', 'label')}</span>
       </label>
     );
   },

--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, ref } from 'vue';
 import { renderContent } from '../utils/render-tnode';
-import CLASSNAMES from '../utils/classnames';
 import checkboxProps from './props';
 import { ClassName } from '../common';
 import { emitEvent } from '../utils/event';
@@ -9,7 +8,7 @@ import { TdCheckboxProps } from './type';
 // hooks
 import { useFormDisabled } from '../form/hooks';
 import useRipple from '../hooks/useRipple';
-import { usePrefixClass } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 export default defineComponent({
   name: 'TCheckbox',
@@ -25,12 +24,14 @@ export default defineComponent({
     const formDisabled = useFormDisabled();
     const labelRef = ref<HTMLElement>();
     const COMPONENT_NAME = usePrefixClass('checkbox');
+    const { STATUS } = useCommonClassName();
 
     if (props.needRipple) {
       useRipple(labelRef);
     }
     return {
       COMPONENT_NAME,
+      STATUS,
       formDisabled,
       labelRef,
     };
@@ -41,9 +42,9 @@ export default defineComponent({
       return [
         `${this.COMPONENT_NAME}`,
         {
-          [CLASSNAMES.STATUS.checked]: this.checked$,
-          [CLASSNAMES.STATUS.disabled]: this.disabled$,
-          [CLASSNAMES.STATUS.indeterminate]: this.indeterminate$,
+          [this.STATUS.checked]: this.checked$,
+          [this.STATUS.disabled]: this.disabled$,
+          [this.STATUS.indeterminate]: this.indeterminate$,
         },
       ];
     },

--- a/src/checkbox/group.tsx
+++ b/src/checkbox/group.tsx
@@ -1,12 +1,10 @@
 import { VNode, defineComponent, h } from 'vue';
 import intersection from 'lodash/intersection';
-import { prefix } from '../config';
 import Checkbox from './checkbox';
 import checkboxGroupProps from './checkbox-group-props';
 import { emitEvent } from '../utils/event';
 import { CheckboxOptionObj, TdCheckboxProps, CheckboxGroupValue, CheckboxGroupChangeContext } from './type';
-
-const name = `${prefix}-checkbox-group`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TCheckboxGroup',
@@ -20,6 +18,13 @@ export default defineComponent({
   },
   props: { ...checkboxGroupProps },
   emits: ['change'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('checkbox-group');
+
+    return {
+      COMPONENT_NAME,
+    };
+  },
   data() {
     return {
       checkedMap: {},
@@ -155,6 +160,7 @@ export default defineComponent({
   },
 
   render(): VNode {
+    const { COMPONENT_NAME } = this;
     let children = null;
     if (this.options?.length) {
       children = this.optionList?.map((option, index) => (
@@ -167,6 +173,6 @@ export default defineComponent({
       this.optionList = this.getOptionListBySlots(nodes);
       children = nodes;
     }
-    return <div class={name}>{children}</div>;
+    return <div class={COMPONENT_NAME}>{children}</div>;
   },
 });

--- a/src/comment/comment.tsx
+++ b/src/comment/comment.tsx
@@ -1,15 +1,22 @@
 import { defineComponent, computed } from 'vue';
-import { prefix } from '../config';
 import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 
-const preName = `${prefix}-comment`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TComment',
   props,
   slots: ['avatar', 'reply', 'author', 'datetime', 'content', 'quote', 'actions'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('comment');
+
+    return {
+      COMPONENT_NAME,
+    };
+  },
   render() {
+    const { COMPONENT_NAME } = this;
     const reply = renderTNodeJSX(this, 'reply');
     const author = renderTNodeJSX(this, 'author');
     const datetime = renderTNodeJSX(this, 'datetime');
@@ -19,20 +26,20 @@ export default defineComponent({
     const avatar = renderTNodeJSX(this, 'avatar');
     const showAuthorDatetime = computed(() => author || datetime);
 
-    const replyDom = reply ? <div class={`${preName}__reply`}>{reply}</div> : null;
+    const replyDom = reply ? <div class={`${COMPONENT_NAME}__reply`}>{reply}</div> : null;
 
-    const quoteDom = quote ? <div class={`${preName}__quote`}>{quote}</div> : null;
+    const quoteDom = quote ? <div class={`${COMPONENT_NAME}__quote`}>{quote}</div> : null;
 
     const avatarDom = avatar ? (
-      <div class={`${preName}__avatar`}>
-        {typeof avatar === 'string' ? <img src={avatar} alt="" class={`${preName}__avatar-image`} /> : avatar}
+      <div class={`${COMPONENT_NAME}__avatar`}>
+        {typeof avatar === 'string' ? <img src={avatar} alt="" class={`${COMPONENT_NAME}__avatar-image`} /> : avatar}
       </div>
     ) : null;
 
     const authorDatetimeDom = showAuthorDatetime.value && (
-      <div class={`${preName}__author`}>
-        {author && <span class={`${preName}__name`}>{author}</span>}
-        {datetime && <span class={`${preName}__time`}>{datetime}</span>}
+      <div class={`${COMPONENT_NAME}__author`}>
+        {author && <span class={`${COMPONENT_NAME}__name`}>{author}</span>}
+        {datetime && <span class={`${COMPONENT_NAME}__time`}>{datetime}</span>}
       </div>
     );
 
@@ -40,7 +47,7 @@ export default defineComponent({
       if (!actions || !actions.length) return null;
 
       return (
-        <ul class={`${preName}__actions`}>
+        <ul class={`${COMPONENT_NAME}__actions`}>
           {(Array.isArray(actions) ? actions : [actions]).map((action, index: number) => (
             <li key={`action-${index}`}>{action}</li>
           ))}
@@ -49,17 +56,17 @@ export default defineComponent({
     };
 
     const contentDom = (
-      <div class={`${preName}__content`}>
+      <div class={`${COMPONENT_NAME}__content`}>
         {authorDatetimeDom}
-        <div class={`${preName}__detail`}>{content}</div>
+        <div class={`${COMPONENT_NAME}__detail`}>{content}</div>
         {quoteDom}
         {renderActions()}
       </div>
     );
 
     return (
-      <div class={preName}>
-        <div class={`${preName}__inner`}>
+      <div class={COMPONENT_NAME}>
+        <div class={`${COMPONENT_NAME}__inner`}>
           {avatarDom}
           {contentDom}
         </div>

--- a/src/common-components/fake-arrow.tsx
+++ b/src/common-components/fake-arrow.tsx
@@ -1,11 +1,9 @@
 import { defineComponent, PropType, computed } from 'vue';
-import { prefix } from '../config';
-
-const name = `${prefix}-fake-arrow`;
+import { usePrefixClass } from '../config-provider';
 
 // 统一使用的翻转箭头组件
 export default defineComponent({
-  name,
+  name: 'TFakeArrow',
   props: {
     // 是否active状态 active状态下箭头向上翻转
     isActive: {
@@ -20,10 +18,11 @@ export default defineComponent({
   },
 
   setup(props) {
+    const COMPONENT_NAME = usePrefixClass('fake-arrow');
     const classes = computed(() => [
-      name,
+      COMPONENT_NAME.value,
       {
-        [`${name}--active`]: props.isActive,
+        [`${COMPONENT_NAME.value}--active`]: props.isActive,
       },
       props.overlayClassName,
     ]);

--- a/src/config-provider/index.ts
+++ b/src/config-provider/index.ts
@@ -3,7 +3,7 @@ import _ConfigProvider from './config-provider';
 
 export * from './type';
 
-export { useConfig } from './useConfig';
+export * from './useConfig';
 
 export const ConfigProvider: WithInstallType<typeof _ConfigProvider> = withInstall(_ConfigProvider);
 export default ConfigProvider;

--- a/src/config-provider/type.ts
+++ b/src/config-provider/type.ts
@@ -111,12 +111,12 @@ export interface AnchorConfig {
    * 展开提示文本
    * @default 请输入
    */
-  anchorCopySuccessText?: string;
+  copySuccessText?: string;
   /**
    * 收起提示文本
    * @default 请输入
    */
-  anchorCopyText?: string;
+  copyText?: string;
 }
 
 export interface AlertConfig {

--- a/src/config-provider/type.ts
+++ b/src/config-provider/type.ts
@@ -11,8 +11,16 @@ import { TNode } from '../common';
 
 export interface GlobalConfigProvider {
   /**
+   * 锚点全局配置
+   */
+  anchor?: AnchorConfig;
+  /**
+   * 警告全局配置
+   */
+  alert?: AlertConfig;
+  /**
    * 动画效果控制，`ripple`指波纹动画， `expand` 指展开动画，`fade` 指渐变动画
-   * @default { include: ['ripple','expand','fade'], exclude: [] }
+   * @default `{ include: ['ripple','expand','fade'], exclude: [] }`
    */
   animation?: Record<'include' | 'exclude', Array<AnimationType>>;
   /**
@@ -23,6 +31,11 @@ export interface GlobalConfigProvider {
    * 级联选择器全局配置
    */
   cascader?: CascaderConfig;
+  /**
+   * CSS 类名前缀
+   * @default t
+   */
+  classPrefix?: string;
   /**
    * 日期选择器全局配置
    */
@@ -91,6 +104,32 @@ export interface GlobalConfigProvider {
    * 上传组件全局配置
    */
   upload?: UploadConfig;
+}
+
+export interface AnchorConfig {
+  /**
+   * 展开提示文本
+   * @default 请输入
+   */
+  anchorCopySuccessText?: string;
+  /**
+   * 收起提示文本
+   * @default 请输入
+   */
+  anchorCopyText?: string;
+}
+
+export interface AlertConfig {
+  /**
+   * 展开提示文本
+   * @default 请输入
+   */
+  expandText?: string;
+  /**
+   * 收起提示文本
+   * @default 请输入
+   */
+  collapseText?: string;
 }
 
 export interface InputConfig {
@@ -414,16 +453,15 @@ export interface TableConfig {
    * 语言配置，'暂无数据' 描述文本
    * @default '暂无数据'
    */
-  empty?: string;
+  empty?: string | TNode;
   /**
-   * 展开和收起图标（配置传入收起图标即可），如果没有配置，组件会内置默认图标。【注意】使用渲染函数输出图标组件
+   * 展开和收起图标（配置传入收起图标即可），如果没有配置，组件会内置默认图标
    */
   expandIcon?: TNode;
   /**
-   * 语言配置，'输入关键词过滤' 描述文本
-   * @default '输入关键词过滤'
+   * 过滤图标，如果没有配置，组件会内置默认图标
    */
-  filterInputPlaceholder?: string;
+  filterIcon?: TNode;
   /**
    * 语言配置，'点击加载更多' 描述文本
    * @default '点击加载更多'
@@ -450,7 +488,7 @@ export interface TableConfig {
    */
   sortDescendingOperationText?: string;
   /**
-   * 排序图标（配置传入降序图标即可），如果没有配置，组件会内置默认图标。【注意】使用渲染函数输出图标组件
+   * 排序图标（配置传入降序图标即可），如果没有配置，组件会内置默认图标
    */
   sortIcon?: TNode;
 }

--- a/src/config-provider/type.ts
+++ b/src/config-provider/type.ts
@@ -11,13 +11,13 @@ import { TNode } from '../common';
 
 export interface GlobalConfigProvider {
   /**
-   * 锚点全局配置
-   */
-  anchor?: AnchorConfig;
-  /**
    * 警告全局配置
    */
   alert?: AlertConfig;
+  /**
+   * 锚点全局配置
+   */
+  anchor?: AnchorConfig;
   /**
    * 动画效果控制，`ripple`指波纹动画， `expand` 指展开动画，`fade` 指渐变动画
    * @default `{ include: ['ripple','expand','fade'], exclude: [] }`
@@ -104,32 +104,6 @@ export interface GlobalConfigProvider {
    * 上传组件全局配置
    */
   upload?: UploadConfig;
-}
-
-export interface AnchorConfig {
-  /**
-   * 展开提示文本
-   * @default 请输入
-   */
-  copySuccessText?: string;
-  /**
-   * 收起提示文本
-   * @default 请输入
-   */
-  copyText?: string;
-}
-
-export interface AlertConfig {
-  /**
-   * 展开提示文本
-   * @default 请输入
-   */
-  expandText?: string;
-  /**
-   * 收起提示文本
-   * @default 请输入
-   */
-  collapseText?: string;
 }
 
 export interface InputConfig {
@@ -680,6 +654,32 @@ export interface StepsConfig {
    * 错误步骤图标，【注意】使用渲染函数输出图标组件
    */
   errorIcon?: TNode;
+}
+
+export interface AlertConfig {
+  /**
+   * 收起提示文本
+   * @default 收起
+   */
+  collapseText?: string;
+  /**
+   * 展开提示文本
+   * @default 展开更多
+   */
+  expandText?: string;
+}
+
+export interface AnchorConfig {
+  /**
+   * 复制成功文字
+   * @default 链接复制成功
+   */
+  copySuccessText?: string;
+  /**
+   * 复制提示文字
+   * @default 复制链接
+   */
+  copyText?: string;
 }
 
 export type AnimationType = 'ripple' | 'expand' | 'fade';

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -58,7 +58,7 @@ export function useConfig<T extends keyof GlobalConfig>(componentName: T) {
   };
 }
 
-export function useComponentName(componentName: string) {
+export function usePrefixClass(componentName: string) {
   const { classPrefix } = useConfig('classPrefix');
   const COMPONENT_NAME = computed(() => {
     return `${classPrefix.value}-${componentName}`;

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -58,10 +58,10 @@ export function useConfig<T extends keyof GlobalConfig>(componentName: T) {
   };
 }
 
-export function usePrefixClass(componentName: string) {
+export function usePrefixClass(componentName?: string) {
   const { classPrefix } = useConfig('classPrefix');
   return computed(() => {
-    return `${classPrefix.value}-${componentName}`;
+    return componentName ? `${classPrefix.value}-${componentName}` : classPrefix.value;
   });
 }
 

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -1,4 +1,4 @@
-import { computed, inject } from 'vue';
+import { computed, inject, reactive } from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
 import _mergeWith from 'lodash/mergeWith';
 import { defaultGlobalConfig, GlobalConfig } from './context';
@@ -60,8 +60,40 @@ export function useConfig<T extends keyof GlobalConfig>(componentName: T) {
 
 export function usePrefixClass(componentName: string) {
   const { classPrefix } = useConfig('classPrefix');
-  const COMPONENT_NAME = computed(() => {
+  return computed(() => {
     return `${classPrefix.value}-${componentName}`;
   });
-  return COMPONENT_NAME;
+}
+
+export function useCommonClassName() {
+  const { classPrefix } = useConfig('classPrefix');
+
+  return {
+    SIZE: computed(() => ({
+      small: `${classPrefix.value}-size-s`,
+      medium: `${classPrefix.value}-size-m`,
+      large: `${classPrefix.value}-size-l`,
+      default: '',
+      xs: `${classPrefix.value}-size-xs`,
+      xl: `${classPrefix.value}-size-xl`,
+      block: `${classPrefix.value}-size-full-width`,
+    })),
+    STATUS: computed(() => ({
+      loading: `${classPrefix.value}-is-loading`,
+      loadMore: `${classPrefix.value}-is-load-more`,
+      disabled: `${classPrefix.value}-is-disabled`,
+      focused: `${classPrefix.value}-is-focused`,
+      success: `${classPrefix.value}-is-success`,
+      error: `${classPrefix.value}-is-error`,
+      warning: `${classPrefix.value}-is-warning`,
+      selected: `${classPrefix.value}-is-selected`,
+      active: `${classPrefix.value}-is-active`,
+      checked: `${classPrefix.value}-is-checked`,
+      current: `${classPrefix.value}-is-current`,
+      hidden: `${classPrefix.value}-is-hidden`,
+      visible: `${classPrefix.value}-is-visible`,
+      expanded: `${classPrefix.value}-is-expanded`,
+      indeterminate: `${classPrefix.value}-is-indeterminate`,
+    })),
+  };
 }

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -57,3 +57,11 @@ export function useConfig<T extends keyof GlobalConfig>(componentName: T) {
     classPrefix,
   };
 }
+
+export function useComponentName(componentName: string) {
+  const { classPrefix } = useConfig('classPrefix');
+  const COMPONENT_NAME = computed(() => {
+    return `${classPrefix.value}-${componentName}`;
+  });
+  return COMPONENT_NAME;
+}

--- a/src/config-provider/zh_CN_config.ts
+++ b/src/config-provider/zh_CN_config.ts
@@ -147,6 +147,14 @@ const GLOBAL_CONFIG_ZH: GlobalConfigProvider = {
   input: {
     placeholder: '请输入',
   },
+  alert: {
+    expandText: '展开更多',
+    collapseText: '收起',
+  },
+  anchor: {
+    anchorCopySuccessText: '链接复制成功',
+    anchorCopyText: '复制链接',
+  },
 };
 
 export default GLOBAL_CONFIG_ZH;

--- a/src/config-provider/zh_CN_config.ts
+++ b/src/config-provider/zh_CN_config.ts
@@ -147,13 +147,17 @@ const GLOBAL_CONFIG_ZH: GlobalConfigProvider = {
   input: {
     placeholder: '请输入',
   },
+  list: {
+    loadingText: '正在加载中，请稍等',
+    loadingMoreText: '点击加载更多',
+  },
   alert: {
     expandText: '展开更多',
     collapseText: '收起',
   },
   anchor: {
-    anchorCopySuccessText: '链接复制成功',
-    anchorCopyText: '复制链接',
+    copySuccessText: '链接复制成功',
+    copyText: '复制链接',
   },
 };
 

--- a/src/date-picker/basic/cell.tsx
+++ b/src/date-picker/basic/cell.tsx
@@ -20,12 +20,15 @@ export default defineComponent({
   },
   setup() {
     const COMPONENT_NAME = usePrefixClass('date-picker__cell');
+    const name = usePrefixClass('date-picker-cell');
     return {
+      name,
       COMPONENT_NAME,
     };
   },
   render() {
     const {
+      name,
       COMPONENT_NAME,
       text,
       value,

--- a/src/date-picker/basic/cell.tsx
+++ b/src/date-picker/basic/cell.tsx
@@ -1,10 +1,8 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../../config';
-
-const name = `${prefix}-date-picker-cell`;
+import { usePrefixClass } from '../../config-provider';
 
 export default defineComponent({
-  name,
+  name: 'TDatePickerCell',
   props: {
     text: [String, Number],
     value: Date,
@@ -20,8 +18,15 @@ export default defineComponent({
     onClick: Function,
     onMouseEnter: { type: Function },
   },
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('date-picker__cell');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   render() {
     const {
+      COMPONENT_NAME,
       text,
       value,
       active,
@@ -39,22 +44,22 @@ export default defineComponent({
     const cellClass = [
       name,
       {
-        [`${prefix}-date-picker__cell--now`]: now,
-        [`${prefix}-date-picker__cell--active`]: active,
-        [`${prefix}-date-picker__cell--disabled`]: disabled,
-        [`${prefix}-date-picker__cell--highlight`]: highlight,
-        [`${prefix}-date-picker__cell--active-start`]: startOfRange,
-        [`${prefix}-date-picker__cell--active-end`]: endOfRange,
-        [`${prefix}-date-picker__cell--additional`]: additional,
-        [`${prefix}-date-picker__cell--first-day-of-month`]: firstDayOfMonth,
-        [`${prefix}-date-picker__cell--last-day-of-month`]: lastDayOfMonth,
+        [`${COMPONENT_NAME}--now`]: now,
+        [`${COMPONENT_NAME}--active`]: active,
+        [`${COMPONENT_NAME}--disabled`]: disabled,
+        [`${COMPONENT_NAME}--highlight`]: highlight,
+        [`${COMPONENT_NAME}--active-start`]: startOfRange,
+        [`${COMPONENT_NAME}--active-end`]: endOfRange,
+        [`${COMPONENT_NAME}--additional`]: additional,
+        [`${COMPONENT_NAME}--first-day-of-month`]: firstDayOfMonth,
+        [`${COMPONENT_NAME}--last-day-of-month`]: lastDayOfMonth,
       },
     ];
 
     return (
       <td class={cellClass}>
         <div
-          class={`${prefix}-date-picker__cell-wrapper`}
+          class={`${COMPONENT_NAME}-wrapper`}
           onClick={(e: MouseEvent) => {
             if (!disabled) {
               onClick(value, { e });
@@ -62,7 +67,7 @@ export default defineComponent({
           }}
           onMouseenter={() => onMouseEnter && onMouseEnter(value)}
         >
-          <span class={`${prefix}-date-picker__cell-text`}>{text}</span>
+          <span class={`${COMPONENT_NAME}-text`}>{text}</span>
         </div>
       </td>
     );

--- a/src/date-picker/basic/header.tsx
+++ b/src/date-picker/basic/header.tsx
@@ -4,11 +4,10 @@ import { RoundIcon, ChevronLeftIcon, ChevronRightIcon } from 'tdesign-icons-vue-
 import TButton from '../../button/button';
 import mixins from '../../utils/mixins';
 import getConfigReceiverMixins, { DatePickerConfig } from '../../config-provider/config-receiver';
-import { prefix } from '../../config';
+import { usePrefixClass } from '../../config-provider';
 
-const name = `${prefix}-date-picker__header`;
 export default defineComponent({
-  name,
+  name: 'TDatePickerHeader',
   ...mixins(getConfigReceiverMixins<DatePickerConfig>('datePicker')),
   components: {
     TButton,
@@ -27,7 +26,14 @@ export default defineComponent({
     onBtnClick: Function,
     onTypeChange: Function,
   },
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('date-picker__header');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   render() {
+    const { COMPONENT_NAME } = this;
     const { type, year, month, onBtnClick, onTypeChange } = this.$props;
     const startYear = parseInt((this.year / 10).toString(), 10) * 10;
     const { rangeSeparator, yearAriaLabel, now, preMonth, preYear, nextMonth, nextYear, preDecade, nextDecade } =
@@ -45,8 +51,8 @@ export default defineComponent({
       nextLabel = nextYear;
     }
     return (
-      <div class={`${prefix}-date-picker__header`}>
-        <span class={`${prefix}-date-picker__header-title`}>
+      <div class={COMPONENT_NAME}>
+        <span class={`${COMPONENT_NAME}-title`}>
           {type === 'year' && (
             <span>
               <span>{startYear}</span>
@@ -55,30 +61,20 @@ export default defineComponent({
             </span>
           )}
           {type !== 'year' && (
-            <t-button
-              class={`${prefix}-date-picker__header-btn`}
-              variant="text"
-              size="small"
-              onClick={() => onTypeChange('year')}
-            >
+            <t-button class={`${COMPONENT_NAME}-btn`} variant="text" size="small" onClick={() => onTypeChange('year')}>
               {`${year} ${yearAriaLabel}`}
             </t-button>
           )}
           {type === 'date' && (
-            <t-button
-              class={`${prefix}-date-picker__header-btn`}
-              variant="text"
-              size="small"
-              onClick={() => onTypeChange('month')}
-            >
+            <t-button class={`${COMPONENT_NAME}-btn`} variant="text" size="small" onClick={() => onTypeChange('month')}>
               {this.global.months[month]}
             </t-button>
           )}
         </span>
 
-        <span class={`${prefix}-date-picker__header-controller`}>
+        <span class={`${COMPONENT_NAME}-controller`}>
           <t-button
-            class={`${prefix}-date-picker__header-controller__btn`}
+            class={`${COMPONENT_NAME}-controller__btn`}
             variant="text"
             onClick={() => onBtnClick(-1)}
             title={preLabel}
@@ -87,10 +83,7 @@ export default defineComponent({
             }}
           />
           <t-button
-            class={[
-              `${prefix}-date-picker__header-controller__btn`,
-              `${prefix}-date-picker__header-controller__btn--now`,
-            ]}
+            class={[`${COMPONENT_NAME}-controller__btn`, `${COMPONENT_NAME}-controller__btn--now`]}
             variant="text"
             onClick={() => onBtnClick(0)}
             title={now}
@@ -99,7 +92,7 @@ export default defineComponent({
             }}
           />
           <t-button
-            class={`${prefix}-date-picker__header-controller__btn`}
+            class={`${COMPONENT_NAME}-controller__btn`}
             variant="text"
             onClick={() => onBtnClick(1)}
             title={nextLabel}

--- a/src/date-picker/basic/table.tsx
+++ b/src/date-picker/basic/table.tsx
@@ -1,17 +1,14 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../../config';
 import TDatePickerCell from './cell';
 import { Cell } from '../interface';
 import mixins from '../../utils/mixins';
 import getConfigReceiverMixins, { DatePickerConfig } from '../../config-provider/config-receiver';
 
-const name = `${prefix}-date-picker-table`;
-
 const DAY_NAMES = ['一', '二', '三', '四', '五', '六', '日'];
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<DatePickerConfig>('datePicker')),
-  name,
+  name: 'TDatePickerTable',
   components: {
     TDatePickerCell,
   },

--- a/src/date-picker/calendar-presets.tsx
+++ b/src/date-picker/calendar-presets.tsx
@@ -1,9 +1,7 @@
-import isFunction from 'lodash/isFunction';
 import { PropType, defineComponent } from 'vue';
 import { DatePickerConfig } from '../config-provider/config-receiver';
-import { CalendarPresetsProps, DateValue, TdDatePickerProps } from './interface';
-import { prefix } from '../config';
-import { emitEvent } from '../utils/event';
+import { CalendarPresetsProps, DateValue } from './interface';
+import { usePrefixClass } from '../config-provider';
 
 import { Button as TButton } from '../button';
 
@@ -21,6 +19,12 @@ export default defineComponent({
     },
     onClick: Function,
   },
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('date-picker__presets');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   methods: {
     clickPreset(value: DateValue | (() => DateValue)) {
       this.onClick(value);
@@ -29,7 +33,7 @@ export default defineComponent({
   render() {
     const { presets } = this;
     return (
-      <div class={`${prefix}-date-picker__presets`}>
+      <div class={this.COMPONENT_NAME}>
         <ul>
           {presets &&
             Object.keys(presets).map((key: string) => (

--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -23,7 +23,7 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 
 // hooks
 import { useFormDisabled } from '../form/hooks';
-import { usePrefixClass, useConfig, useCommonClassName } from '../config-provider';
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 dayjs.extend(isBetween);
 
@@ -43,7 +43,7 @@ export default defineComponent({
   emits: ['input', 'open', 'close', 'focus', 'click', 'change', 'pick'],
   setup() {
     const disabled = useFormDisabled();
-    const { classPrefix } = useConfig('classPrefix');
+    const classPrefix = usePrefixClass();
     const COMPONENT_NAME = usePrefixClass('date-picker');
     const { SIZE, STATUS } = useCommonClassName();
     return {

--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -4,9 +4,7 @@ import isBetween from 'dayjs/plugin/isBetween';
 import { CalendarIcon, TimeIcon } from 'tdesign-icons-vue-next';
 import { emitEvent } from '../utils/event';
 
-import { prefix } from '../config';
 import props from './props';
-import CLASSNAMES from '../utils/classnames';
 
 import { Button as TButton } from '../button';
 import { Input as TInput } from '../input';
@@ -25,10 +23,9 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 
 // hooks
 import { useFormDisabled } from '../form/hooks';
+import { usePrefixClass, useConfig, useCommonClassName } from '../config-provider';
 
 dayjs.extend(isBetween);
-
-const name = `${prefix}-date-picker`;
 
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<DatePickerConfig>('datePicker')),
@@ -46,7 +43,14 @@ export default defineComponent({
   emits: ['input', 'open', 'close', 'focus', 'click', 'change', 'pick'],
   setup() {
     const disabled = useFormDisabled();
+    const { classPrefix } = useConfig('classPrefix');
+    const COMPONENT_NAME = usePrefixClass('date-picker');
+    const { SIZE, STATUS } = useCommonClassName();
     return {
+      classPrefix,
+      COMPONENT_NAME,
+      SIZE,
+      STATUS,
       disabled,
     };
   },
@@ -145,20 +149,20 @@ export default defineComponent({
     },
     classes(): any {
       return [
-        name,
-        CLASSNAMES.SIZE[this.size] || '',
+        this.COMPONENT_NAME,
+        this.SIZE[this.size] || '',
         {
-          [`${name}--month-picker`]: this.mode === 'year' || this.mode === 'month',
-          [`${prefix}-inline`]: this.inline || this.inlineView,
+          [`${this.COMPONENT_NAME}--month-picker`]: this.mode === 'year' || this.mode === 'month',
+          [`${this.classPrefix}-inline`]: this.inline || this.inlineView,
         },
       ];
     },
     pickerStyles() {
       return {
-        [`${name}__container`]: true,
-        [`${name}--open`]: this.isOpen || this.inlineView,
-        [`${name}--calendar-inline-view`]: this.inlineView,
-        [`${name}--range`]: this.range,
+        [`${this.COMPONENT_NAME}__container`]: true,
+        [`${this.COMPONENT_NAME}--open`]: this.isOpen || this.inlineView,
+        [`${this.COMPONENT_NAME}--calendar-inline-view`]: this.inlineView,
+        [`${this.COMPONENT_NAME}--range`]: this.range,
       };
     },
   },
@@ -587,10 +591,10 @@ export default defineComponent({
         )}
         {!showTime && panelComponent}
         {(!!presets || enableTimePicker) && (
-          <div class={`${prefix}-date-picker__footer`}>
+          <div class={`${this.classPrefix}-date-picker__footer`}>
             <TCalendarPresets presets={presets} global={global} onClick={range ? this.clickRange : this.dateClick} />
             {enableTimePicker && (
-              <div class={`${name}--apply`}>
+              <div class={`${this.COMPONENT_NAME}--apply`}>
                 {enableTimePicker && (
                   <t-button theme="primary" variant="text" onClick={this.toggleTime}>
                     {showTime ? global.selectDate : global.selectTime}
@@ -608,9 +612,9 @@ export default defineComponent({
       </div>
     );
     const inputClassNames = [
-      `${prefix}-form-controls`,
+      `${this.classPrefix}-form-controls`,
       {
-        [CLASSNAMES.STATUS.active]: this.isOpen,
+        [this.STATUS.active]: this.isOpen,
       },
     ];
     const prefixIcon = renderTNodeJSX(this, 'prefixIcon');
@@ -628,14 +632,14 @@ export default defineComponent({
       <div class={this.classes}>
         <t-popup
           ref="popup"
-          class={`${name}__popup-reference`}
+          class={`${this.COMPONENT_NAME}__popup-reference`}
           trigger="click"
           placement="bottom-left"
           disabled={disabled}
           showArrow={false}
           visible={isOpen}
           popupProps={popupProps}
-          overlayClassName={name}
+          overlayClassName={this.COMPONENT_NAME}
           content={popupContent}
           expandAnimation={true}
           onVisibleChange={(

--- a/src/date-picker/panel/date-range.tsx
+++ b/src/date-picker/panel/date-range.tsx
@@ -2,10 +2,10 @@ import { defineComponent, PropType } from 'vue';
 import dayjs from 'dayjs';
 import TDateHeader from '../basic/header';
 import TDateTable from '../basic/table';
-import { prefix } from '../../config';
 import { DatePickerConfig } from '../../config-provider/config-receiver';
-
 import { DateValue } from '../type';
+
+import { usePrefixClass } from '../../config-provider';
 
 import {
   getWeeks,
@@ -25,9 +25,8 @@ const TODAY = getToday();
 const LEFT = 'left';
 const RIGHT = 'right';
 
-const name = `${prefix}-date-picker-date-range`;
 export default defineComponent({
-  name,
+  name: 'TDatePickerDateRange',
   components: {
     TDateHeader,
     TDateTable,
@@ -57,6 +56,12 @@ export default defineComponent({
     onPick: Function,
   },
   emits: ['change'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('date-picker');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   data() {
     return {
       leftYear: null,
@@ -295,6 +300,7 @@ export default defineComponent({
   },
   render() {
     const {
+      COMPONENT_NAME,
       leftYear,
       leftMonth,
       leftType,
@@ -308,8 +314,8 @@ export default defineComponent({
       firstDayOfWeek,
     } = this;
     return (
-      <div class={`${prefix}-date-picker__panels`}>
-        <div class={`${prefix}-date-picker__panel`}>
+      <div class={`${COMPONENT_NAME}__panels`}>
+        <div class={`${COMPONENT_NAME}__panel`}>
           <t-date-header
             year={leftYear}
             month={leftMonth}
@@ -326,7 +332,7 @@ export default defineComponent({
             onCellMouseEnter={this.onMouseEnter}
           />
         </div>
-        <div class={`${prefix}-date-picker__panel`}>
+        <div class={`${COMPONENT_NAME}__panel`}>
           <t-date-header
             year={rightYear}
             month={rightMonth}

--- a/src/date-picker/panel/date.tsx
+++ b/src/date-picker/panel/date.tsx
@@ -1,10 +1,10 @@
 import { defineComponent, PropType } from 'vue';
 import TDateHeader from '../basic/header';
 import TDateTable from '../basic/table';
-import { prefix } from '../../config';
 import props from '../props';
 import { TdDatePickerProps } from '../type';
 import { DatePickerConfig } from '../../config-provider/config-receiver';
+import { usePrefixClass } from '../../config-provider';
 
 import {
   getWeeks,
@@ -18,10 +18,8 @@ import {
   OptionsType,
 } from '../../_common/js/date-picker/utils';
 
-const name = `${prefix}-date-picker-panel`;
-
 export default defineComponent({
-  name,
+  name: 'TDatePickerPanel',
   components: {
     TDateHeader,
     TDateTable,
@@ -46,6 +44,12 @@ export default defineComponent({
     onChange: props.onChange,
   },
   emits: ['change'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('date-picker-panel');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   data() {
     return {
       year: this.value.getFullYear(),
@@ -151,9 +155,9 @@ export default defineComponent({
     },
   },
   render() {
-    const { year, month, type, tableData, firstDayOfWeek } = this;
+    const { year, month, type, tableData, firstDayOfWeek, COMPONENT_NAME } = this;
     return (
-      <div class={`${prefix}-date-picker__panel`}>
+      <div class={COMPONENT_NAME}>
         <t-date-header
           year={year}
           month={month}

--- a/src/date-picker/panel/date.tsx
+++ b/src/date-picker/panel/date.tsx
@@ -45,7 +45,7 @@ export default defineComponent({
   },
   emits: ['change'],
   setup() {
-    const COMPONENT_NAME = usePrefixClass('date-picker-panel');
+    const COMPONENT_NAME = usePrefixClass('date-picker__panel');
     return {
       COMPONENT_NAME,
     };

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -6,12 +6,9 @@ import { DialogCloseContext, TdDialogProps } from './type';
 import props from './props';
 import TransferDom from '../utils/transfer-dom';
 import { addClass, removeClass } from '../utils/dom';
-import { useConfig } from '../config-provider';
+import { useConfig, usePrefixClass } from '../config-provider';
 import { useAction } from './hooks';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
-
-const name = `${prefix}-dialog`;
-const lockClass = `${prefix}-dialog--lock`;
 
 function GetCSSValue(v: string | number) {
   return Number.isNaN(Number(v)) ? v : `${Number(v)}px`;
@@ -87,6 +84,8 @@ export default defineComponent({
 
   emits: ['update:visible'],
   setup(props: TdDialogProps, context) {
+    const COMPONENT_NAME = usePrefixClass('dialog');
+    const LOCK_CLASS = usePrefixClass('dialog--lock');
     const renderContent = useContent();
     const renderTNodeJSX = useTNodeJSX();
     const dialogEle = ref<HTMLElement | null>(null);
@@ -107,16 +106,16 @@ export default defineComponent({
     const isModal = computed(() => props.mode === 'modal');
     // 是否非模态对话框
     const isModeless = computed(() => props.mode === 'modeless');
-    const maskClass = computed(() => [`${name}__mask`, !props.showOverlay && `${prefix}-is-hidden`]);
+    const maskClass = computed(() => [`${COMPONENT_NAME}__mask`, !props.showOverlay && `${prefix}-is-hidden`]);
     const dialogClass = computed(() => {
       const dialogClass = [
-        `${name}`,
-        `${name}--default`,
-        `${name}--${props.placement}`,
-        `${name}__modal-${props.theme}`,
+        `${COMPONENT_NAME}`,
+        `${COMPONENT_NAME}--default`,
+        `${COMPONENT_NAME}--${props.placement}`,
+        `${COMPONENT_NAME}__modal-${props.theme}`,
       ];
       if (['modeless', 'modal'].includes(props.mode)) {
-        dialogClass.push(`${name}--fixed`);
+        dialogClass.push(`${COMPONENT_NAME}--fixed`);
       }
       return dialogClass;
     });
@@ -147,7 +146,7 @@ export default defineComponent({
             const bodyCssText = `position: relative;width: calc(100% - ${scrollWidth.value}px);`;
             document.body.style.cssText = bodyCssText;
           }
-          !isModeless.value && addClass(document.body, lockClass);
+          !isModeless.value && addClass(document.body, LOCK_CLASS.value);
           nextTick(() => {
             if (mousePosition && dialogEle.value) {
               dialogEle.value.style.transformOrigin = `${mousePosition.x - dialogEle.value.offsetLeft}px ${
@@ -157,7 +156,7 @@ export default defineComponent({
           });
         } else {
           document.body.style.cssText = '';
-          removeClass(document.body, lockClass);
+          removeClass(document.body, LOCK_CLASS.value);
         }
         addKeyboardEvent(value);
       },
@@ -254,7 +253,7 @@ export default defineComponent({
           })}
         </div>
       );
-      const bodyClassName = props.theme === 'default' ? `${name}__body` : `${name}__body__icon`;
+      const bodyClassName = props.theme === 'default' ? `${COMPONENT_NAME}__body` : `${COMPONENT_NAME}__body__icon`;
       return (
         // /* 非模态形态下draggable为true才允许拖拽 */
         <div
@@ -264,17 +263,17 @@ export default defineComponent({
           v-draggable={isModeless.value && props.draggable}
           ref="dialogEle"
         >
-          <div class={`${name}__header`}>
+          <div class={`${COMPONENT_NAME}__header`}>
             {getIcon()}
             {renderTNodeJSX('header', defaultHeader)}
           </div>
           {props.closeBtn ? (
-            <span class={`${name}__close`} onClick={closeBtnAction}>
+            <span class={`${COMPONENT_NAME}__close`} onClick={closeBtnAction}>
               {renderTNodeJSX('closeBtn', defaultCloseBtn)}
             </span>
           ) : null}
           <div class={bodyClassName}>{body}</div>
-          <div class={`${name}__footer`}>{renderTNodeJSX('footer', defaultFooter)}</div>
+          <div class={`${COMPONENT_NAME}__footer`}>{renderTNodeJSX('footer', defaultFooter)}</div>
         </div>
       );
     };
@@ -287,6 +286,7 @@ export default defineComponent({
     });
 
     return {
+      COMPONENT_NAME,
       scrollWidth,
       isModal,
       isModeless,
@@ -302,15 +302,16 @@ export default defineComponent({
     };
   },
   render() {
+    const { COMPONENT_NAME } = this;
     const maskView = this.isModal && <div key="mask" class={this.maskClass} onClick={this.overlayAction}></div>;
     const dialogView = this.renderDialog();
     const view = [maskView, dialogView];
     const ctxStyle = { zIndex: this.zIndex };
-    const ctxClass = [`${name}__ctx`, { 't-dialog__ctx--fixed': this.mode === 'modal' }];
+    const ctxClass = [`${COMPONENT_NAME}__ctx`, { 't-dialog__ctx--fixed': this.mode === 'modal' }];
     return (
       <transition
         duration={300}
-        name={`${name}-zoom__vue`}
+        name={`${COMPONENT_NAME}-zoom__vue`}
         onAfterEnter={this.afterEnter}
         onAfterLeave={this.afterLeave}
       >

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -106,16 +106,16 @@ export default defineComponent({
     const isModal = computed(() => props.mode === 'modal');
     // 是否非模态对话框
     const isModeless = computed(() => props.mode === 'modeless');
-    const maskClass = computed(() => [`${COMPONENT_NAME}__mask`, !props.showOverlay && `${prefix}-is-hidden`]);
+    const maskClass = computed(() => [`${COMPONENT_NAME.value}__mask`, !props.showOverlay && `${prefix}-is-hidden`]);
     const dialogClass = computed(() => {
       const dialogClass = [
-        `${COMPONENT_NAME}`,
-        `${COMPONENT_NAME}--default`,
-        `${COMPONENT_NAME}--${props.placement}`,
-        `${COMPONENT_NAME}__modal-${props.theme}`,
+        `${COMPONENT_NAME.value}`,
+        `${COMPONENT_NAME.value}--default`,
+        `${COMPONENT_NAME.value}--${props.placement}`,
+        `${COMPONENT_NAME.value}__modal-${props.theme}`,
       ];
       if (['modeless', 'modal'].includes(props.mode)) {
-        dialogClass.push(`${COMPONENT_NAME}--fixed`);
+        dialogClass.push(`${COMPONENT_NAME.value}--fixed`);
       }
       return dialogClass;
     });
@@ -253,7 +253,8 @@ export default defineComponent({
           })}
         </div>
       );
-      const bodyClassName = props.theme === 'default' ? `${COMPONENT_NAME}__body` : `${COMPONENT_NAME}__body__icon`;
+      const bodyClassName =
+        props.theme === 'default' ? `${COMPONENT_NAME.value}__body` : `${COMPONENT_NAME.value}__body__icon`;
       return (
         // /* 非模态形态下draggable为true才允许拖拽 */
         <div
@@ -263,17 +264,17 @@ export default defineComponent({
           v-draggable={isModeless.value && props.draggable}
           ref="dialogEle"
         >
-          <div class={`${COMPONENT_NAME}__header`}>
+          <div class={`${COMPONENT_NAME.value}__header`}>
             {getIcon()}
             {renderTNodeJSX('header', defaultHeader)}
           </div>
           {props.closeBtn ? (
-            <span class={`${COMPONENT_NAME}__close`} onClick={closeBtnAction}>
+            <span class={`${COMPONENT_NAME.value}__close`} onClick={closeBtnAction}>
               {renderTNodeJSX('closeBtn', defaultCloseBtn)}
             </span>
           ) : null}
           <div class={bodyClassName}>{body}</div>
-          <div class={`${COMPONENT_NAME}__footer`}>{renderTNodeJSX('footer', defaultFooter)}</div>
+          <div class={`${COMPONENT_NAME.value}__footer`}>{renderTNodeJSX('footer', defaultFooter)}</div>
         </div>
       );
     };

--- a/src/dialog/hooks.tsx
+++ b/src/dialog/hooks.tsx
@@ -38,7 +38,6 @@ export function useAction(action: BtnAction) {
     const defaultTheme = globalConfirmBtnTheme?.[theme] || 'primary';
     let props: ButtonProps = {
       theme: defaultTheme,
-      content: '确定',
       onClick: (e) => {
         action.confirmBtnAction(e);
       },
@@ -55,7 +54,6 @@ export function useAction(action: BtnAction) {
     const { globalCancel } = options;
     let props: ButtonProps = {
       theme: 'default',
-      content: '取消',
       onClick: (e) => {
         action.cancelBtnAction(e);
       },

--- a/src/divider/divider.tsx
+++ b/src/divider/divider.tsx
@@ -1,32 +1,36 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../config';
 import props from './props';
 import { renderContent } from '../utils/render-tnode';
-
-const name = `${prefix}-divider`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TDivider',
 
   props: { ...props },
 
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('divider');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   render() {
-    const { theme, dashed, align } = this;
+    const { theme, dashed, align, COMPONENT_NAME } = this;
     const children = renderContent(this, 'default', 'content');
 
     const dividerClassNames = [
-      `${name}`,
-      [`${name}--${theme}`],
+      `${COMPONENT_NAME}`,
+      [`${COMPONENT_NAME}--${theme}`],
       {
-        [`${name}--dashed`]: !!dashed,
-        [`${name}--with-text`]: !!children,
-        [`${name}--with-text-${align}`]: !!children,
+        [`${COMPONENT_NAME}--dashed`]: !!dashed,
+        [`${COMPONENT_NAME}--with-text`]: !!children,
+        [`${COMPONENT_NAME}--with-text-${align}`]: !!children,
       },
     ];
 
     return (
       <div class={dividerClassNames} {...this.$attrs}>
-        {children && <span class={`${name}__inner-text`}>{children}</span>}
+        {children && <span class={`${COMPONENT_NAME}__inner-text`}>{children}</span>}
       </div>
     );
   },

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, nextTick, onUpdated, ref, watch } from 'vue';
 import { CloseIcon } from 'tdesign-icons-vue-next';
-import { useConfig } from '../config-provider';
+import { useConfig, usePrefixClass } from '../config-provider';
 import { addClass, removeClass } from '../utils/dom';
 import { ClassName, Styles } from '../common';
 import { prefix } from '../config';
@@ -13,7 +13,6 @@ import { useAction } from '../dialog/hooks';
 
 type FooterButtonType = 'confirm' | 'cancel';
 
-const name = `${prefix}-drawer`;
 const lockClass = `${prefix}-drawer--lock`;
 
 export default defineComponent({
@@ -32,6 +31,7 @@ export default defineComponent({
   emits: ['update:visible'],
   setup(props, context) {
     const { global } = useConfig('drawer');
+    const COMPONENT_NAME = usePrefixClass('drawer');
     const confirmBtnAction = (e: MouseEvent) => {
       props.onConfirm?.({ e });
     };
@@ -119,7 +119,12 @@ export default defineComponent({
       const theme = isCancel ? 'default' : 'primary';
       const isApiObject = typeof btnApi === 'object';
       return (
-        <t-button theme={theme} onClick={clickAction} props={isApiObject ? btnApi : {}} class={`${name}-${btnType}`}>
+        <t-button
+          theme={theme}
+          onClick={clickAction}
+          props={isApiObject ? btnApi : {}}
+          class={`${COMPONENT_NAME.value}-${btnType}`}
+        >
           {btnApi && typeof btnApi === 'object' ? btnApi.content : btnApi}
         </t-button>
       );
@@ -134,13 +139,13 @@ export default defineComponent({
       const confirmBtn = getConfirmBtn({
         confirmBtn: props.confirmBtn,
         globalConfirm: global.value.confirm,
-        className: `${prefix}-drawer__confirm`,
+        className: `${COMPONENT_NAME.value}__confirm`,
       });
       // this.getCancelBtn is a function of useAction
       const cancelBtn = getCancelBtn({
         cancelBtn: props.cancelBtn,
         globalCancel: global.value.cancel,
-        className: `${prefix}-drawer__cancel`,
+        className: `${COMPONENT_NAME.value}__cancel`,
       });
       return (
         <div style={footerStyle.value}>
@@ -195,6 +200,7 @@ export default defineComponent({
     });
 
     return {
+      COMPONENT_NAME,
       drawerEle,
       drawerClasses,
       wrapperStyles,
@@ -215,6 +221,7 @@ export default defineComponent({
   },
 
   render() {
+    const { COMPONENT_NAME } = this;
     if (this.destroyOnClose && !this.visible) return;
     const defaultCloseBtn = <close-icon class="t-submenu-icon"></close-icon>;
     const body = renderContent(this, 'body', 'default');
@@ -228,16 +235,18 @@ export default defineComponent({
         {...this.$attrs}
         ref="drawerEle"
       >
-        {this.showOverlay && <div class={`${name}__mask`} onClick={this.handleWrapperClick} />}
+        {this.showOverlay && <div class={`${COMPONENT_NAME}__mask`} onClick={this.handleWrapperClick} />}
         <div class={this.wrapperClasses} style={this.wrapperStyles}>
-          {this.header && <div class={`${name}__header`}>{renderTNodeJSX(this, 'header')}</div>}
+          {this.header && <div class={`${COMPONENT_NAME}__header`}>{renderTNodeJSX(this, 'header')}</div>}
           {this.closeBtn && (
-            <div class={`${name}__close-btn`} onClick={this.handleCloseBtnClick}>
+            <div class={`${COMPONENT_NAME}__close-btn`} onClick={this.handleCloseBtnClick}>
               {renderTNodeJSX(this, 'closeBtn', defaultCloseBtn)}
             </div>
           )}
-          <div class={[`${name}__body`, 'narrow-scrollbar']}>{body}</div>
-          {this.footer && <div class={`${name}__footer`}>{renderTNodeJSX(this, 'footer', defaultFooter)}</div>}
+          <div class={[`${COMPONENT_NAME}__body`, 'narrow-scrollbar']}>{body}</div>
+          {this.footer && (
+            <div class={`${COMPONENT_NAME}__footer`}>{renderTNodeJSX(this, 'footer', defaultFooter)}</div>
+          )}
         </div>
       </div>
     );

--- a/src/dropdown/dropdown-item.tsx
+++ b/src/dropdown/dropdown-item.tsx
@@ -1,15 +1,12 @@
 import { defineComponent, ref } from 'vue';
 import { ChevronRightIcon } from 'tdesign-icons-vue-next';
 import TDivider from '../divider';
-import { prefix } from '../config';
-import { STATUS_CLASSNAMES } from '../utils/classnames';
 import itemProps from './dropdown-item-props';
 import { renderContent } from '../utils/render-tnode';
 import { TNodeReturnValue } from '../common';
 import { emitEvent } from '../utils/event';
 import useRipple from '../hooks/useRipple';
-
-const name = `${prefix}-dropdown__item`;
+import { useCommonClassName, usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TDropdownItem',
@@ -37,11 +34,16 @@ export default defineComponent({
   setup() {
     const itemRef = ref<HTMLElement>();
     useRipple(itemRef);
-    return { itemRef };
+
+    const { STATUS } = useCommonClassName();
+    const COMPONENT_NAME = usePrefixClass('dropdown__item');
+    const classPrefix = usePrefixClass();
+
+    return { classPrefix, COMPONENT_NAME, STATUS, itemRef };
   },
   methods: {
     renderSuffix(): TNodeReturnValue {
-      return this.hasChildren ? <chevron-right-icon class={`${name}__item-icon`} /> : null;
+      return this.hasChildren ? <chevron-right-icon class={`${this.COMPONENT_NAME}__item-icon`} /> : null;
     },
     handleItemClick(e: MouseEvent): void {
       e.stopPropagation();
@@ -61,20 +63,21 @@ export default defineComponent({
     },
   },
   render() {
+    const { STATUS, COMPONENT_NAME, classPrefix } = this;
     const classes = [
-      name,
+      COMPONENT_NAME,
       {
-        [`${prefix}-dropdown--suffix`]: this.hasChildren,
-        [STATUS_CLASSNAMES.disabled]: this.disabled,
-        [STATUS_CLASSNAMES.active]: this.active,
+        [`${classPrefix}-dropdown--suffix`]: this.hasChildren,
+        [STATUS.disabled]: this.disabled,
+        [STATUS.active]: this.active,
       },
     ];
 
     return (
       <div>
         <div ref="itemRef" class={classes} onClick={this.handleItemClick} onMouseover={this.handleMouseover}>
-          <div class={`${name}-content`}>
-            <span class={`${name}-text`}>{renderContent(this, 'content', 'default')}</span>
+          <div class={`${COMPONENT_NAME}-content`}>
+            <span class={`${COMPONENT_NAME}-text`}>{renderContent(this, 'content', 'default')}</span>
           </div>
           {this.renderSuffix()}
         </div>

--- a/src/dropdown/dropdown-menu.tsx
+++ b/src/dropdown/dropdown-menu.tsx
@@ -1,13 +1,11 @@
 import { defineComponent, VNode } from 'vue';
 import DropdownItem from './dropdown-item';
-import { prefix } from '../config';
 import { DropdownOption } from './type';
 import { TNodeReturnValue } from '../common';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { pxCompat } from '../utils/helper';
 import { emitEvent } from '../utils/event';
-
-const name = `${prefix}-dropdown__menu`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TDropdownMenu',
@@ -38,6 +36,12 @@ export default defineComponent({
     },
   },
   emits: ['click'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('dropdown__menu');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   data() {
     return {
       path: '', // 当前选中路径，形如{/id1/id2/id3}
@@ -59,7 +63,7 @@ export default defineComponent({
       emitEvent(this, 'click', data, context);
     },
     renderMenuColumn(children: Array<DropdownOption>, showSubmenu: boolean, pathPrefix: string): VNode {
-      const menuClass = [`${name}-column`, 'narrow-scrollbar', { submenu__visible: showSubmenu }];
+      const menuClass = [`${this.COMPONENT_NAME}-column`, 'narrow-scrollbar', { submenu__visible: showSubmenu }];
       const { maxHeight, maxColumnWidth, minColumnWidth } = this.dropdown;
       return (
         <div
@@ -91,14 +95,15 @@ export default defineComponent({
     },
   },
   render() {
+    const { COMPONENT_NAME } = this;
     const columns: TNodeReturnValue[] = [];
     let menuItems = this.options as DropdownOption[];
     let pathPrefix = '';
     if (this.$slots.default) {
       return (
-        <div class={name}>
+        <div class={COMPONENT_NAME}>
           <div
-            class={[`${name}-column`, 'narrow-scrollbar']}
+            class={[`${COMPONENT_NAME}-column`, 'narrow-scrollbar']}
             style={{
               maxHeight: `${this.dropdown.maxHeight}px`,
               maxWidth: `${this.dropdown.maxColumnWidth}px`,
@@ -124,6 +129,6 @@ export default defineComponent({
         menuItems = [];
       }
     }
-    return <div class={name}>{columns}</div>;
+    return <div class={COMPONENT_NAME}>{columns}</div>;
   },
 });

--- a/src/dropdown/dropdown.tsx
+++ b/src/dropdown/dropdown.tsx
@@ -6,8 +6,7 @@ import { DropdownOption, TdDropdownProps } from './type';
 import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { emitEvent } from '../utils/event';
-
-const name = `${prefix}-dropdown`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TDropdown',
@@ -23,6 +22,12 @@ export default defineComponent({
     ...props,
   },
   emits: ['click', 'visibleChange'],
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('dropdown');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   methods: {
     handleMenuClick(data: DropdownOption, context: { e: MouseEvent }) {
       if (this.hideAfterItemClick) {
@@ -41,7 +46,7 @@ export default defineComponent({
       disabled: this.disabled,
       placement: this.placement,
       trigger: this.trigger,
-      overlayClassName: [name, (this.popupProps as TdDropdownProps['popupProps'])?.overlayClassName],
+      overlayClassName: [this.COMPONENT_NAME, (this.popupProps as TdDropdownProps['popupProps'])?.overlayClassName],
     };
 
     return (

--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -5,7 +5,6 @@ import lodashGet from 'lodash/get';
 import lodashSet from 'lodash/set';
 import isNil from 'lodash/isNil';
 import lodashTemplate from 'lodash/template';
-import { prefix } from '../config';
 import { validate } from './form-model';
 import {
   Data,
@@ -24,6 +23,8 @@ import { ClassName, TNodeReturnValue, Styles } from '../common';
 import mixins from '../utils/mixins';
 import getConfigReceiverMixins, { FormConfig } from '../config-provider/config-receiver';
 
+import { usePrefixClass } from '../config-provider';
+
 type IconConstructor = typeof ErrorCircleFilledIcon;
 
 type FormInstance = InstanceType<typeof Form>;
@@ -35,8 +36,6 @@ export const enum ValidateStatus {
   FAIL = 'fail',
 }
 
-const name = `${prefix}-form-item`;
-
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<FormConfig>('form')),
   name: 'TFormItem',
@@ -46,6 +45,12 @@ export default defineComponent({
   },
 
   props: { ...props },
+  setup() {
+    const FROM_LABEL = usePrefixClass('form__label');
+    return {
+      FROM_LABEL,
+    };
+  },
 
   data() {
     return {
@@ -73,6 +78,7 @@ export default defineComponent({
       ];
     },
     labelClasses() {
+      const { FROM_LABEL } = this;
       const parent = this.form;
       const labelAlign = isNil(this.labelAlign) ? parent?.labelAlign : this.labelAlign;
       const labelWidth = isNil(this.labelWidth) ? parent?.labelWidth : this.labelWidth;
@@ -80,11 +86,11 @@ export default defineComponent({
       return [
         CLASS_NAMES.label,
         {
-          [`${prefix}-form__label--required`]: this.needRequiredMark,
-          [`${prefix}-form__label--colon`]: this.hasColon,
-          [`${prefix}-form__label--top`]: labelAlign === 'top' || !labelWidth,
-          [`${prefix}-form__label--left`]: labelAlign === 'left' && labelWidth,
-          [`${prefix}-form__label--right`]: labelAlign === 'right' && labelWidth,
+          [`${FROM_LABEL}--required`]: this.needRequiredMark,
+          [`${FROM_LABEL}--colon`]: this.hasColon,
+          [`${FROM_LABEL}--top`]: labelAlign === 'top' || !labelWidth,
+          [`${FROM_LABEL}--left`]: labelAlign === 'left' && labelWidth,
+          [`${FROM_LABEL}--right`]: labelAlign === 'right' && labelWidth,
         },
       ];
     },

--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -2,7 +2,6 @@ import { defineComponent, VNode, ComponentPublicInstance, provide, toRefs } from
 import isEmpty from 'lodash/isEmpty';
 import isBoolean from 'lodash/isBoolean';
 import isArray from 'lodash/isArray';
-import { prefix } from '../config';
 import { FormValidateResult, TdFormProps, FormValidateParams, ValidateResultList } from './type';
 import props from './props';
 import { FORM_ITEM_CLASS_PREFIX, CLASS_NAMES, FORM_CONTROL_COMPONENTS } from './const';
@@ -11,12 +10,11 @@ import { FormResetEvent, FormSubmitEvent, ClassName } from '../common';
 import { emitEvent } from '../utils/event';
 
 import { FormDisabledProvider } from './hooks';
+import { usePrefixClass } from '../config-provider';
 
 export type FormItemInstance = InstanceType<typeof FormItem>;
 
 type Result = FormValidateResult<TdFormProps['data']>;
-
-const name = `${prefix}-form`;
 
 export default defineComponent({
   name: 'TForm',
@@ -32,9 +30,14 @@ export default defineComponent({
 
   setup(props) {
     const { disabled } = toRefs(props);
+    const COMPONENT_NAME = usePrefixClass('form');
+
     provide<FormDisabledProvider>('formDisabled', {
       disabled,
     });
+    return {
+      COMPONENT_NAME,
+    };
   },
 
   data() {
@@ -48,7 +51,7 @@ export default defineComponent({
       return [
         CLASS_NAMES.form,
         {
-          [`${name}-inline`]: this.layout === 'inline',
+          [`${this.COMPONENT_NAME}-inline`]: this.layout === 'inline',
         },
       ];
     },

--- a/src/grid/col.tsx
+++ b/src/grid/col.tsx
@@ -1,11 +1,8 @@
 import { computed, defineComponent, inject } from 'vue';
-import { prefix } from '../config';
 import props from './col-props';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
+import { usePrefixClass } from '../config-provider';
 import { RowProviderType, useRowSize, parseFlex, calcColPadding, getColClasses } from './common';
-
-const name = `${prefix}-col`;
 
 export default defineComponent({
   name: 'TCol',
@@ -15,11 +12,12 @@ export default defineComponent({
   props: { ...props },
 
   setup(props) {
+    const COMPONENT_NAME = usePrefixClass('col');
     const rowContext = inject<RowProviderType>('rowContext', Object.create(null));
 
     const size = useRowSize();
 
-    const colClasses = computed(() => getColClasses(name, props));
+    const colClasses = computed(() => getColClasses(COMPONENT_NAME.value, props));
 
     const colStyle = computed(() => {
       const colStyle: Record<string, string> = {};

--- a/src/grid/row.tsx
+++ b/src/grid/row.tsx
@@ -1,10 +1,8 @@
 import { defineComponent, provide, computed } from 'vue';
-import { prefix } from '../config';
 import props from './row-props';
 import { useRowSize, calcRowStyle, getRowClasses, RowProviderType } from './common';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-row`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TRow',
@@ -18,7 +16,8 @@ export default defineComponent({
 
     const size = useRowSize();
 
-    const rowClasses = computed(() => getRowClasses(name, props));
+    const COMPONENT_NAME = usePrefixClass('col');
+    const rowClasses = computed(() => getRowClasses(COMPONENT_NAME.value, props));
 
     const rowStyle = computed(() => calcRowStyle(props.gutter, size.value));
 

--- a/src/grid/row.tsx
+++ b/src/grid/row.tsx
@@ -16,7 +16,7 @@ export default defineComponent({
 
     const size = useRowSize();
 
-    const COMPONENT_NAME = usePrefixClass('col');
+    const COMPONENT_NAME = usePrefixClass('row');
     const rowClasses = computed(() => getRowClasses(COMPONENT_NAME.value, props));
 
     const rowStyle = computed(() => calcRowStyle(props.gutter, size.value));

--- a/src/hooks/useRipple.ts
+++ b/src/hooks/useRipple.ts
@@ -1,6 +1,6 @@
 import { ref, onMounted, onUnmounted, Ref } from 'vue';
 import useKeepAnimation from './useKeepAnimation';
-import { useConfig } from '../config-provider/useConfig';
+import { usePrefixClass } from '../config-provider/useConfig';
 import setStyle from '../utils/set-style';
 
 const period = 200;
@@ -36,7 +36,7 @@ const getRippleColor = (el: HTMLElement, fixedRippleColor?: string) => {
  */
 export default function useRipple(el: Ref<HTMLElement>, fixedRippleColor?: Ref<string>) {
   const rippleContainer = ref(null);
-  const { classPrefix } = useConfig('classPrefix');
+  const classPrefix = usePrefixClass();
   // 全局配置ripple
   const { keepRipple } = useKeepAnimation();
   // 为节点添加斜八角动画 add ripple to the DOM and set up the animation

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, VNode } from 'vue';
 import { AddIcon, RemoveIcon, ChevronDownIcon, ChevronUpIcon } from 'tdesign-icons-vue-next';
-import { prefix } from '../config';
 import TButton from '../button';
 import CLASSNAMES from '../utils/classnames';
 import props from './props';
@@ -10,8 +9,7 @@ import { emitEvent } from '../utils/event';
 
 // hooks
 import { useFormDisabled } from '../form/hooks';
-
-const name = `${prefix}-input-number`;
+import { usePrefixClass } from '../config-provider';
 
 type InputNumberEvent = {
   onInput?: (e: InputEvent) => void;
@@ -44,9 +42,13 @@ export default defineComponent({
   },
   props: { ...props },
   emits: ['update:value', 'change', 'blur', 'focus', 'keydown-enter', 'keydown', 'keyup', 'keypress'],
-  setup(props) {
+  setup() {
     const disabled = useFormDisabled();
+    const COMPONENT_NAME = usePrefixClass('input-number');
+    const classPrefix = usePrefixClass();
     return {
+      classPrefix,
+      COMPONENT_NAME,
       disabled,
     };
   },
@@ -91,7 +93,7 @@ export default defineComponent({
     },
     reduceClasses() {
       return [
-        `${name}__decrease`,
+        `${this.COMPONENT_NAME}__decrease`,
         {
           [CLASSNAMES.STATUS.disabled]: this.disabledReduce,
         },
@@ -104,7 +106,7 @@ export default defineComponent({
     },
     addClasses(): ClassName {
       return [
-        `${name}__increase`,
+        `${this.COMPONENT_NAME}__increase`,
         {
           [CLASSNAMES.STATUS.disabled]: this.disabledAdd,
         },
@@ -131,7 +133,7 @@ export default defineComponent({
         't-input',
         {
           't-is-error': this.isError,
-          [`${prefix}-align-${this.align}`]: this.align,
+          [`${this.classPrefix}-align-${this.align}`]: this.align,
         },
       ];
     },
@@ -140,7 +142,7 @@ export default defineComponent({
         't-input__inner',
         {
           [CLASSNAMES.STATUS.disabled]: this.disabled,
-          [`${name}-text-align`]: this.theme === 'row',
+          [`${this.COMPONENT_NAME}-text-align`]: this.theme === 'row',
         },
       ];
     },
@@ -352,7 +354,7 @@ export default defineComponent({
           />
         )}
         {/* // 保持和input结构相同 */}
-        <div class={`${prefix}-input__wrap`}>
+        <div class={`${this.classPrefix}-input__wrap`}>
           <div class={this.inputWrapProps}>
             <input value={this.displayValue} class={this.inputClasses} {...this.inputAttrs} {...this.inputEvents} />
           </div>

--- a/src/input/addon.tsx
+++ b/src/input/addon.tsx
@@ -1,10 +1,8 @@
 import { defineComponent, h, VNodeChild } from 'vue';
-import { prefix } from '../config';
-
-const name = `${prefix}-addon`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
-  name,
+  name: 'TAddon',
   inheritAttrs: false,
   props: {
     prepend: {
@@ -20,6 +18,12 @@ export default defineComponent({
       },
     },
   },
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('addon');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   methods: {
     renderAddon(h: any, type: string, addon: string | Function | undefined): VNodeChild {
       let addonNode: VNodeChild;
@@ -32,18 +36,19 @@ export default defineComponent({
       } else {
         addonNode = null;
       }
-      return addonNode ? <span class={`${name}__${type}`}>{addonNode}</span> : addonNode;
+      return addonNode ? <span class={`${this.COMPONENT_NAME}__${type}`}>{addonNode}</span> : addonNode;
     },
   },
   render() {
+    const { COMPONENT_NAME } = this;
     const prepend = this.renderAddon(h, 'prepend', this.prepend);
     const append = this.renderAddon(h, 'append', this.append);
     const defaultSlot: VNodeChild[] = this.$slots.default ? this.$slots.default(null) : [null];
     const className = [
-      name,
+      COMPONENT_NAME,
       {
-        [`${name}--prepend`]: prepend,
-        [`${name}--append`]: append,
+        [`${COMPONENT_NAME}--prepend`]: prepend,
+        [`${COMPONENT_NAME}--append`]: append,
       },
     ];
 

--- a/src/input/input-group.tsx
+++ b/src/input/input-group.tsx
@@ -1,8 +1,7 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../config';
 import { ClassName } from '../common';
+import { usePrefixClass } from '../config-provider';
 
-const name = `${prefix}-input-group`;
 export default defineComponent({
   name: 'TInputGroup',
   props: {
@@ -11,12 +10,18 @@ export default defineComponent({
       default: false,
     },
   },
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('input-group');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   computed: {
     CLASS(): ClassName {
       return [
-        name,
+        this.COMPONENT_NAME,
         {
-          [`${name}--separate`]: this.separate,
+          [`${this.COMPONENT_NAME}--separate`]: this.separate,
         },
       ];
     },

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -6,18 +6,13 @@ import { InputValue } from './type';
 import { getCharacterLength, omit } from '../utils/helper';
 import getConfigReceiverMixins, { InputConfig } from '../config-provider/config-receiver';
 import mixins from '../utils/mixins';
-import CLASSNAMES from '../utils/classnames';
-import { prefix } from '../config';
 import props from './props';
 import { emitEvent } from '../utils/event';
 import { renderTNodeJSX } from '../utils/render-tnode';
 
 // hooks
 import { useFormDisabled } from '../form/hooks';
-
-const name = `${prefix}-input`;
-const INPUT_WRAP_CLASS = `${prefix}-input__wrap`;
-const INPUT_TIPS_CLASS = `${prefix}-input__tips`;
+import { usePrefixClass, useCommonClassName } from '../config-provider';
 
 function getValidAttrs(obj: Record<string, unknown>): Record<string, unknown> {
   const newObj = {};
@@ -37,8 +32,20 @@ export default defineComponent({
   emits: ['enter', 'keydown', 'keyup', 'keypress', 'clear', 'change', 'focus', 'blur', 'click'],
   setup() {
     const disabled = useFormDisabled();
+    const COMPONENT_NAME = usePrefixClass('input');
+    const INPUT_WRAP_CLASS = usePrefixClass('input__wrap');
+    const INPUT_TIPS_CLASS = usePrefixClass('input__tips');
+    const { STATUS, SIZE } = useCommonClassName();
+    const classPrefix = usePrefixClass();
+
     return {
       disabled,
+      COMPONENT_NAME,
+      INPUT_WRAP_CLASS,
+      INPUT_TIPS_CLASS,
+      classPrefix,
+      STATUS,
+      SIZE,
     };
   },
   data() {
@@ -243,6 +250,8 @@ export default defineComponent({
   },
 
   render(): VNodeChild {
+    const { COMPONENT_NAME, INPUT_WRAP_CLASS, INPUT_TIPS_CLASS, SIZE, STATUS, classPrefix } = this;
+
     const inputEvents = getValidAttrs({
       onFocus: (e: FocusEvent) => this.emitFocus(e),
       onBlur: this.formatAndEmitBlur,
@@ -265,35 +274,34 @@ export default defineComponent({
     const label = renderTNodeJSX(this, 'label', { silent: true });
     const suffix = renderTNodeJSX(this, 'suffix');
 
-    const labelContent = label ? <div class={`${name}__prefix`}>{label}</div> : null;
-    const suffixContent = suffix ? <div class={`${name}__suffix`}>{suffix}</div> : null;
+    const labelContent = label ? <div class={`${COMPONENT_NAME}__prefix`}>{label}</div> : null;
+    const suffixContent = suffix ? <div class={`${COMPONENT_NAME}__suffix`}>{suffix}</div> : null;
 
     if (this.showClear) {
-      suffixIcon = <CloseCircleFilledIcon class={`${name}__suffix-clear`} onClick={this.emitClear} />;
+      suffixIcon = <CloseCircleFilledIcon class={`${COMPONENT_NAME}__suffix-clear`} onClick={this.emitClear} />;
     }
 
     if (this.type === 'password') {
       if (this.renderType === 'password') {
-        suffixIcon = <BrowseOffIcon class={`${name}__suffix-clear`} onClick={this.emitPassword} />;
+        suffixIcon = <BrowseOffIcon class={`${COMPONENT_NAME}__suffix-clear`} onClick={this.emitPassword} />;
       } else if (this.renderType === 'text') {
-        suffixIcon = <BrowseIcon class={`${name}__suffix-clear`} onClick={this.emitPassword} />;
+        suffixIcon = <BrowseIcon class={`${COMPONENT_NAME}__suffix-clear`} onClick={this.emitPassword} />;
       }
     }
 
     const classes = [
-      name,
+      COMPONENT_NAME,
       {
-        [CLASSNAMES.SIZE[this.size]]: this.size !== 'medium',
-        [CLASSNAMES.STATUS.disabled]: this.disabled,
-        [CLASSNAMES.STATUS.focused]: this.focused,
-        [`${prefix}-is-${this.status}`]: this.status,
-        [`${prefix}-align-${this.align}`]: this.align !== 'left',
-        [`${prefix}-is-disabled`]: this.disabled,
-        [`${prefix}-is-readonly`]: this.readonly,
-        [`${name}--prefix`]: prefixIcon || labelContent,
-        [`${name}--suffix`]: suffixIcon || suffixContent,
-        [`${name}--focused`]: this.focused,
-        [`${name}--auto-width`]: this.autoWidth,
+        [SIZE[this.size]]: this.size !== 'medium',
+        [STATUS.disabled]: this.disabled,
+        [STATUS.focused]: this.focused,
+        [`${classPrefix}-is-${this.status}`]: this.status,
+        [`${classPrefix}-align-${this.align}`]: this.align !== 'left',
+        [`${classPrefix}-is-readonly`]: this.readonly,
+        [`${COMPONENT_NAME}--prefix`]: prefixIcon || labelContent,
+        [`${COMPONENT_NAME}--suffix`]: suffixIcon || suffixContent,
+        [`${COMPONENT_NAME}--focused`]: this.focused,
+        [`${COMPONENT_NAME}--auto-width`]: this.autoWidth,
       },
     ];
     const inputNode = (
@@ -305,10 +313,12 @@ export default defineComponent({
         onWheel={this.onHandleMousewheel}
         {...wrapperAttrs}
       >
-        {prefixIcon ? <span class={[`${name}__prefix`, `${name}__prefix-icon`]}>{prefixIcon}</span> : null}
+        {prefixIcon ? (
+          <span class={[`${COMPONENT_NAME}__prefix`, `${COMPONENT_NAME}__prefix-icon`]}>{prefixIcon}</span>
+        ) : null}
         {labelContent}
         <input
-          class={`${name}__inner`}
+          class={`${COMPONENT_NAME}__inner`}
           {...{ ...this.inputAttrs }}
           {...inputEvents}
           ref="inputRef"
@@ -316,13 +326,19 @@ export default defineComponent({
           onInput={(e: Event) => this.handleInput(e as InputEvent)}
         />
         {this.autoWidth && (
-          <span ref="inputPreRef" class={`${prefix}-input__input-pre`}>
+          <span ref="inputPreRef" class={`${classPrefix}-input__input-pre`}>
             {this.value || this.tPlaceholder}
           </span>
         )}
         {suffixContent}
         {suffixIcon ? (
-          <span class={[`${name}__suffix`, `${name}__suffix-icon`, { [`${name}__clear`]: this.showClear }]}>
+          <span
+            class={[
+              `${COMPONENT_NAME}__suffix`,
+              `${COMPONENT_NAME}__suffix-icon`,
+              { [`${COMPONENT_NAME}__clear`]: this.showClear },
+            ]}
+          >
             {suffixIcon}
           </span>
         ) : null}
@@ -332,7 +348,7 @@ export default defineComponent({
     return (
       <div class={INPUT_WRAP_CLASS}>
         {inputNode}
-        {tips && <div class={`${INPUT_TIPS_CLASS} ${prefix}-input__tips--${this.status || 'normal'}`}>{tips}</div>}
+        {tips && <div class={`${INPUT_TIPS_CLASS} ${classPrefix}-input__tips--${this.status || 'normal'}`}>{tips}</div>}
       </div>
     );
   },

--- a/src/layout/aside.tsx
+++ b/src/layout/aside.tsx
@@ -1,8 +1,7 @@
 import { defineComponent, onMounted, onUnmounted, inject } from 'vue';
-import { prefix } from '../config';
 import props from './aside-props';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
+import { usePrefixClass } from '../config-provider';
 import { LayoutProvideType } from './layout';
 
 export default defineComponent({
@@ -12,6 +11,7 @@ export default defineComponent({
 
   setup() {
     const { hasSide } = inject<LayoutProvideType>('layout', Object.create(null));
+    const classPrefix = usePrefixClass();
     if (!hasSide) return;
 
     onMounted(() => {
@@ -21,12 +21,16 @@ export default defineComponent({
     onUnmounted(() => {
       hasSide.value = false;
     });
+    return {
+      classPrefix,
+    };
   },
 
   render() {
+    const { classPrefix } = this;
     const styles = this.width ? { width: this.width } : {};
     return (
-      <aside class={`${prefix}-layout__sider`} style={styles}>
+      <aside class={`${classPrefix}-layout__sider`} style={styles}>
         {renderTNodeJSX(this, 'default')}
       </aside>
     );

--- a/src/layout/content.tsx
+++ b/src/layout/content.tsx
@@ -1,11 +1,16 @@
 import { defineComponent } from 'vue';
 import { renderTNodeJSX } from '../utils/render-tnode';
-import { prefix } from '../config';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TContent',
-
+  setup() {
+    const classPrefix = usePrefixClass();
+    return {
+      classPrefix,
+    };
+  },
   render() {
-    return <main class={`${prefix}-layout__content`}>{renderTNodeJSX(this, 'default')}</main>;
+    return <main class={`${this.classPrefix}-layout__content`}>{renderTNodeJSX(this, 'default')}</main>;
   },
 });

--- a/src/layout/footer.tsx
+++ b/src/layout/footer.tsx
@@ -1,5 +1,5 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../config';
+import { usePrefixClass } from '../config-provider';
 import props from './footer-props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 
@@ -7,11 +7,16 @@ export default defineComponent({
   name: 'TFooter',
 
   props,
-
+  setup() {
+    const classPrefix = usePrefixClass();
+    return {
+      classPrefix,
+    };
+  },
   render() {
     const styles = this.height ? { height: this.height } : {};
     return (
-      <footer class={`${prefix}-layout__footer`} style={styles}>
+      <footer class={`${this.classPrefix}-layout__footer`} style={styles}>
         {renderTNodeJSX(this, 'default')}
       </footer>
     );

--- a/src/layout/header.tsx
+++ b/src/layout/header.tsx
@@ -1,5 +1,5 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../config';
+import { usePrefixClass } from '../config-provider';
 import props from './header-props';
 import { renderTNodeJSX } from '../utils/render-tnode';
 
@@ -8,10 +8,16 @@ export default defineComponent({
 
   props,
 
+  setup() {
+    const classPrefix = usePrefixClass();
+    return {
+      classPrefix,
+    };
+  },
   render() {
     const styles = this.height ? { height: this.height } : {};
     return (
-      <header class={`${prefix}-layout__header`} style={styles}>
+      <header class={`${this.classPrefix}-layout__header`} style={styles}>
         {renderTNodeJSX(this, 'default')}
       </header>
     );

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -1,8 +1,6 @@
 import { defineComponent, computed, provide, ref, Ref } from 'vue';
-import { prefix } from '../config';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-layout`;
+import { usePrefixClass } from '../config-provider';
 
 export type LayoutProvideType = {
   hasSide: Ref<boolean>;
@@ -14,10 +12,11 @@ export default defineComponent({
   setup() {
     const hasSide = ref(false);
 
+    const COMPONENT_NAME = usePrefixClass('layout');
     const classes = computed(() => [
-      name,
+      COMPONENT_NAME.value,
       {
-        [`${name}--with-sider`]: hasSide.value,
+        [`${COMPONENT_NAME.value}--with-sider`]: hasSide.value,
       },
     ]);
 

--- a/src/list/list-item-meta.tsx
+++ b/src/list/list-item-meta.tsx
@@ -26,6 +26,7 @@ export default defineComponent({
     };
     return {
       renderAvatar,
+      COMPONENT_NAME,
     };
   },
   render() {

--- a/src/list/list-item-meta.tsx
+++ b/src/list/list-item-meta.tsx
@@ -1,14 +1,14 @@
 import { defineComponent, ComponentPublicInstance } from 'vue';
-import { prefix } from '../config';
 import props from './list-item-meta-props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-list-item__meta`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TListItemMeta',
   props,
   setup(props, ctx) {
+    const COMPONENT_NAME = usePrefixClass('list-item__meta');
+
     const renderAvatar = (context: ComponentPublicInstance) => {
       if (props.avatar || ctx.slots.avatar) {
         console.warn('`avatar` is going to be deprecated, please use `image` instead');
@@ -17,29 +17,30 @@ export default defineComponent({
       if (!thumbnail) return;
       if (typeof thumbnail === 'string') {
         return (
-          <div class={`${name}-avatar`}>
+          <div class={`${COMPONENT_NAME.value}-avatar`}>
             <img src={thumbnail}></img>
           </div>
         );
       }
-      return <div class={`${name}-avatar`}>{thumbnail}</div>;
+      return <div class={`${COMPONENT_NAME.value}-avatar`}>{thumbnail}</div>;
     };
     return {
       renderAvatar,
     };
   },
   render() {
+    const { COMPONENT_NAME } = this;
     const propsTitleContent = renderTNodeJSX(this, 'title');
     const propsDescriptionContent = renderTNodeJSX(this, 'description');
 
     const listItemMetaContent = [
       this.renderAvatar(this),
-      <div class={`${name}-content`}>
-        {propsTitleContent && <h3 class={`${name}-title`}>{propsTitleContent}</h3>}
-        {propsDescriptionContent && <p class={`${name}-description`}>{propsDescriptionContent}</p>}
+      <div class={`${COMPONENT_NAME}-content`}>
+        {propsTitleContent && <h3 class={`${COMPONENT_NAME}-title`}>{propsTitleContent}</h3>}
+        {propsDescriptionContent && <p class={`${COMPONENT_NAME}-description`}>{propsDescriptionContent}</p>}
       </div>,
     ];
 
-    return <div class={name}>{listItemMetaContent}</div>;
+    return <div class={COMPONENT_NAME}>{listItemMetaContent}</div>;
   },
 });

--- a/src/list/list-item.tsx
+++ b/src/list/list-item.tsx
@@ -22,7 +22,7 @@ export default defineComponent({
       <li class={COMPONENT_NAME}>
         <div class={`${COMPONENT_NAME}-main`}>
           {propsDefaultContent || propsContent}
-          {propsActionContent && <li class={`${name}__action`}>{propsActionContent}</li>}
+          {propsActionContent && <li class={`${COMPONENT_NAME}__action`}>{propsActionContent}</li>}
         </div>
       </li>
     );

--- a/src/list/list-item.tsx
+++ b/src/list/list-item.tsx
@@ -1,21 +1,26 @@
 import { defineComponent } from 'vue';
-import { prefix } from '../config';
 import props from './props';
 import { renderTNodeJSX } from '../utils/render-tnode';
-
-const name = `${prefix}-list-item`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TListItem',
   props,
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('list-item');
+    return {
+      COMPONENT_NAME,
+    };
+  },
   render() {
+    const { COMPONENT_NAME } = this;
     const propsDefaultContent = renderTNodeJSX(this, 'default');
     const propsContent = renderTNodeJSX(this, 'content');
     const propsActionContent = renderTNodeJSX(this, 'action');
 
     return (
-      <li class={name}>
-        <div class={`${name}-main`}>
+      <li class={COMPONENT_NAME}>
+        <div class={`${COMPONENT_NAME}-main`}>
           {propsDefaultContent || propsContent}
           {propsActionContent && <li class={`${name}__action`}>{propsActionContent}</li>}
         </div>

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -1,14 +1,11 @@
 import { defineComponent, VNodeChild, computed } from 'vue';
 import { useTNodeJSX } from '../hooks/tnode';
 import TLoading from '../loading';
-import { prefix } from '../config';
 import props from './props';
 import { TdListProps } from './type';
 import CLASSNAMES from '../utils/classnames';
 import { LOAD_MORE, LOADING } from './const';
-import { useConfig } from '../config-provider';
-
-const name = `${prefix}-list`;
+import { useConfig, usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TList',
@@ -17,6 +14,8 @@ export default defineComponent({
   },
   setup(props: TdListProps) {
     const { global } = useConfig('list');
+    const COMPONENT_NAME = usePrefixClass('list');
+
     const renderTNodeJSX = useTNodeJSX();
     /** 列表基础逻辑 start */
     const listClass = computed(() => {
@@ -24,9 +23,9 @@ export default defineComponent({
         `${name}`,
         CLASSNAMES.SIZE[props.size],
         {
-          [`${name}--split`]: props.split,
-          [`${name}--stripe`]: props.stripe,
-          [`${name}--vertical-action`]: props.layout === 'vertical',
+          [`${COMPONENT_NAME.value}--split`]: props.split,
+          [`${COMPONENT_NAME.value}--stripe`]: props.stripe,
+          [`${COMPONENT_NAME.value}--vertical-action`]: props.layout === 'vertical',
         },
       ];
     });
@@ -34,9 +33,9 @@ export default defineComponent({
       const propsHeaderContent = renderTNodeJSX('header');
       const propsFooterContent = renderTNodeJSX('footer');
       return [
-        propsHeaderContent && <div class={`${name}__header`}>{propsHeaderContent}</div>,
+        propsHeaderContent && <div class={`${COMPONENT_NAME.value}__header`}>{propsHeaderContent}</div>,
         <ul class={`${name}__inner`}>{renderTNodeJSX('default')}</ul>,
-        propsFooterContent && <div class={`${name}__footer`}>{propsFooterContent}</div>,
+        propsFooterContent && <div class={`${COMPONENT_NAME.value}__footer`}>{propsFooterContent}</div>,
       ];
     };
     /** 列表基础逻辑 end */

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -6,7 +6,7 @@ import props from './props';
 import { TdListProps } from './type';
 import CLASSNAMES from '../utils/classnames';
 import { LOAD_MORE, LOADING } from './const';
-import { ClassName } from '../common';
+import { useConfig } from '../config-provider';
 
 const name = `${prefix}-list`;
 
@@ -16,9 +16,10 @@ export default defineComponent({
     ...props,
   },
   setup(props: TdListProps) {
+    const { global } = useConfig('list');
     const renderTNodeJSX = useTNodeJSX();
     /** 列表基础逻辑 start */
-    const listClass = computed<ClassName>(() => {
+    const listClass = computed(() => {
       return [
         `${name}`,
         CLASSNAMES.SIZE[props.size],
@@ -66,12 +67,12 @@ export default defineComponent({
           return (
             <div>
               <TLoading />
-              <span>正在加载中，请稍等</span>
+              <span>{global.value.loadingText}</span>
             </div>
           );
         }
         if (props.asyncLoading === LOAD_MORE) {
-          return <span>点击加载更多</span>;
+          return <span>{global.value.loadingMoreText}</span>;
         }
       }
       return renderTNodeJSX('asyncLoading');

--- a/src/list/list.tsx
+++ b/src/list/list.tsx
@@ -20,7 +20,7 @@ export default defineComponent({
     /** 列表基础逻辑 start */
     const listClass = computed(() => {
       return [
-        `${name}`,
+        `${COMPONENT_NAME.value}`,
         CLASSNAMES.SIZE[props.size],
         {
           [`${COMPONENT_NAME.value}--split`]: props.split,
@@ -34,7 +34,7 @@ export default defineComponent({
       const propsFooterContent = renderTNodeJSX('footer');
       return [
         propsHeaderContent && <div class={`${COMPONENT_NAME.value}__header`}>{propsHeaderContent}</div>,
-        <ul class={`${name}__inner`}>{renderTNodeJSX('default')}</ul>,
+        <ul class={`${COMPONENT_NAME.value}__inner`}>{renderTNodeJSX('default')}</ul>,
         propsFooterContent && <div class={`${COMPONENT_NAME.value}__footer`}>{propsFooterContent}</div>,
       ];
     };
@@ -56,8 +56,8 @@ export default defineComponent({
     /** loading加载相关逻辑 start */
     const loadingClass = computed(() => {
       return typeof props.asyncLoading === 'string' && ['loading', 'load-more'].includes(props.asyncLoading)
-        ? `${name}__load ${name}__load--${props.asyncLoading}`
-        : `${name}__load`;
+        ? `${COMPONENT_NAME.value}__load ${COMPONENT_NAME.value}__load--${props.asyncLoading}`
+        : `${COMPONENT_NAME.value}__load`;
     });
 
     const renderLoading = () => {
@@ -83,6 +83,7 @@ export default defineComponent({
     };
     /** loading加载相关逻辑 end */
     return {
+      COMPONENT_NAME,
       listClass,
       loadingClass,
       renderLoading,

--- a/src/loading/icon/gradient.tsx
+++ b/src/loading/icon/gradient.tsx
@@ -1,20 +1,23 @@
 import { defineComponent, onMounted, getCurrentInstance } from 'vue';
-import { prefix } from '../../config';
 import circleAdapter from '../../_common/js/loading/circle-adapter';
-
-const name = `${prefix}-loading__gradient`;
+import { useConfig } from '../../config-provider';
 
 export default defineComponent({
-  name,
+  name: 'TLoadingGradient',
 
   setup() {
+    const { classPrefix } = useConfig('classPrefix');
     onMounted(() => {
       const circleElem = getCurrentInstance().refs.circle as HTMLElement;
       circleAdapter(circleElem);
     });
+    return {
+      classPrefix,
+    };
   },
   render() {
-    const classes = [name, `${prefix}-icon-loading`];
+    const { classPrefix } = this;
+    const classes = [`${classPrefix}-loading__gradient`, `${classPrefix}-icon-loading`];
     return (
       <svg
         class={classes}

--- a/src/loading/icon/gradient.tsx
+++ b/src/loading/icon/gradient.tsx
@@ -1,12 +1,12 @@
 import { defineComponent, onMounted, getCurrentInstance } from 'vue';
 import circleAdapter from '../../_common/js/loading/circle-adapter';
-import { useConfig } from '../../config-provider';
+import { usePrefixClass } from '../../config-provider';
 
 export default defineComponent({
   name: 'TLoadingGradient',
 
   setup() {
-    const { classPrefix } = useConfig('classPrefix');
+    const classPrefix = usePrefixClass();
     onMounted(() => {
       const circleElem = getCurrentInstance().refs.circle as HTMLElement;
       circleAdapter(circleElem);
@@ -17,7 +17,9 @@ export default defineComponent({
   },
   render() {
     const { classPrefix } = this;
-    const classes = [`${classPrefix}-loading__gradient`, `${classPrefix}-icon-loading`];
+    const name = `${classPrefix}-loading__gradient`;
+
+    const classes = [name, `${classPrefix}-icon-loading`];
     return (
       <svg
         class={classes}

--- a/src/menu/head-menu.tsx
+++ b/src/menu/head-menu.tsx
@@ -1,13 +1,13 @@
 import { defineComponent, computed, provide, ref, reactive, watch, onMounted, watchEffect } from 'vue';
 import { useEmitEvent } from '../hooks/event';
 import log from '../_common/js/log/log';
-import { prefix } from '../config';
 import props from './head-menu-props';
 import { MenuValue } from './type';
 import { TdMenuInterface, TdOpenType } from './const';
 import { Tabs, TabPanel } from '../tabs';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import VMenu from './v-menu';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'THeadMenu',
@@ -15,6 +15,7 @@ export default defineComponent({
   props,
   emits: ['change', 'expand'],
   setup(props, ctx) {
+    const classPrefix = usePrefixClass();
     const emitEvent = useEmitEvent();
     watchEffect(() => {
       if (ctx.slots.options) {
@@ -25,7 +26,11 @@ export default defineComponent({
     const activeValues = ref([]);
     const expandValues = ref(props.defaultExpanded || props.expanded || []);
     const theme = computed(() => props.theme);
-    const menuClass = computed(() => [`${prefix}-menu`, `${prefix}-head-menu`, `${prefix}-menu--${props.theme}`]);
+    const menuClass = computed(() => [
+      `${classPrefix.value}-menu`,
+      `${classPrefix.value}-head-menu`,
+      `${classPrefix.value}-menu--${props.theme}`,
+    ]);
     const mode = ref(props.expandType);
     const submenu = reactive([]);
     const vMenu = new VMenu({ isMutex: true, expandValues: expandValues.value });
@@ -106,6 +111,7 @@ export default defineComponent({
     });
 
     return {
+      classPrefix,
       mode,
       menuClass,
       expandValues,
@@ -119,7 +125,7 @@ export default defineComponent({
     renderNormalSubmenu() {
       if (this.submenu.length === 0) return null;
       return (
-        <ul class={[`${prefix}-head-menu__submenu`, `${prefix}-submenu`]}>
+        <ul class={[`${this.classPrefix}-head-menu__submenu`, `${this.classPrefix}-submenu`]}>
           {
             <t-tabs value={this.activeValue} onChange={this.handleTabChange}>
               {this.submenu.map((item) => (
@@ -132,14 +138,15 @@ export default defineComponent({
     },
   },
   render() {
+    const { classPrefix } = this;
     const operations = renderContent(this, 'operations', 'options');
     const logo = renderTNodeJSX(this, 'logo');
     return (
       <div class={this.menuClass}>
-        <div class={`${prefix}-head-menu__inner`}>
-          {logo && <div class={`${prefix}-menu__logo`}>{logo}</div>}
-          <ul class={`${prefix}-menu`}>{renderContent(this, 'default', 'content')}</ul>
-          {operations && <div class={`${prefix}-menu__operations`}>{operations}</div>}
+        <div class={`${classPrefix}-head-menu__inner`}>
+          {logo && <div class={`${classPrefix}-menu__logo`}>{logo}</div>}
+          <ul class={`${classPrefix}-menu`}>{renderContent(this, 'default', 'content')}</ul>
+          {operations && <div class={`${classPrefix}-menu__operations`}>{operations}</div>}
         </div>
         {this.mode === 'normal' && this.renderNormalSubmenu()}
       </div>

--- a/src/menu/menu-group.tsx
+++ b/src/menu/menu-group.tsx
@@ -2,14 +2,22 @@ import { defineComponent } from 'vue';
 import { prefix } from '../config';
 import props from './menu-group-props';
 import { renderTNodeJSX } from '../utils/render-tnode';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TMenuGroup',
   props,
+  setup() {
+    const classPrefix = usePrefixClass();
+    return {
+      classPrefix,
+    };
+  },
   render() {
+    const { classPrefix } = this;
     return (
-      <div class={`${prefix}-menu-group`}>
-        <div class={`${prefix}-menu-group__title`}>{this.title}</div>
+      <div class={`${classPrefix}-menu-group`}>
+        <div class={`${classPrefix}-menu-group__title`}>{this.title}</div>
         {renderTNodeJSX(this, 'default')}
       </div>
     );

--- a/src/menu/menu-item.tsx
+++ b/src/menu/menu-item.tsx
@@ -1,28 +1,29 @@
 import { defineComponent, computed, inject, onMounted, ref } from 'vue';
-import { prefix } from '../config';
 import props from './menu-item-props';
 import { TdMenuInterface, TdSubMenuInterface } from './const';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import { emitEvent } from '../utils/event';
 import useRipple from '../hooks/useRipple';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TMenuItem',
   props: { ...props },
   emits: ['click'],
   setup(props, ctx) {
+    const classPrefix = usePrefixClass();
     const menu = inject<TdMenuInterface>('TdMenu');
     const itemRef = ref<HTMLElement>();
     useRipple(itemRef);
     const submenu = inject<TdSubMenuInterface>('TdSubmenu', null);
     const active = computed(() => menu.activeValue.value === props.value);
     const classes = computed(() => [
-      `${prefix}-menu__item`,
+      `${classPrefix.value}-menu__item`,
       {
-        [`${prefix}-is-active`]: active.value,
-        [`${prefix}-is-disabled`]: props.disabled,
-        [`${prefix}-menu__item--plain`]: !ctx.slots.icon && !props.icon,
-        [`${prefix}-submenu__item`]: !!submenu && !menu.isHead,
+        [`${classPrefix.value}-is-active`]: active.value,
+        [`${classPrefix.value}-is-disabled`]: props.disabled,
+        [`${classPrefix.value}-menu__item--plain`]: !ctx.slots.icon && !props.icon,
+        [`${classPrefix.value}-submenu__item`]: !!submenu && !menu.isHead,
       },
     ]);
 
@@ -32,6 +33,7 @@ export default defineComponent({
     });
 
     return {
+      classPrefix,
       menu,
       active,
       classes,
@@ -66,7 +68,7 @@ export default defineComponent({
     return (
       <li ref="itemRef" class={this.classes} onClick={this.handleClick}>
         {renderTNodeJSX(this, 'icon')}
-        <span class={[`${prefix}-menu__content`]}>{renderContent(this, 'default', 'content')}</span>
+        <span class={[`${this.classPrefix}-menu__content`]}>{renderContent(this, 'default', 'content')}</span>
       </li>
     );
   },

--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -1,6 +1,5 @@
 import { defineComponent, ref, computed, provide, watchEffect, watch, onMounted } from 'vue';
 import { useEmitEvent } from '../hooks/event';
-import { prefix } from '../config';
 import props from './props';
 import { MenuValue } from './type';
 import { TdMenuInterface, TdOpenType } from './const';
@@ -8,12 +7,14 @@ import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import VMenu from './v-menu';
 import { ClassName } from '../common';
 import log from '../_common/js/log/log';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TMenu',
   props: { ...props },
   emits: ['collapsed', 'change', 'expand'],
   setup(props, ctx) {
+    const classPrefix = usePrefixClass();
     const emitEvent = useEmitEvent();
     watchEffect(() => {
       if (ctx.slots.options) {
@@ -24,15 +25,15 @@ export default defineComponent({
     const theme = computed(() => props.theme);
     const isMutex = computed(() => props.expandMutex);
     const menuClass = computed(() => [
-      `${prefix}-default-menu`,
-      `${prefix}-menu--${props.theme}`,
+      `${classPrefix.value}-default-menu`,
+      `${classPrefix.value}-menu--${props.theme}`,
       {
-        [`${prefix}-is-collapsed`]: props.collapsed,
+        [`${classPrefix.value}-is-collapsed`]: props.collapsed,
       },
     ]);
     const innerClasses = computed(() => [
-      `${prefix}-menu`,
-      { [`${prefix}-menu--scroll`]: mode.value !== 'popup' },
+      `${classPrefix.value}-menu`,
+      { [`${classPrefix.value}-menu--scroll`]: mode.value !== 'popup' },
       'narrow-scrollbar',
     ]);
     const expandWidth = typeof props.width === 'number' ? `${props.width}px` : props.width;
@@ -101,6 +102,7 @@ export default defineComponent({
 
     return {
       styles,
+      classPrefix,
       menuClass,
       innerClasses,
       activeValue,
@@ -113,10 +115,10 @@ export default defineComponent({
     const logo = renderTNodeJSX(this, 'logo');
     return (
       <div class={this.menuClass} style={this.styles}>
-        <div class={`${prefix}-default-menu__inner`}>
-          {logo && <div class={`${prefix}-menu__logo`}>{logo}</div>}
+        <div class={`${this.classPrefix}-default-menu__inner`}>
+          {logo && <div class={`${this.classPrefix}-menu__logo`}>{logo}</div>}
           <ul class={this.innerClasses}>{renderContent(this, 'default', 'content')}</ul>
-          {operations && <div class={`${prefix}-menu__operations`}>{operations}</div>}
+          {operations && <div class={`${this.classPrefix}-menu__operations`}>{operations}</div>}
         </div>
       </div>
     );

--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -1,17 +1,18 @@
 import { defineComponent, computed, inject, ref, provide, onMounted, getCurrentInstance, watch } from 'vue';
-import { prefix } from '../config';
 import props from './submenu-props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import { TdMenuInterface, TdSubMenuInterface, TdMenuItem } from './const';
 import FakeArrow from '../common-components/fake-arrow';
 import useRipple from '../hooks/useRipple';
 import { ClassName } from '../common';
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TSubmenu',
 
   props,
   setup(props, ctx) {
+    const classPrefix = usePrefixClass();
     const menu = inject<TdMenuInterface>('TdMenu');
     const { theme, activeValues, expandValues, mode, isHead, open } = menu;
     const submenu = inject<TdSubMenuInterface>('TdSubmenu', null);
@@ -32,36 +33,36 @@ export default defineComponent({
     useRipple(submenuRef, rippleColor);
 
     const classes = computed(() => [
-      `${prefix}-submenu`,
+      `${classPrefix.value}-submenu`,
       {
-        [`${prefix}-is-disabled`]: props.disabled,
-        [`${prefix}-is-opened`]: isOpen.value,
+        [`${classPrefix.value}-is-disabled`]: props.disabled,
+        [`${classPrefix.value}-is-opened`]: isOpen.value,
       },
     ]);
     const popupClass = computed(() => [
-      `${prefix}-menu__popup`,
+      `${classPrefix.value}-menu__popup`,
       {
-        [`${prefix}-is-opened`]: popupVisible.value,
-        [`${prefix}-is-vertical`]: !isHead,
+        [`${classPrefix.value}-is-opened`]: popupVisible.value,
+        [`${classPrefix.value}-is-vertical`]: !isHead,
       },
     ]);
     const submenuClass = computed(() => [
-      `${prefix}-menu__item`,
+      `${classPrefix.value}-menu__item`,
       {
-        [`${prefix}-is-disabled`]: props.disabled,
-        [`${prefix}-is-opened`]: isOpen.value,
-        [`${prefix}-is-active`]: isActive.value,
+        [`${classPrefix.value}-is-disabled`]: props.disabled,
+        [`${classPrefix.value}-is-opened`]: isOpen.value,
+        [`${classPrefix.value}-is-active`]: isActive.value,
       },
     ]);
     const subClass = computed(() => [
-      `${prefix}-menu__sub`,
+      `${classPrefix.value}-menu__sub`,
       {
-        [`${prefix}-is-opened`]: isOpen.value,
+        [`${classPrefix.value}-is-opened`]: isOpen.value,
       },
     ]);
     const arrowClass: ClassName = computed(() => [
       {
-        [`${prefix}-fake-arrow--active`]: isOpen.value,
+        [`${classPrefix.value}-fake-arrow--active`]: isOpen.value,
       },
     ]);
 
@@ -115,6 +116,7 @@ export default defineComponent({
     });
 
     return {
+      classPrefix,
       menuItems,
       mode,
       isHead,
@@ -148,7 +150,7 @@ export default defineComponent({
           />
         </div>,
         <div ref="popup" class={this.popupClass}>
-          <ul ref="popupInner" class={`${prefix}-menu__popup-wrapper`}>
+          <ul ref="popupInner" class={`${this.classPrefix}-menu__popup-wrapper`}>
             {renderContent(this, 'default', 'content')}
           </ul>
         </div>,
@@ -174,7 +176,7 @@ export default defineComponent({
       const normalSubmenu = [
         <div ref="submenuRef" class={this.submenuClass} onClick={this.handleSubmenuItemClick}>
           {icon}
-          <span class={[`${prefix}-menu__content`]}>{renderTNodeJSX(this, 'title', { silent: true })}</span>
+          <span class={[`${this.classPrefix}-menu__content`]}>{renderTNodeJSX(this, 'title', { silent: true })}</span>
           {hasContent && (
             <FakeArrow
               overlayClassName={this.arrowClass}
@@ -190,14 +192,14 @@ export default defineComponent({
       const popupSubmenu = [
         <div class={this.submenuClass}>
           {icon}
-          <span class={[`${prefix}-menu__content`]}>{renderTNodeJSX(this, 'title', { silent: true })}</span>
+          <span class={[`${this.classPrefix}-menu__content`]}>{renderTNodeJSX(this, 'title', { silent: true })}</span>
           <FakeArrow
             overlayClassName={this.arrowClass}
             overlayStyle={{ transform: `rotate(${needRotate ? -90 : 0}deg)` }}
           />
         </div>,
         <div ref="popup" class={this.popupClass}>
-          <ul ref="popupInner" class={`${prefix}-menu__popup-wrapper`}>
+          <ul ref="popupInner" class={`${this.classPrefix}-menu__popup-wrapper`}>
             {child}
           </ul>
         </div>,

--- a/src/message/message.tsx
+++ b/src/message/message.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, h, ComponentPublicInstance } from 'vue';
+import { defineComponent, h } from 'vue';
 import {
   InfoCircleFilledIcon,
   CheckCircleFilledIcon,
@@ -8,13 +8,11 @@ import {
 } from 'tdesign-icons-vue-next';
 import TLoading from '../loading';
 
-import { prefix } from '../config';
 import { THEME_LIST } from './const';
 import { renderTNodeJSX, renderContent } from '../utils/render-tnode';
 import props from './props';
 import { emitEvent } from '../utils/event';
-
-const name = `${prefix}-message`;
+import { usePrefixClass } from '../config-provider';
 
 export default defineComponent({
   name: 'TMessage',
@@ -23,23 +21,31 @@ export default defineComponent({
 
   emits: ['duration-end', 'click-close-btn'],
 
+  setup() {
+    const COMPONENT_NAME = usePrefixClass('message');
+    const classPrefix = usePrefixClass();
+    return {
+      classPrefix,
+      COMPONENT_NAME,
+    };
+  },
+
   data() {
     return {
       timer: null,
     };
   },
-
   computed: {
     classes(): Array<any> {
       const status = {};
       THEME_LIST.forEach((t) => {
-        status[`${prefix}-is-${t}`] = this.theme === t;
+        status[`${this.classPrefix}-is-${t}`] = this.theme === t;
       });
       return [
-        name,
+        this.COMPONENT_NAME,
         status,
         {
-          [`${prefix}-is-closable`]: this.closeBtn || this.$slots.closeBtn,
+          [`${this.classPrefix}-is-closable`]: this.closeBtn || this.$slots.closeBtn,
         },
       ];
     },
@@ -70,7 +76,7 @@ export default defineComponent({
     renderClose() {
       const defaultClose = <CloseIcon />;
       return (
-        <span class={`${name}__close`} onClick={this.close}>
+        <span class={`${this.COMPONENT_NAME}__close`} onClick={this.close}>
           {renderTNodeJSX(this, 'closeBtn', defaultClose)}
         </span>
       );

--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -1,7 +1,6 @@
 import { defineComponent } from 'vue';
 import { PLACEMENT_OFFSET } from './const';
 import TMessage from './message';
-import { prefix } from '../config';
 import { MessageOptions } from './type';
 
 export const DEFAULT_Z_INDEX = 6000;
@@ -15,7 +14,7 @@ const getUniqueId = (() => {
 })();
 
 export const MessageList = defineComponent({
-  name: `${prefix}-message__list`,
+  name: 'TMessageList',
   components: { TMessage },
   props: {
     zIndex: {

--- a/src/time-picker/panel/panel-col.tsx
+++ b/src/time-picker/panel/panel-col.tsx
@@ -5,18 +5,21 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import { panelColProps } from './props';
 import { COMPONENT_NAME, EPickerCols } from '../constant';
-
-import { prefix } from '../../config';
-
-const name = `${prefix}-time-picker-pane-col`;
+import { useCommonClassName } from '../../config-provider';
 
 dayjs.extend(customParseFormat);
 
 export default defineComponent({
-  name,
+  name: 'TTimePickerPanelCol',
   props: panelColProps(),
 
   emits: ['time-pick'],
+  setup() {
+    const { STATUS } = useCommonClassName();
+    return {
+      STATUS,
+    };
+  },
   data() {
     return {
       splitValue: Object.create(null),
@@ -148,8 +151,8 @@ export default defineComponent({
         const classNames = [
           `${COMPONENT_NAME}__panel-body-scroll-item`,
           {
-            [`${prefix}-is-disabled`]: !this.timeItemCanUsed(col, el),
-            [`${prefix}-is-current`]: isCurrent,
+            [this.STATUS.disabled]: !this.timeItemCanUsed(col, el),
+            [this.STATUS.current]: isCurrent,
           },
         ];
         return (

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -173,7 +173,7 @@ exports[`ssr snapshot test renders ./examples/alert/demos/collapse.vue correctly
           <div><span>这是折叠的第一条消息</span></div>
           <div><span>这是折叠的第二条消息</span></div>
           <!--]-->
-          <div class="t-alert__collapse">展开全部</div>
+          <div class="t-alert__collapse">展开更多</div>
         </div>
         <!---->
       </div>

--- a/test/unit/alert/__snapshots__/demo.test.js.snap
+++ b/test/unit/alert/__snapshots__/demo.test.js.snap
@@ -401,7 +401,7 @@ exports[`Alert Alert collapseVue demo works fine 1`] = `
           <div
             class="t-alert__collapse"
           >
-            展开全部
+            展开更多
           </div>
         </div>
         <!---->


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 新特性提交

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- 迁移组件的 prefix 和 commonclassnames。当前为静态配置，迁移后支持动态设置
- 替换组件内的中文词条

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
