### PR TITLE
fix(date-picker): reset time after time panel show

### DIFF
--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -337,15 +337,10 @@ export default defineComponent({
       }
     },
     toggleTime() {
-      this.timeValue = dayjs(this.start as Date);
-      this.endTimeValue = dayjs(this.end as Date);
+      this.startTimeValue = dayjs(this.start);
+      this.endTimeValue = dayjs(this.end);
 
       this.showTime = !this.showTime;
-
-      this.$nextTick(() => {
-        const timePickerPanel = this.$refs.timePickerPanel as any;
-        timePickerPanel && timePickerPanel.panelColUpdate();
-      });
     },
 
     clickRange(value: DateValue) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复 修复datepicker打开时间面板重置时间的问题
- 删掉废弃的update逻辑

Before

https://user-images.githubusercontent.com/26377630/158923834-05edc928-18e1-43cd-992e-9cbadb1b5623.mp4


After

https://user-images.githubusercontent.com/26377630/158923842-81646307-18af-436c-859b-dc7a296c5113.mp4



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(date-picker): 打开时间面板重置时间

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
