### PR TITLE
refactor: refactor notification component used by composition , and a…

### DIFF
--- a/src/notification/notification.tsx
+++ b/src/notification/notification.tsx
@@ -1,63 +1,76 @@
-import { defineComponent, h, VNodeChild } from 'vue';
+import { ComponentPublicInstance, defineComponent, h, onMounted } from 'vue';
 import { InfoCircleFilledIcon, CheckCircleFilledIcon, CloseIcon } from 'tdesign-icons-vue-next';
 import isFunction from 'lodash/isFunction';
 import { prefix } from '../config';
 import { renderTNodeJSX, renderContent } from '../utils/render-tnode';
 import props from './props';
-import { emitEvent } from '../utils/event';
+import { useEmitEvent } from '../hooks/event';
 
 const name = `${prefix}-notification`;
 
 export default defineComponent({
   name: 'TNotification',
-  props: { ...props },
-  emits: ['duration-end', 'click-close-btn'],
-  mounted() {
-    if (this.duration > 0) {
-      const timer = setTimeout(() => {
-        clearTimeout(timer);
-        emitEvent(this, 'duration-end', this);
-      }, this.duration);
-    }
+  props: {
+    ...props,
   },
-  methods: {
-    close(e?: MouseEvent) {
-      emitEvent(this, 'click-close-btn', e, this);
-    },
-    renderIcon() {
-      let icon;
-      if (this.icon === false) return null;
-      if (isFunction(this.icon)) {
-        icon = this.icon(h);
-      } else if (this.$slots.icon) {
-        icon = this.$slots.icon(null);
-      } else if (this.theme) {
+  emits: ['duration-end', 'click-close-btn'],
+  setup(props, { slots }) {
+    const emitEvent = useEmitEvent();
+    const close = (e?: MouseEvent) => {
+      emitEvent('click-close-btn', e);
+    };
+    const renderIcon = () => {
+      let iconContent;
+      if (props.icon === false) return null;
+      if (isFunction(props.icon)) {
+        iconContent = props.icon(h);
+      } else if (slots.icon) {
+        iconContent = slots.icon(null);
+      } else if (props.theme) {
         const iconType =
-          this.theme === 'success' ? (
-            <CheckCircleFilledIcon class={`t-is-${this.theme}`} />
+          props.theme === 'success' ? (
+            <CheckCircleFilledIcon class={`t-is-${props.theme}`} />
           ) : (
-            <InfoCircleFilledIcon class={`t-is-${this.theme}`} />
+            <InfoCircleFilledIcon class={`t-is-${props.theme}`} />
           );
-        icon = <div class="t-notification__icon">{iconType}</div>;
+        iconContent = <div class="t-notification__icon">{iconType}</div>;
       }
-      return icon;
-    },
-    renderClose() {
+      return iconContent;
+    };
+
+    const renderClose = (context: ComponentPublicInstance) => {
       const defaultClose = <CloseIcon />;
       return (
-        <span class={`${prefix}-message__close`} onClick={this.close}>
-          {renderTNodeJSX(this, 'closeBtn', defaultClose)}
+        <span class={`${prefix}-message__close`} onClick={close}>
+          {renderTNodeJSX(context, 'closeBtn', defaultClose)}
         </span>
       );
-    },
-    renderContent() {
-      return <div class={`${name}__content`}>{renderContent(this, 'default', 'content')}</div>;
-    },
+    };
+
+    const renderMainContent = (context: ComponentPublicInstance) => {
+      return <div class={`${name}__content`}>{renderContent(context, 'default', 'content')}</div>;
+    };
+
+    onMounted(() => {
+      if (props.duration > 0) {
+        const timer = setTimeout(() => {
+          clearTimeout(timer);
+          emitEvent('duration-end');
+        }, props.duration);
+      }
+    });
+
+    return {
+      renderIcon,
+      renderClose,
+      renderMainContent,
+    };
   },
   render() {
-    const icon = this.renderIcon();
-    const close = this.renderClose();
-    const content = this.renderContent();
+    const { renderIcon, renderClose, renderMainContent } = this;
+    const icon = renderIcon();
+    const close = renderClose(this);
+    const content = renderMainContent(this);
     const footer = renderTNodeJSX(this, 'footer');
     const title = renderTNodeJSX(this, 'title');
 

--- a/src/notification/notificationList.tsx
+++ b/src/notification/notificationList.tsx
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue';
+import { defineComponent, ref, computed, TransitionGroup } from 'vue';
 import Notification from './notification';
 import { prefix } from '../config';
 import { TdNotificationProps, NotificationOptions } from './type';
@@ -15,66 +15,80 @@ export default defineComponent({
       },
     },
   },
-  data() {
-    return {
-      list: [],
+  setup(props) {
+    const { placement } = props as NotificationOptions;
+
+    const list = ref([]);
+
+    const styles = computed<Styles>(() => ({
+      zIndex: DEFAULT_Z_INDEX,
+      ...PLACEMENT_OFFSET[placement],
+    }));
+
+    const add = (options: TdNotificationProps): number => {
+      list.value.push(options);
+      return list.value.length - 1;
     };
-  },
-  computed: {
-    styles(): Styles {
-      return {
-        zIndex: DEFAULT_Z_INDEX,
-        ...PLACEMENT_OFFSET[this.placement],
-      };
-    },
-  },
-  methods: {
-    add(options: TdNotificationProps): number {
-      this.list.push(options);
-      return this.list.length - 1;
-    },
-    remove(index: number) {
-      this.list.splice(index, 1);
-    },
-    removeAll() {
-      this.list = [];
-    },
-    getOffset(val: string | number) {
+
+    const remove = (index: number) => {
+      list.value.splice(index, 1);
+    };
+
+    const removeAll = () => {
+      list.value = [];
+    };
+
+    const getOffset = (val: string | number) => {
       if (!val) return;
       return isNaN(Number(val)) ? val : `${val}px`;
-    },
-    notificationStyles(item: { offset: NotificationOptions['offset']; zIndex: number }) {
+    };
+
+    const notificationStyles = (item: { offset: NotificationOptions['offset']; zIndex: number }) => {
       const styles: Styles = {
         marginBottom: DISTANCE,
       };
       if (item.offset) {
         styles.position = 'relative';
-        styles.left = this.getOffset(item.offset[0]);
-        styles.top = this.getOffset(item.offset[1]);
+        styles.left = getOffset(item.offset[0]);
+        styles.top = getOffset(item.offset[1]);
       }
       if (item.zIndex) styles['z-index'] = item.zIndex;
       return styles;
-    },
-    getListeners(index: number) {
+    };
+
+    const getListeners = (options: NotificationOptions, index: number) => {
       return {
-        onClickCloseBtn: () => this.remove(index),
-        onDurationEnd: () => this.remove(index),
+        onClickCloseBtn: () => remove(index),
+        onDurationEnd: () => remove(index),
       };
-    },
+    };
+
+    return {
+      list,
+      styles,
+      add,
+      remove,
+      removeAll,
+      getOffset,
+      notificationStyles,
+      getListeners,
+    };
   },
   render() {
-    if (!this.list.length) return;
+    const { placement, styles, list } = this;
     return (
-      <div class={`${prefix}-notification__show--${this.placement}`} style={this.styles}>
-        {this.list.map((item, index) => (
-          <Notification
-            ref={`notification${index}`}
-            key={item.id}
-            style={this.notificationStyles(item)}
-            {...item}
-            {...this.getListeners(index)}
-          />
-        ))}
+      <div class={`${prefix}-notification__show--${placement}`} style={styles}>
+        <TransitionGroup name="notification-slide-fade">
+          {list.map((item, index) => (
+            <Notification
+              ref={`notification${index}`}
+              key={item.id}
+              style={this.notificationStyles(item)}
+              {...item}
+              {...this.getListeners(item, index)}
+            />
+          ))}
+        </TransitionGroup>
       </div>
     );
   },


### PR DESCRIPTION
…dd notification recycle effect

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？
1. 使用vue3 composition API重构notification和notificationList组件
2. 使用transition-group完善notification回收时的动画效果

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 是关于什么的改动？

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/58

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 将`methods`、`computed`写入`setup`函数中，使用`useEmitEvent`替换`emitEvent`。

2. 先前的`notification`只有出现时的动画，回收时直接消失。重构时使用了`transition-group`包裹`notificationList`组件，并将之前四个方向的样式进行了提取，封装成`slide-fade`函数。


<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充
- [x] 代码演示无须提供
- [x] TypeScript 定义已补充
- [x] Changelog 无须提供
