### PR TITLE
refactor: input warp class

### DIFF
--- a/examples/input/input.md
+++ b/examples/input/input.md
@@ -6,19 +6,20 @@
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 align | String | left | 文本内容位置，居左/居中/居右。可选项：left/center/right | N
-autocomplete | String | - | 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)。可选项：on/off | N
+autocomplete | String | - | 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) | N
 autofocus | Boolean | false | 自动聚焦 | N
 autoWidth | Boolean | false | 宽度随内容自适应 | N
 clearable | Boolean | false | 是否可清空 | N
 disabled | Boolean | false | 是否禁用输入框 | N
-format | Function | - | 指定输入框展示值的格式。TS 类型：`(value: InputValue) => number | string` | N
+format | Function | - | 【开发中】指定输入框展示值的格式。TS 类型：`(value: InputValue) => number | string` | N
+innerClass | String / Object / Array | - | t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`。TS 类型：`ClassName`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 label | String / Slot / Function | - | 左侧文本。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 maxcharacter | Number | - | 用户最多可以输入的字符个数，一个中文汉字表示两个字符长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
 maxlength | Number | - | 用户最多可以输入的文本长度，一个中文等于一个计数长度。值小于等于 0 的时候，则表示不限制输入长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
 name | String | - | 名称 | N
 placeholder | String | undefined | 占位符 | N
 prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-readonly | Boolean | false | 输入框是否只读 | N
+readonly | Boolean | false | 只读状态 | N
 showClearIconOnEmpty | Boolean | false | 输入框内容为空时，悬浮状态是否显示清空按钮，默认不显示 | N
 size | String | medium | 输入框尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 status | String | - | 输入框状态。可选项：success/warning/error | N

--- a/examples/input/input.md
+++ b/examples/input/input.md
@@ -12,7 +12,7 @@ autoWidth | Boolean | false | 宽度随内容自适应 | N
 clearable | Boolean | false | 是否可清空 | N
 disabled | Boolean | false | 是否禁用输入框 | N
 format | Function | - | 【开发中】指定输入框展示值的格式。TS 类型：`(value: InputValue) => number | string` | N
-innerClass | String / Object / Array | - | t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`。TS 类型：`ClassName`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+inputClass | String / Object / Array | - | t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`。TS 类型：`ClassName`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 label | String / Slot / Function | - | 左侧文本。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 maxcharacter | Number | - | 用户最多可以输入的字符个数，一个中文汉字表示两个字符长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
 maxlength | Number | - | 用户最多可以输入的文本长度，一个中文等于一个计数长度。值小于等于 0 的时候，则表示不限制输入长度。`maxcharacter` 和 `maxlength` 二选一使用 | N

--- a/examples/select-input/demos/custom-tag.vue
+++ b/examples/select-input/demos/custom-tag.vue
@@ -3,7 +3,7 @@
     <!-- 单选，使用 valueDisplay 插槽定义选中的某一项的内容，也可使用同名渲染函数 props.valueDisplay -->
     <t-select-input :value="selectValue1" placeholder="Please Select" clearable @clear="onClear">
       <template #valueDisplay>
-        <span class="displaySpan">
+        <span v-if="selectValue1" class="displaySpan">
           <ControlPlatformIcon class="tdesign-demo-select-input__img" />
           {{ selectValue1.label }}
         </span>
@@ -20,7 +20,7 @@
     <br /><br />
 
     <!-- 多选，第一种方式：使用 tag 插槽定义选中的某一项的内容，也可使用同名渲染函数 props.tag -->
-    <t-select-input :value="selectValue2" placeholder="Please Select" multiple @tag-change="onTagChange2">
+    <t-select-input :value="selectValue2" clearable placeholder="Please Select" multiple @tag-change="onTagChange2">
       <template #tag="{ value }">
         <span class="displaySpan">
           <ControlPlatformIcon />

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -290,6 +290,7 @@ export default defineComponent({
 
     const classes = [
       COMPONENT_NAME,
+      this.innerClass,
       {
         [SIZE[this.size]]: this.size !== 'medium',
         [STATUS.disabled]: this.disabled,
@@ -317,7 +318,7 @@ export default defineComponent({
         {labelContent}
         <input
           class={`${COMPONENT_NAME}__inner`}
-          {...{ ...this.inputAttrs }}
+          {...this.inputAttrs}
           {...inputEvents}
           ref="inputRef"
           value={this.inputValue}

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -290,7 +290,7 @@ export default defineComponent({
 
     const classes = [
       COMPONENT_NAME,
-      this.innerClass,
+      this.inputClass,
       {
         [SIZE[this.size]]: this.size !== 'medium',
         [STATUS.disabled]: this.disabled,

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -27,7 +27,6 @@ function getValidAttrs(obj: Record<string, unknown>): Record<string, unknown> {
 export default defineComponent({
   ...mixins(getConfigReceiverMixins<InputConfig>('input')),
   name: 'TInput',
-  inheritAttrs: false,
   props: { ...props },
   emits: ['enter', 'keydown', 'keyup', 'keypress', 'clear', 'change', 'focus', 'blur', 'click'],
   setup() {
@@ -267,8 +266,6 @@ export default defineComponent({
       // eslint-disable-next-line @typescript-eslint/no-empty-function
     });
 
-    const wrapperAttrs = omit(this.$attrs, [...Object.keys(inputEvents), ...Object.keys(this.inputAttrs), 'input']);
-
     const prefixIcon = this.renderIcon(this.prefixIcon, 'prefix-icon');
 
     let suffixIcon = this.renderIcon(this.suffixIcon, 'suffix-icon');
@@ -313,7 +310,6 @@ export default defineComponent({
         onMouseenter={this.onInputMouseenter}
         onMouseleave={this.onInputMouseleave}
         onWheel={this.onHandleMousewheel}
-        {...wrapperAttrs}
       >
         {prefixIcon ? (
           <span class={[`${COMPONENT_NAME}__prefix`, `${COMPONENT_NAME}__prefix-icon`]}>{prefixIcon}</span>

--- a/src/input/props.ts
+++ b/src/input/props.ts
@@ -35,8 +35,8 @@ export default {
     type: Function as PropType<TdInputProps['format']>,
   },
   /** t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]` */
-  innerClass: {
-    type: [String, Object, Array] as PropType<TdInputProps['innerClass']>,
+  inputClass: {
+    type: [String, Object, Array] as PropType<TdInputProps['inputClass']>,
   },
   /** 左侧文本 */
   label: {

--- a/src/input/props.ts
+++ b/src/input/props.ts
@@ -19,11 +19,8 @@ export default {
   },
   /** 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) */
   autocomplete: {
-    type: String as PropType<TdInputProps['autocomplete']>,
-    validator(val: TdInputProps['autocomplete']): boolean {
-      if (!val) return true;
-      return ['on', 'off'].includes(val);
-    },
+    type: String,
+    default: '',
   },
   /** 自动聚焦 */
   autofocus: Boolean,
@@ -36,6 +33,10 @@ export default {
   /** 【开发中】指定输入框展示值的格式 */
   format: {
     type: Function as PropType<TdInputProps['format']>,
+  },
+  /** t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]` */
+  innerClass: {
+    type: [String, Object, Array] as PropType<TdInputProps['innerClass']>,
   },
   /** 左侧文本 */
   label: {
@@ -63,7 +64,7 @@ export default {
   prefixIcon: {
     type: Function as PropType<TdInputProps['prefixIcon']>,
   },
-  /** 输入框是否只读 */
+  /** 只读状态 */
   readonly: Boolean,
   /** 输入框内容为空时，悬浮状态是否显示清空按钮，默认不显示 */
   showClearIconOnEmpty: Boolean,

--- a/src/input/type.ts
+++ b/src/input/type.ts
@@ -4,7 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
-import { TNode, SizeEnum } from '../common';
+import { TNode, SizeEnum, ClassName } from '../common';
 
 export interface TdInputProps {
   /**
@@ -14,8 +14,9 @@ export interface TdInputProps {
   align?: 'left' | 'center' | 'right';
   /**
    * 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)
+   * @default ''
    */
-  autocomplete?: 'on' | 'off';
+  autocomplete?: string;
   /**
    * 自动聚焦
    * @default false
@@ -40,6 +41,10 @@ export interface TdInputProps {
    * 【开发中】指定输入框展示值的格式
    */
   format?: (value: InputValue) => number | string;
+  /**
+   * t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`
+   */
+  innerClass?: ClassName;
   /**
    * 左侧文本
    */
@@ -66,7 +71,7 @@ export interface TdInputProps {
    */
   prefixIcon?: TNode;
   /**
-   * 输入框是否只读
+   * 只读状态
    * @default false
    */
   readonly?: boolean;

--- a/src/input/type.ts
+++ b/src/input/type.ts
@@ -44,7 +44,7 @@ export interface TdInputProps {
   /**
    * t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`
    */
-  innerClass?: ClassName;
+  inputClass?: ClassName;
   /**
    * 左侧文本
    */

--- a/src/select-input/select-input.tsx
+++ b/src/select-input/select-input.tsx
@@ -83,8 +83,9 @@ export default defineComponent({
           ? this.renderSelectMultiple({
               commonInputProps: this.commonInputProps,
               onInnerClear: this.onInnerClear,
+              popupVisible: visibleProps.visible,
             })
-          : this.renderSelectSingle()}
+          : this.renderSelectSingle(visibleProps.visible)}
       </Popup>
     );
 

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -65,7 +65,7 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       inputValue: tInputValue.value || '',
       inputProps: {
         readonly: !props.allowInput || props.readonly,
-        innerClass: {
+        inputClass: {
           [`${classPrefix.value}-input--focused`]: p.popupVisible,
         },
       },

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -6,10 +6,12 @@ import { InputValue } from '../input';
 import TagInput, { TagInputValue, InputValueChangeContext } from '../tag-input';
 import Loading from '../loading';
 import useDefault from '../hooks/useDefaultValue';
+import { usePrefixClass } from '../config-provider';
 
 export interface RenderSelectMultipleParams {
   commonInputProps: SelectInputCommonProperties;
   onInnerClear: (context: { e: MouseEvent }) => void;
+  popupVisible: boolean;
 }
 
 const DEFAULT_KEYS = {
@@ -20,6 +22,7 @@ const DEFAULT_KEYS = {
 
 export default function useMultiple(props: TdSelectInputProps, context: SetupContext) {
   const { inputValue } = toRefs(props);
+  const classPrefix = usePrefixClass();
   const tagInputRef = ref();
   const [tInputValue, setTInputValue] = useDefault(
     inputValue,
@@ -51,7 +54,6 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       ...p.commonInputProps,
       ...props.tagInputProps,
       tagProps: props.tagProps,
-      readonly: !props.allowInput,
       label: props.label,
       autoWidth: props.autoWidth,
       placeholder: tPlaceholder.value,
@@ -61,6 +63,9 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       value: tags.value,
       valueDisplay: props.valueDisplay,
       inputValue: tInputValue.value || '',
+      inputProps: {
+        readonly: !props.allowInput || props.readonly,
+      },
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
     };
 
@@ -83,6 +88,9 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
         }}
         onFocus={(val, context) => {
           props.onFocus?.(props.value, { ...context, tagInputValue: val });
+        }}
+        innerClass={{
+          [`${classPrefix.value}-input--focused`]: p.popupVisible,
         }}
       />
     );

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -65,6 +65,9 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       inputValue: tInputValue.value || '',
       inputProps: {
         readonly: !props.allowInput || props.readonly,
+        innerClass: {
+          [`${classPrefix.value}-input--focused`]: p.popupVisible,
+        },
       },
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
     };
@@ -88,9 +91,6 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
         }}
         onFocus={(val, context) => {
           props.onFocus?.(props.value, { ...context, tagInputValue: val });
-        }}
-        innerClass={{
-          [`${classPrefix.value}-input--focused`]: p.popupVisible,
         }}
       />
     );

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -90,7 +90,7 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
         onFocus={(val, context) => {
           props.onFocus?.(value.value, { ...context, inputValue: val });
         }}
-        innerClass={{
+        inputClass={{
           [`${classPrefix.value}-input--focused`]: popupVisible,
         }}
       />

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -6,6 +6,8 @@ import { TdSelectInputProps } from './type';
 import Input, { InputValue } from '../input';
 import Loading from '../loading';
 import { useTNodeJSX } from '../hooks/tnode';
+import { usePrefixClass } from '../config-provider';
+import useDefaultValue from '../hooks/useDefaultValue';
 
 // single 和 multiple 共有特性
 const COMMON_PROPERTIES = [
@@ -34,9 +36,15 @@ function getInputValue(value: TdSelectInputProps['value'], keys: TdSelectInputPr
 }
 
 export default function useSingle(props: TdSelectInputProps, context: SetupContext) {
-  const { value, keys } = toRefs(props);
+  const { value, keys, inputValue: propsInputValue } = toRefs(props);
+  const classPrefix = usePrefixClass();
   const inputRef = ref();
-  const inputValue = ref<string | number>('');
+  const [inputValue, setInputValue] = useDefaultValue(
+    propsInputValue,
+    props.defaultInputValue ?? '',
+    props.onInputChange,
+    'inputValue',
+  );
   const renderTNode = useTNodeJSX();
 
   const commonInputProps = computed<SelectInputCommonProperties>(() => pick(props, COMMON_PROPERTIES));
@@ -44,13 +52,12 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
   const onInnerClear = (context: { e: MouseEvent }) => {
     context?.e?.stopPropagation();
     props.onClear?.(context);
-    inputValue.value = '';
+    setInputValue('', { trigger: 'clear' });
   };
 
   const onInnerInputChange = (value: InputValue, context: { e: InputEvent | MouseEvent }) => {
     if (props.allowInput) {
-      inputValue.value = value;
-      props.onInputChange?.(value, { ...context, trigger: 'input' });
+      setInputValue(value, { ...context, trigger: 'input' });
     }
   };
 
@@ -62,18 +69,20 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
     { immediate: true },
   );
 
-  const renderSelectSingle = () => {
+  const renderSelectSingle = (popupVisible: boolean) => {
     const singleValueDisplay = renderTNode('valueDisplay');
+    const displayedValue = popupVisible && props.allowInput ? inputValue : getInputValue(value.value, keys.value);
     const prefixContent = [singleValueDisplay, renderTNode('label')];
     const inputProps = {
       ...commonInputProps.value,
       ...props.inputProps,
-      value: singleValueDisplay ? undefined : inputValue.value,
+      value: singleValueDisplay ? undefined : displayedValue,
       label: prefixContent.length ? () => prefixContent : undefined,
       autoWidth: props.autoWidth,
       readonly: !props.allowInput,
       placeholder: singleValueDisplay ? '' : props.placeholder,
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
+      showClearIconOnEmpty: Boolean(props.clearable && inputValue.value),
     };
     return (
       <Input
@@ -83,11 +92,14 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
         onChange={onInnerInputChange}
         onClear={onInnerClear}
         onBlur={(val, context) => {
-          props.onBlur?.(value, { ...context, inputValue: val });
+          props.onBlur?.(value.value, { ...context, inputValue: val });
           inputValue.value = getInputValue(value.value, keys.value);
         }}
         onFocus={(val, context) => {
-          props.onFocus?.(value, { ...context, inputValue: val });
+          props.onFocus?.(value.value, { ...context, inputValue: val });
+        }}
+        innerClass={{
+          [`${classPrefix.value}-input--focused`]: popupVisible,
         }}
       />
     );

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -61,14 +61,6 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
     }
   };
 
-  watch(
-    [value],
-    () => {
-      inputValue.value = getInputValue(value.value, keys.value);
-    },
-    { immediate: true },
-  );
-
   const renderSelectSingle = (popupVisible: boolean) => {
     const singleValueDisplay = renderTNode('valueDisplay');
     const displayedValue = popupVisible && props.allowInput ? inputValue : getInputValue(value.value, keys.value);

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -26,7 +26,7 @@ export default defineComponent({
 
   props: { ...props },
 
-  setup(props: TdTagInputProps, context) {
+  setup(props: TdTagInputProps) {
     const { NAME_CLASS, CLEAR_CLASS, BREAK_LINE_CLASS } = useComponentClassName();
 
     const { inputValue } = toRefs(props);
@@ -129,12 +129,12 @@ export default defineComponent({
     return (
       <TInput
         ref="tagInputRef"
+        readonly={this.readonly}
         {...this.inputProps}
         value={this.tInputValue}
         onWheel={this.onWheel}
         autoWidth={this.autoWidth}
         size={this.size}
-        readonly={this.readonly}
         disabled={this.disabled}
         label={() => this.renderLabel({ displayNode, label })}
         class={this.classes}

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -23,7 +23,6 @@ function getValidAttrs(obj: object): object {
 
 export default defineComponent({
   name: 'TTextarea',
-  inheritAttrs: false,
   props: { ...props },
   emits: ['update:modelValue'],
   setup(props, { attrs }) {
@@ -171,7 +170,9 @@ export default defineComponent({
         'narrow-scrollbar',
       ]);
 
-      const textareaNode = (
+      const tips = renderTNodeJSX('tips');
+
+      return (
         <div class={textareaClasses.value}>
           <textarea
             onInput={handleInput}
@@ -180,7 +181,6 @@ export default defineComponent({
             value={innerValue.value}
             style={textareaStyle.value}
             class={classes.value}
-            {...attrs}
             {...inputEvents}
             {...inputAttrs.value}
           ></textarea>
@@ -192,20 +192,11 @@ export default defineComponent({
               props.maxlength
             }`}</span>
           ) : null}
+          {tips && (
+            <div class={`${TEXTAREA_TIPS_CLASS.value} ${name.value}__tips--${props.status || 'normal'}`}>{tips}</div>
+          )}
         </div>
       );
-
-      const tips = renderTNodeJSX('tips');
-      if (tips) {
-        return (
-          <div class={TEXTAREA_WRAP_CLASS.value}>
-            {textareaNode}
-            <div class={`${TEXTAREA_TIPS_CLASS.value} ${name.value}__tips--${props.status || 'normal'}`}>{tips}</div>
-          </div>
-        );
-      }
-
-      return textareaNode;
     };
   },
 });

--- a/src/time-picker/time-picker.tsx
+++ b/src/time-picker/time-picker.tsx
@@ -324,7 +324,6 @@ export default defineComponent({
             clearable={this.clearable}
             placeholder=" "
             value={this.time ? ' ' : undefined}
-            class={this.isShowPanel ? this.STATUS.focused : ''}
             v-slots={slots}
             ref="tInput"
             onFocus={this.handleTInputFocus}

--- a/src/upload/useUpload.tsx
+++ b/src/upload/useUpload.tsx
@@ -241,6 +241,7 @@ export const useUpload = (props: TdUploadProps, uploadCtx: UploadCtxType) => {
         onError,
         onProgress: handleProgress,
         onSuccess: handleSuccess,
+        method: props.method,
       });
     }
   };

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -6669,8 +6669,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                             <!---->
@@ -6685,8 +6685,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                             <!---->
@@ -6701,8 +6701,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                             <!---->
@@ -6860,8 +6860,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
       <!--[-->
       <div class="t-color-picker__trigger">
         <div class="t-color-picker__trigger--default">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--prefix t-input--auto-width" modelvalue="#0052d9">
+          <div class="t-input__wrap" modelvalue="#0052d9">
+            <div class="t-input t-input--prefix t-input--auto-width">
               <!---->
               <div class="t-input__prefix">
                 <!--[-->
@@ -6947,8 +6947,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                             <!---->
@@ -6963,8 +6963,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                             <!---->
@@ -6979,8 +6979,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                     <div class="input-group__item" style="flex:1;">
                       <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                         <!---->
-                        <div class="t-input__wrap">
-                          <div class="t-input t-align-center" unselectable="off">
+                        <div class="t-input__wrap" unselectable="off">
+                          <div class="t-input t-align-center">
                             <!---->
                             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                             <!---->
@@ -7138,8 +7138,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
       <!--[-->
       <div class="t-color-picker__trigger">
         <div class="t-color-picker__trigger--default">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--prefix t-input--auto-width" modelvalue="#0052d9">
+          <div class="t-input__wrap" modelvalue="#0052d9">
+            <div class="t-input t-input--prefix t-input--auto-width">
               <!---->
               <div class="t-input__prefix">
                 <!--[-->
@@ -7181,8 +7181,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                 <div class="t-color-picker__gradient-degree" title="45deg">
                   <div class="t-input-number t-size-m t-input-number--normal" modelvalue="45">
                     <!---->
-                    <div class="t-input__wrap">
-                      <div class="t-input" unselectable="off">
+                    <div class="t-input__wrap" unselectable="off">
+                      <div class="t-input">
                         <!---->
                         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="45°">
                         <!---->
@@ -7251,8 +7251,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
                   <div class="input-group">
                     <!--[-->
                     <div class="input-group__item" style="flex:3;">
-                      <div class="t-input__wrap">
-                        <div class="t-input t-align-center" modelvalue="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)" title="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)">
+                      <div class="t-input__wrap" modelvalue="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)" title="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)">
+                        <div class="t-input t-align-center">
                           <!---->
                           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)">
                           <!---->
@@ -7408,8 +7408,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/color-mode.vue 
       <!--[-->
       <div class="t-color-picker__trigger">
         <div class="t-color-picker__trigger--default">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--prefix t-input--auto-width" modelvalue="linear-gradient(45deg, #4facfe 0%, #00f2fe 100%)">
+          <div class="t-input__wrap" modelvalue="linear-gradient(45deg, #4facfe 0%, #00f2fe 100%)">
+            <div class="t-input t-input--prefix t-input--auto-width">
               <!---->
               <div class="t-input__prefix">
                 <!--[-->
@@ -7506,8 +7506,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/enable-alpha.vu
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                     <!---->
@@ -7522,8 +7522,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/enable-alpha.vu
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                     <!---->
@@ -7538,8 +7538,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/enable-alpha.vu
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                     <!---->
@@ -7554,8 +7554,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/enable-alpha.vu
             <div class="input-group__item" style="flex:1.15;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="100" title="100">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="100%">
                     <!---->
@@ -7785,8 +7785,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/panel.vue corre
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                     <!---->
@@ -7801,8 +7801,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/panel.vue corre
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                     <!---->
@@ -7817,8 +7817,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/panel.vue corre
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                     <!---->
@@ -8050,8 +8050,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                       <!---->
@@ -8066,8 +8066,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                       <!---->
@@ -8082,8 +8082,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                       <!---->
@@ -8341,8 +8341,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                       <!---->
@@ -8357,8 +8357,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                       <!---->
@@ -8373,8 +8373,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/recent-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                       <!---->
@@ -8542,8 +8542,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/status-disabled
     <!--[-->
     <div class="t-color-picker__trigger">
       <div class="t-color-picker__trigger--default">
-        <div class="t-input__wrap">
-          <div class="t-input t-is-disabled t-input--prefix t-input--auto-width" modelvalue="#0052d9">
+        <div class="t-input__wrap" modelvalue="#0052d9">
+          <div class="t-input t-is-disabled t-input--prefix t-input--auto-width">
             <!---->
             <div class="t-input__prefix">
               <!--[-->
@@ -8637,8 +8637,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/status-readonly
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-is-disabled t-input-number--normal" modelvalue="0" title="0">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-is-disabled t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-is-disabled t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value="0">
                     <!---->
@@ -8653,8 +8653,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/status-readonly
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-is-disabled t-input-number--normal" modelvalue="82" title="82">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-is-disabled t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-is-disabled t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value="82">
                     <!---->
@@ -8669,8 +8669,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/status-readonly
             <div class="input-group__item" style="flex:1;">
               <div class="t-input-number t-size-m t-is-disabled t-input-number--normal" modelvalue="217" title="217">
                 <!---->
-                <div class="t-input__wrap">
-                  <div class="t-input t-is-disabled t-align-center" unselectable="off">
+                <div class="t-input__wrap" unselectable="off">
+                  <div class="t-input t-is-disabled t-align-center">
                     <!---->
                     <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value="217">
                     <!---->
@@ -8902,8 +8902,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                       <!---->
@@ -8918,8 +8918,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                       <!---->
@@ -8934,8 +8934,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                       <!---->
@@ -9058,8 +9058,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                       <!---->
@@ -9074,8 +9074,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                       <!---->
@@ -9090,8 +9090,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/swatch-color.vu
               <div class="input-group__item" style="flex:1;">
                 <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                   <!---->
-                  <div class="t-input__wrap">
-                    <div class="t-input t-align-center" unselectable="off">
+                  <div class="t-input__wrap" unselectable="off">
+                    <div class="t-input t-align-center">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                       <!---->
@@ -9191,8 +9191,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/trigger.vue cor
                   <div class="input-group__item" style="flex:1;">
                     <div class="t-input-number t-size-m t-input-number--normal" modelvalue="0" title="0">
                       <!---->
-                      <div class="t-input__wrap">
-                        <div class="t-input t-align-center" unselectable="off">
+                      <div class="t-input__wrap" unselectable="off">
+                        <div class="t-input t-align-center">
                           <!---->
                           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0">
                           <!---->
@@ -9207,8 +9207,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/trigger.vue cor
                   <div class="input-group__item" style="flex:1;">
                     <div class="t-input-number t-size-m t-input-number--normal" modelvalue="82" title="82">
                       <!---->
-                      <div class="t-input__wrap">
-                        <div class="t-input t-align-center" unselectable="off">
+                      <div class="t-input__wrap" unselectable="off">
+                        <div class="t-input t-align-center">
                           <!---->
                           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="82">
                           <!---->
@@ -9223,8 +9223,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/trigger.vue cor
                   <div class="input-group__item" style="flex:1;">
                     <div class="t-input-number t-size-m t-input-number--normal" modelvalue="217" title="217">
                       <!---->
-                      <div class="t-input__wrap">
-                        <div class="t-input t-align-center" unselectable="off">
+                      <div class="t-input__wrap" unselectable="off">
+                        <div class="t-input t-align-center">
                           <!---->
                           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="217">
                           <!---->
@@ -9382,8 +9382,8 @@ exports[`ssr snapshot test renders ./examples/color-picker/demos/trigger.vue cor
     <!--[-->
     <div class="t-color-picker__trigger">
       <div class="t-color-picker__trigger--default">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--prefix t-input--auto-width" modelvalue="#0052d9">
+        <div class="t-input__wrap" modelvalue="#0052d9">
+          <div class="t-input t-input--prefix t-input--auto-width">
             <!---->
             <div class="t-input__prefix">
               <!--[-->
@@ -9620,6 +9620,7 @@ exports[`ssr snapshot test renders ./examples/comment/demos/reply-form.vue corre
         <!--[-->
         <div class="form-container">
           <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入内容"></textarea>
+            <!---->
             <!---->
             <!---->
           </div><button class="t-button t-size-m t-button--variant-base t-button--theme-primary form-submit" type="button"><span class="t-button__text"><!--[-->回复<!--]--></span></button>
@@ -10036,8 +10037,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select date" type="text" value>
             <!---->
@@ -10412,8 +10413,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select date" type="text" value>
             <!---->
@@ -10500,8 +10501,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select month" type="text" value>
             <!---->
@@ -10652,8 +10653,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select month" type="text" value>
             <!---->
@@ -10735,8 +10736,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select year" type="text" value>
             <!---->
@@ -10877,8 +10878,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/date-picker.
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="select year" type="text" value>
             <!---->
@@ -10979,8 +10980,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue style="width:400px;">
+          <div class="t-input__wrap" modelvalue style="width:400px;">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="There is no required mark on the left of this input in Form" type="text" value>
               <!---->
@@ -11000,8 +11001,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue style="width:400px;">
+          <div class="t-input__wrap" modelvalue style="width:400px;">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="There is required mark on the left of this input in Form" type="password" value>
               <!---->
@@ -11301,8 +11302,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="see empty data in TreeSelect" type="text" value>
             <!---->
@@ -11356,8 +11357,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="see loading text in TreeSelect" type="text" value>
             <!---->
@@ -11429,8 +11430,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="tree select" type="text" value>
             <!---->
@@ -11783,8 +11784,8 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/pagination.v
     </svg></div>
   <div class="t-pagination__jump">jump to<div class="t-input-number t-size-m t-input-number--normal t-pagination__input" modelvalue="1">
       <!---->
-      <div class="t-input__wrap">
-        <div class="t-input" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="1">
           <!---->
@@ -12236,8 +12237,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/base.vue correct
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue="2021-11-10" allowinput="0">
+        <div class="t-input__wrap" modelvalue="2021-11-10" allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value="2021-11-10">
             <!---->
@@ -12441,8 +12442,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/custom-icon.vue 
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--prefix t-input--suffix" modelvalue allowinput="0"><span class="t-input__prefix t-input__prefix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse" style=""><path fill="currentColor" d="M10.88 8a2.88 2.88 0 11-5.76 0 2.88 2.88 0 015.76 0zm-1 0a1.88 1.88 0 10-3.76 0 1.88 1.88 0 003.76 0z" fill-opacity="0.9"></path><path fill="currentColor" d="M1.12 8.23A7.72 7.72 0 008 12.5c2.9 0 5.54-1.63 6.88-4.27L15 8l-.12-.23A7.73 7.73 0 008 3.5a7.74 7.74 0 00-6.88 4.27L1 8l.12.23zM8 11.5A6.73 6.73 0 012.11 8 6.73 6.73 0 0113.9 8 6.74 6.74 0 018 11.5z" fill-opacity="0.9"></path></svg></span>
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--prefix t-input--suffix"><span class="t-input__prefix t-input__prefix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse" style=""><path fill="currentColor" d="M10.88 8a2.88 2.88 0 11-5.76 0 2.88 2.88 0 015.76 0zm-1 0a1.88 1.88 0 10-3.76 0 1.88 1.88 0 003.76 0z" fill-opacity="0.9"></path><path fill="currentColor" d="M1.12 8.23A7.72 7.72 0 008 12.5c2.9 0 5.54-1.63 6.88-4.27L15 8l-.12-.23A7.73 7.73 0 008 3.5a7.74 7.74 0 00-6.88 4.27L1 8l.12.23zM8 11.5A6.73 6.73 0 012.11 8 6.73 6.73 0 0113.9 8 6.74 6.74 0 018 11.5z" fill-opacity="0.9"></path></svg></span>
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
             <!---->
             <!----><span class="t-input__suffix t-input__suffix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fill-opacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fill-opacity="0.9"></path></svg><!--]--></span>
@@ -12830,8 +12831,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-presets.vue
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
             <!---->
@@ -13223,8 +13224,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-presets-alt
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue="2020-12-28 至 2020-12-28" allowinput="0">
+          <div class="t-input__wrap" modelvalue="2020-12-28 至 2020-12-28" allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value="2020-12-28 至 2020-12-28">
               <!---->
@@ -13435,8 +13436,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-presets-alt
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue="2020-12-28" allowinput="0">
+          <div class="t-input__wrap" modelvalue="2020-12-28" allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value="2020-12-28">
               <!---->
@@ -13828,8 +13829,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-presets-tim
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
             <!---->
@@ -14209,8 +14210,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-range.vue c
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="开始时间 至 结束时间" type="text" value>
             <!---->
@@ -14592,8 +14593,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-range.vue c
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
             <!---->
@@ -14804,8 +14805,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/date-time.vue co
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue="2021-05-01 11:30:20" allowinput="0">
+        <div class="t-input__wrap" modelvalue="2021-05-01 11:30:20" allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value="2021-05-01 11:30:20">
             <!---->
@@ -15010,8 +15011,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/disable-date.vue
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue allowinput="0">
+          <div class="t-input__wrap" modelvalue allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
               <!---->
@@ -15212,8 +15213,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/disable-date.vue
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue allowinput="0">
+          <div class="t-input__wrap" modelvalue allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
               <!---->
@@ -15414,8 +15415,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/disable-date.vue
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue allowinput="0">
+          <div class="t-input__wrap" modelvalue allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
               <!---->
@@ -15792,8 +15793,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/disable-date.vue
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue allowinput="0">
+          <div class="t-input__wrap" modelvalue allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
               <!---->
@@ -15994,8 +15995,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/disable-date.vue
         </div>
         <!--[-->
         <div class="t-form-controls">
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue allowinput="0">
+          <div class="t-input__wrap" modelvalue allowinput="0">
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
               <!---->
@@ -16200,8 +16201,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/first-day-of-wee
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择日期" type="text" value>
             <!---->
@@ -16293,8 +16294,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/month.vue correc
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择月份" type="text" value>
             <!---->
@@ -16381,8 +16382,8 @@ exports[`ssr snapshot test renders ./examples/date-picker/demos/year.vue correct
       </div>
       <!--[-->
       <div class="t-form-controls">
-        <div class="t-input__wrap">
-          <div class="t-input t-input--suffix" modelvalue allowinput="0">
+        <div class="t-input__wrap" modelvalue allowinput="0">
+          <div class="t-input t-input--suffix">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择年份" type="text" value>
             <!---->
@@ -17796,8 +17797,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/align.vue correctly 1`]
       <div class="t-form__controls" style="margin-left:60px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -17817,8 +17818,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/align.vue correctly 1`]
       <div class="t-form__controls" style="margin-left:60px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -17857,8 +17858,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/base.vue correctly 1`] 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value>
               <!---->
@@ -17878,8 +17879,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/base.vue correctly 1`] 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value>
               <!---->
@@ -17965,8 +17966,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -17986,8 +17987,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18007,8 +18008,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -18027,8 +18028,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18130,8 +18131,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18151,8 +18152,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/clear-validate.vue corr
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18192,8 +18193,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/custom-validator.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18213,8 +18214,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/custom-validator.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -18233,8 +18234,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/custom-validator.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -18274,8 +18275,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-is-disabled" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-is-disabled">
               <!---->
               <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value>
               <!---->
@@ -18394,8 +18395,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
                 <!--[-->
                 <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
                 <!---->
-                <div class="t-input__wrap" style="display:none;">
-                  <div class="t-input t-is-disabled t-select__input" modelvalue>
+                <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+                  <div class="t-input t-is-disabled">
                     <!---->
                     <!----><input class="t-input__inner" disabled placeholder type="text" value>
                     <!---->
@@ -18645,8 +18646,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
               </div>
               <!--[-->
               <div class="t-form-controls">
-                <div class="t-input__wrap">
-                  <div class="t-input t-is-disabled t-input--suffix" modelvalue allowinput="0">
+                <div class="t-input__wrap" modelvalue allowinput="0">
+                  <div class="t-input t-is-disabled t-input--suffix">
                     <!---->
                     <!----><input class="t-input__inner" disabled placeholder="请选择日期" type="text" value>
                     <!---->
@@ -18669,7 +18670,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-textarea t-is-disabled"><textarea style="" class="t-textarea__inner t-is-disabled narrow-scrollbar" clearable disabled placeholder="简单描述自己的经历"></textarea>
+          <div class="t-textarea t-is-disabled" clearable><textarea style="" class="t-textarea__inner t-is-disabled narrow-scrollbar" disabled placeholder="简单描述自己的经历"></textarea>
+            <!---->
             <!---->
             <!---->
           </div>
@@ -18730,8 +18732,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
           <!--[-->
           <div class="t-input-number t-size-m t-is-disabled t-input-number--normal">
             <!---->
-            <div class="t-input__wrap">
-              <div class="t-input t-is-disabled" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-disabled">
                 <!---->
                 <!----><input class="t-input__inner" disabled placeholder="数字" type="text" value>
                 <!---->
@@ -18830,8 +18832,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18851,8 +18853,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18872,8 +18874,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -18892,8 +18894,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -18995,8 +18997,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19016,8 +19018,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/error-message.vue corre
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19064,8 +19066,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/layout.vue correctly 1`
       <div class="t-form__controls" style="margin-left:calc(2em + 24px);">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19085,8 +19087,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/layout.vue correctly 1`
       <div class="t-form__controls" style="margin-left:calc(2em + 24px);">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -19114,8 +19116,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/login.vue correctly 1`]
       <div class="t-form__controls" style="">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--prefix" modelvalue><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-desktop" style=""><path fill="currentColor" d="M2.5 11h5v2H3v1h10v-1H8.5v-2h5a1 1 0 001-1V3a1 1 0 00-1-1h-11a1 1 0 00-1 1v7a1 1 0 001 1zm0-8h11v7h-11V3z" fill-opacity="0.9"></path></svg><!--]--></span>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--prefix"><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-desktop" style=""><path fill="currentColor" d="M2.5 11h5v2H3v1h10v-1H8.5v-2h5a1 1 0 001-1V3a1 1 0 00-1-1h-11a1 1 0 00-1 1v7a1 1 0 001 1zm0-8h11v7h-11V3z" fill-opacity="0.9"></path></svg><!--]--></span>
               <!----><input class="t-input__inner" placeholder="请输入账户名" type="text" value>
               <!---->
               <!---->
@@ -19134,8 +19136,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/login.vue correctly 1`]
       <div class="t-form__controls" style="">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--prefix t-input--suffix" modelvalue><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fill-opacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fill-opacity="0.9"></path></svg><!--]--></span>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--prefix t-input--suffix"><span class="t-input__prefix t-input__prefix-icon"><!--[--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-lock-on" style=""><path fill="currentColor" d="M6 10v1h4v-1H6z" fill-opacity="0.9"></path><path fill="currentColor" d="M4.5 5v1H3a.5.5 0 00-.5.5v7c0 .28.22.5.5.5h10a.5.5 0 00.5-.5v-7A.5.5 0 0013 6h-1.5V5a3.5 3.5 0 00-7 0zm6 1h-5V5a2.5 2.5 0 015 0v1zm-7 1h9v6h-9V7z" fill-opacity="0.9"></path></svg><!--]--></span>
               <!----><input class="t-input__inner" placeholder="请输入密码" type="password" value>
               <!---->
               <!----><span class="t-input__suffix t-input__suffix-icon"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-browse-off t-input__suffix-clear" style=""><path fill="currentColor" d="M10.77 11.98l1.38 1.37.7-.7-9.7-9.7-.7.7 1.2 1.21a7.9 7.9 0 00-2.53 2.91L1 8l.12.23a7.72 7.72 0 009.65 3.75zM10 11.2A6.67 6.67 0 012.11 8c.56-1 1.34-1.83 2.26-2.43l1.08 1.09a2.88 2.88 0 003.9 3.9l.64.64zM6.21 7.42l2.37 2.37a1.88 1.88 0 01-2.37-2.37zM14.88 8.23L15 8l-.12-.23a7.73 7.73 0 00-9.35-3.86l.8.8A6.7 6.7 0 0113.9 8a6.87 6.87 0 01-2.02 2.26l.7.7a7.9 7.9 0 002.3-2.73z" fill-opacity="0.9"></path><path fill="currentColor" d="M10.88 8c0 .37-.07.73-.2 1.06l-.82-.82.02-.24a1.88 1.88 0 00-2.12-1.86l-.82-.82A2.87 2.87 0 0110.88 8z" fill-opacity="0.9"></path></svg></span>
@@ -19180,8 +19182,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/reset.vue correctly 1`]
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue="TDesign">
+          <div class="t-input__wrap" modelvalue="TDesign">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="TDesign">
               <!---->
@@ -19201,8 +19203,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/reset.vue correctly 1`]
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue="12345678910">
+          <div class="t-input__wrap" modelvalue="12345678910">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="12345678910">
               <!---->
@@ -19264,8 +19266,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/size.vue correctly 1`] 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue="TDesign">
+          <div class="t-input__wrap" modelvalue="TDesign">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="TDesign">
               <!---->
@@ -19285,8 +19287,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/size.vue correctly 1`] 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue="12345678910">
+          <div class="t-input__wrap" modelvalue="12345678910">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="12345678910">
               <!---->
@@ -19426,8 +19428,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-complicated-da
               <div class="t-form__controls" style="margin-left:80px;">
                 <div class="t-form__controls-content">
                   <!--[-->
-                  <div class="t-input__wrap">
-                    <div class="t-input" modelvalue="StudentA">
+                  <div class="t-input__wrap" modelvalue="StudentA">
+                    <div class="t-input">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="StudentA">
                       <!---->
@@ -19496,8 +19498,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-complicated-da
               <div class="t-form__controls" style="margin-left:80px;">
                 <div class="t-form__controls-content">
                   <!--[-->
-                  <div class="t-input__wrap">
-                    <div class="t-input" modelvalue="StudentB">
+                  <div class="t-input__wrap" modelvalue="StudentB">
+                    <div class="t-input">
                       <!---->
                       <!----><input class="t-input__inner" placeholder="请输入内容" type="text" value="StudentB">
                       <!---->
@@ -19582,8 +19584,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19603,8 +19605,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19624,8 +19626,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -19644,8 +19646,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19747,8 +19749,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19768,8 +19770,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validate-message.vue co
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19810,8 +19812,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator.vue correctly
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19852,8 +19854,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator.vue correctly
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input t-input--suffix" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input t-input--suffix">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="password" value>
               <!---->
@@ -19872,8 +19874,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator.vue correctly
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19975,8 +19977,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator.vue correctly
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -19996,8 +19998,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator.vue correctly
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
               <!---->
@@ -20050,8 +20052,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="校验不通过状态" type="text" value>
               <!---->
@@ -20071,8 +20073,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="校验警告状态" type="text" value>
               <!---->
@@ -20092,8 +20094,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="不带绿色边框的成功状态" type="text" value>
               <!---->
@@ -20113,8 +20115,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="带绿色边框的成功状态" type="text" value>
               <!---->
@@ -20134,8 +20136,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="隐藏状态图标" type="text" value>
               <!---->
@@ -20155,8 +20157,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="校验警告状态" type="text" value>
               <!---->
@@ -20176,8 +20178,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="正在校验中，请稍等" type="text" value>
               <!---->
@@ -20196,8 +20198,8 @@ exports[`ssr snapshot test renders ./examples/form/demos/validator-status.vue co
       <div class="t-form__controls" style="margin-left:80px;">
         <div class="t-form__controls-content">
           <!--[-->
-          <div class="t-input__wrap">
-            <div class="t-input" modelvalue>
+          <div class="t-input__wrap" modelvalue>
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder="自定义右侧图标" type="text" value>
               <!---->
@@ -21216,8 +21218,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/base.vue correctly 1`]
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input" modelvalue="有默认值">
+  <div class="t-input__wrap" modelvalue="有默认值">
+    <div class="t-input">
       <!---->
       <!----><input class="t-input__inner" placeholder="请输入内容（有默认值）" type="text" value="有默认值">
       <!---->
@@ -21241,8 +21243,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/base.vue correctly 1`]
 
 exports[`ssr snapshot test renders ./examples/input/demos/clearable.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="max-width:500px;">
-  <div class="t-input__wrap">
-    <div class="t-input" modelvalue="Hello TDesign">
+  <div class="t-input__wrap" modelvalue="Hello TDesign">
+    <div class="t-input">
       <!---->
       <!----><input class="t-input__inner" placeholder="请输入" type="text" value="Hello TDesign">
       <!---->
@@ -21271,8 +21273,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/focus.vue correctly 1`
 
 exports[`ssr snapshot test renders ./examples/input/demos/format.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="max-width:500px;">
-  <div class="t-input__wrap">
-    <div class="t-input" modelvalue>
+  <div class="t-input__wrap" modelvalue>
+    <div class="t-input">
       <!---->
       <!----><input class="t-input__inner" placeholder="请输入数字" type="text" value>
       <!---->
@@ -21288,8 +21290,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
   <div>
     <div class="t-input-group t-input-group--separate">
       <!--[-->
-      <div class="t-input__wrap">
-        <div class="t-input" style="width:100px;">
+      <div class="t-input__wrap" style="width:100px;">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0731">
           <!---->
@@ -21366,8 +21368,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
   <div>
     <div class="t-input-group t-input-group--separate">
       <!--[-->
-      <div class="t-input__wrap">
-        <div class="t-input" style="width:100px;">
+      <div class="t-input__wrap" style="width:100px;">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="0731">
           <!---->
@@ -21376,8 +21378,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
         </div>
         <!---->
       </div><span style="line-height:32px;"> - </span>
-      <div class="t-input__wrap">
-        <div class="t-input" style="width:100px;">
+      <div class="t-input__wrap" style="width:100px;">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="12345">
           <!---->
@@ -21386,8 +21388,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
         </div>
         <!---->
       </div>
-      <div class="t-input__wrap">
-        <div class="t-input" style="width:100px;">
+      <div class="t-input__wrap" style="width:100px;">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="678901">
           <!---->
@@ -21396,8 +21398,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
         </div>
         <!---->
       </div>
-      <div class="t-input__wrap">
-        <div class="t-input" style="width:100px;">
+      <div class="t-input__wrap" style="width:100px;">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text">
           <!---->
@@ -21414,8 +21416,8 @@ exports[`ssr snapshot test renders ./examples/input/demos/group.vue correctly 1`
 
 exports[`ssr snapshot test renders ./examples/input/demos/max-length-count.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="max-width:500px;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--suffix" modelvalue>
+  <div class="t-input__wrap" modelvalue>
+    <div class="t-input t-input--suffix">
       <!---->
       <!----><input class="t-input__inner" placeholder="请输入" maxlength="5" type="text" value>
       <!---->
@@ -21594,6 +21596,7 @@ exports[`ssr snapshot test renders ./examples/input/demos/textarea.vue correctly
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入内容"></textarea>
     <!---->
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -21609,8 +21612,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
         <!--]-->
         <!--]-->
       </button>
-      <div class="t-input__wrap">
-        <div class="t-input" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="100">
           <!---->
@@ -21635,8 +21638,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
         <!--]-->
         <!--]-->
       </button>
-      <div class="t-input__wrap">
-        <div class="t-input t-align-center" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input t-align-center">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="200">
           <!---->
@@ -21661,8 +21664,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
         <!--]-->
         <!--]-->
       </button>
-      <div class="t-input__wrap">
-        <div class="t-input t-align-right" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input t-align-right">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="300">
           <!---->
@@ -21683,8 +21686,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
   <div style="width:20%;">
     <div class="t-input-number t-size-m t-input-number--normal" style="width:120px;">
       <!---->
-      <div class="t-input__wrap">
-        <div class="t-input" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="100">
           <!---->
@@ -21697,8 +21700,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
     </div>
     <div class="t-input-number t-size-m t-input-number--normal" style="width:120px;">
       <!---->
-      <div class="t-input__wrap">
-        <div class="t-input t-align-center" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input t-align-center">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="200">
           <!---->
@@ -21711,8 +21714,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/align.vue corre
     </div>
     <div class="t-input-number t-size-m t-input-number--normal" style="width:120px;">
       <!---->
-      <div class="t-input__wrap">
-        <div class="t-input t-align-right" unselectable="off">
+      <div class="t-input__wrap" unselectable="off">
+        <div class="t-input t-align-right">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value="300">
           <!---->
@@ -21737,8 +21740,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/auto-width.vue 
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center t-input--auto-width" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center t-input--auto-width">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3"><span class="t-input__input-pre">3</span>
         <!---->
@@ -21767,8 +21770,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/center.vue corr
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -21798,8 +21801,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/default.vue cor
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="2021">
         <!---->
@@ -21829,8 +21832,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/disabled.vue co
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-disabled t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-is-disabled t-align-center">
         <!---->
         <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value="3">
         <!---->
@@ -21860,8 +21863,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/empty.vue corre
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="输入" type="text" value>
         <!---->
@@ -21891,8 +21894,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/format.vue corr
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3%">
         <!---->
@@ -21922,8 +21925,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/left.vue correc
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -21947,8 +21950,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/normal.vue corr
 <div>
   <div class="t-input-number t-size-m t-input-number--normal" modelvalue="3">
     <!---->
-    <div class="t-input__wrap">
-      <div class="t-input" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -21972,8 +21975,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/size.vue correc
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -21998,8 +22001,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/size.vue correc
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -22024,8 +22027,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/size.vue correc
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
         <!---->
@@ -22062,8 +22065,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-disabled t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-disabled t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" disabled placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22099,8 +22102,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-align-center t-is-readonly" unselectable="on">
+            <div class="t-input__wrap" unselectable="on">
+              <div class="t-input t-align-center t-is-readonly">
                 <!---->
                 <!----><input class="t-input__inner" readonly placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22136,8 +22139,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22173,8 +22176,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-success t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-success t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22210,8 +22213,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-warning t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-warning t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22247,8 +22250,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-error t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-error t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22284,8 +22287,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22321,8 +22324,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-success t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-success t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22358,8 +22361,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-warning t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-warning t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22395,8 +22398,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/status.vue corr
               <!--]-->
               <!--]-->
             </button>
-            <div class="t-input__wrap">
-              <div class="t-input t-is-error t-align-center" unselectable="off">
+            <div class="t-input__wrap" unselectable="off">
+              <div class="t-input t-is-error t-align-center">
                 <!---->
                 <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3">
                 <!---->
@@ -22434,8 +22437,8 @@ exports[`ssr snapshot test renders ./examples/input-number/demos/step.vue correc
       <!--]-->
       <!--]-->
     </button>
-    <div class="t-input__wrap">
-      <div class="t-input t-align-center" unselectable="off">
+    <div class="t-input__wrap" unselectable="off">
+      <div class="t-input t-align-center">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value="3.20">
         <!---->
@@ -25416,8 +25419,8 @@ exports[`ssr snapshot test renders ./examples/message/demos/offset.vue correctly
 exports[`ssr snapshot test renders ./examples/message/demos/placement.vue correctly 1`] = `
 <div>
   <div class="t-message-offset">
-    <div class="t-input__wrap">
-      <div class="t-input" modelvalue>
+    <div class="t-input__wrap" modelvalue>
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入横向偏移量" type="text" value>
         <!---->
@@ -25426,8 +25429,8 @@ exports[`ssr snapshot test renders ./examples/message/demos/placement.vue correc
       </div>
       <!---->
     </div>
-    <div class="t-input__wrap">
-      <div class="t-input" modelvalue>
+    <div class="t-input__wrap" modelvalue>
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入纵向偏移量" type="text" value>
         <!---->
@@ -25737,8 +25740,8 @@ exports[`ssr snapshot test renders ./examples/notification/demos/operation.vue c
 exports[`ssr snapshot test renders ./examples/notification/demos/placement.vue correctly 1`] = `
 <div>
   <div class="t-message-offset">
-    <div class="t-input__wrap">
-      <div class="t-input" modelvalue>
+    <div class="t-input__wrap" modelvalue>
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入横向偏移量" type="text" value>
         <!---->
@@ -25747,8 +25750,8 @@ exports[`ssr snapshot test renders ./examples/notification/demos/placement.vue c
       </div>
       <!---->
     </div>
-    <div class="t-input__wrap">
-      <div class="t-input" modelvalue>
+    <div class="t-input__wrap" modelvalue>
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入纵向偏移量" type="text" value>
         <!---->
@@ -26051,8 +26054,8 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/jump.vue correctl
       </svg></div>
     <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input" modelvalue="1">
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input" unselectable="off">
+        <div class="t-input__wrap" unselectable="off">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="请输入" type="text" value="1">
             <!---->
@@ -28362,8 +28365,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/creatable.vue correct
         <!---->
         <!----><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="支持自定义创建" type="text" value>
             <!---->
@@ -28750,8 +28753,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/filterable.vue correc
         <!---->
         <!----><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="-请选择-" type="text" value>
             <!---->
@@ -28800,8 +28803,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/filterable.vue correc
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="-请选择-" type="text" value>
             <!---->
@@ -28893,8 +28896,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/group.vue correctly 1
         <!---->
         <!----><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="请选择" type="text" value>
             <!---->
@@ -28976,8 +28979,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/group.vue correctly 1
         <!---->
         <!----><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="请选择" type="text" value>
             <!---->
@@ -29355,6 +29358,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/panel.vue correctly 1
               <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入关键词搜索"></textarea>
                 <!---->
                 <!---->
+                <!---->
               </div>
             </div>
             <!--]-->
@@ -29597,8 +29601,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/remote-search.vue cor
         <!---->
         <!----><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="请选择" type="text" value>
             <!---->
@@ -29643,8 +29647,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/remote-search.vue cor
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap">
-          <div class="t-input t-is-readonly t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue>
+          <div class="t-input t-is-readonly">
             <!---->
             <!----><input class="t-input__inner" readonly placeholder="请输入搜索" type="text" value>
             <!---->
@@ -30010,8 +30014,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/autowidth-multi
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-input--suffix t-input--auto-width t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix t-input--suffix t-input--auto-width">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->+2<!--]--><!----></span>
@@ -30082,8 +30086,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/borderless-mult
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->+2<!--]--><!----></span>
@@ -30115,8 +30119,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/collapsed-items
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->+5<!--]--><!----></span>
@@ -30143,8 +30147,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/collapsed-items
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->更多(4)<!--]--><!----></span>
@@ -30171,8 +30175,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/collapsed-items
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -30254,8 +30258,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/custom-tag.vue 
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-is-readonly t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-readonly t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[--><!--[--><span class="displaySpan"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-control-platform" style=""><path fill="currentColor" d="M14.5 4.25L8.47.77a.94.94 0 00-.94 0L1.5 4.25v6.96c0 .33.18.64.47.81L8 15.5l6.03-3.48a.94.94 0 00.47-.81V4.25zM8 7.42L3 4.54l5-2.89 5 2.89-5 2.88zm.5.87l5-2.89v5.77l-5 2.89V8.29zm-1 0v5.77l-5-2.89V5.4l5 2.89z" fill-rule="evenodd" clip-rule="evenodd"></path></svg> tdesign-vue</span>
@@ -30285,8 +30289,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/custom-tag.vue 
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-is-readonly t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-readonly t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[-->
@@ -30334,8 +30338,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/excess-tags-dis
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-angular<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-mobile-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-mobile-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -30363,8 +30367,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/excess-tags-dis
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-tag-input t-tag-input--break-line">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line">
+      <div class="t-input t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-angular<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-mobile-vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->tdesign-mobile-react<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -30479,8 +30483,8 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/multiple.vue co
       </div>
     </div>
     <!--[-->
-    <div class="t-input__wrap">
-      <div class="t-input t-input--prefix t-input--suffix t-tag-input t-tag-input--break-line">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line">
+      <div class="t-input t-input--prefix t-input--suffix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -31537,8 +31541,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number.vue corr
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -31600,8 +31604,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number.vue corr
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -31627,8 +31631,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number.vue corr
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -31683,8 +31687,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number-vertical
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -31746,8 +31750,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number-vertical
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -31773,8 +31777,8 @@ exports[`ssr snapshot test renders ./examples/slider/demos/input-number-vertical
             <!--]-->
             <!--]-->
           </button>
-          <div class="t-input__wrap">
-            <div class="t-input" unselectable="off">
+          <div class="t-input__wrap" unselectable="off">
+            <div class="t-input">
               <!---->
               <!----><input class="t-input__inner" placeholder type="text" value="0">
               <!---->
@@ -34679,8 +34683,8 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                                     </div>
                                     <!--[-->
                                     <div class="t-form-controls">
-                                      <div class="t-input__wrap">
-                                        <div class="t-input t-input--suffix" modelvalue allowinput="0">
+                                      <div class="t-input__wrap" modelvalue allowinput="0">
+                                        <div class="t-input t-input--suffix">
                                           <!---->
                                           <!----><input class="t-input__inner" placeholder="请选择月份" type="text" value>
                                           <!---->
@@ -43238,8 +43242,8 @@ exports[`ssr snapshot test renders ./examples/tag/demos/theme.vue correctly 1`] 
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/auto-width.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-input--auto-width t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix t-input--auto-width">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43255,8 +43259,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/auto-width.vue cor
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/base.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43268,8 +43272,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/base.vue correctly
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43282,8 +43286,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/base.vue correctly
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43301,8 +43305,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/base.vue correctly
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/collapsed.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->+4<!--]--><!----></span>
@@ -43314,8 +43318,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/collapsed.vue corr
     </div>
     <!---->
   </div><!-- 方式一：使用渲染函数自定义折叠项 -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->更多(3)<!--]--><!----></span>
@@ -43327,8 +43331,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/collapsed.vue corr
     </div>
     <!---->
   </div><!-- 方式二：使用插槽自定义折叠项 -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43361,8 +43365,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/collapsed.vue corr
 exports[`ssr snapshot test renders ./examples/tag-input/demos/custom-tag.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
   <!-- 方式一：使用 tag 定义标签内部内容。也可以使用同名渲染函数 tag -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[--><!--[--><img src="https://tdesign.gtimg.com/site/avatar.jpg" style="max-width:20px;max-height:20px;border-radius:50%;"><span>  StudentA</span>
@@ -43382,8 +43386,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/custom-tag.vue cor
     </div>
     <!---->
   </div><br><br><!-- 方式二：使用 valueDisplay 定义全部内容。也可以使用同名渲染函数 valueDisplay -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43414,8 +43418,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/custom-tag.vue cor
 exports[`ssr snapshot test renders ./examples/tag-input/demos/excess.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
   <!-- 标签数量超出时，滚动显示 -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43428,8 +43432,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/excess.vue correct
     </div>
     <!---->
   </div><!-- 标签数量超出时，换行显示 -->
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input t-tag-input--break-line">
+  <div class="t-input__wrap t-tag-input t-tag-input--break-line">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43447,8 +43451,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/excess.vue correct
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/max.vue correctly 1`] = `
 <div style="width:100%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[-->
@@ -43465,8 +43469,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/max.vue correctly 
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/size.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-size-s t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-size-s t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-s" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-s" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43478,8 +43482,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/size.vue correctly
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43491,8 +43495,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/size.vue correctly
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-size-l t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-size-l t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-l" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-l" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43510,8 +43514,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/size.vue correctly
 exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:100%;">
   <div class="t-tdesign-demo__tag-input"><label>禁用状态：</label>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-disabled t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-disabled t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--disabled t-size-m" style=""><!----><!--[-->Vue<!--]--><!----></span><span class="t-tag t-tag--default t-tag--dark t-tag--disabled t-size-m" style=""><!----><!--[-->React<!--]--><!----></span><span class="t-tag t-tag--default t-tag--dark t-tag--disabled t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><!----></span>
@@ -43525,8 +43529,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correct
     </div>
   </div>
   <div class="t-tdesign-demo__tag-input"><label>只读状态：</label>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-readonly t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-readonly t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->Vue<!--]--><!----></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->React<!--]--><!----></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><!----></span>
@@ -43540,8 +43544,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correct
     </div>
   </div>
   <div class="t-tdesign-demo__tag-input"><label>成功状态：</label>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-success t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-success t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43555,8 +43559,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correct
     </div>
   </div>
   <div class="t-tdesign-demo__tag-input"><label>告警状态：</label>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-warning t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-warning t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43570,8 +43574,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correct
     </div>
   </div>
   <div class="t-tdesign-demo__tag-input"><label>错误状态：</label>
-    <div class="t-input__wrap">
-      <div class="t-input t-is-error t-input--prefix t-tag-input">
+    <div class="t-input__wrap t-tag-input">
+      <div class="t-input t-is-error t-input--prefix">
         <!---->
         <div class="t-input__prefix">
           <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43589,8 +43593,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/status.vue correct
 
 exports[`ssr snapshot test renders ./examples/tag-input/demos/theme.vue correctly 1`] = `
 <div class="tdesign-demo-block-column" style="width:80%;">
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--primary t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--primary t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--primary t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43602,8 +43606,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/theme.vue correctl
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--success t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--success t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43615,8 +43619,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/theme.vue correctl
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--warning t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--warning t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43628,8 +43632,8 @@ exports[`ssr snapshot test renders ./examples/tag-input/demos/theme.vue correctl
     </div>
     <!---->
   </div>
-  <div class="t-input__wrap">
-    <div class="t-input t-input--prefix t-tag-input">
+  <div class="t-input__wrap t-tag-input">
+    <div class="t-input t-input--prefix">
       <!---->
       <div class="t-input__prefix">
         <!--[--><span class="t-tag t-tag--danger t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Vue<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->React<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--danger t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->Miniprogram<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
@@ -43649,12 +43653,15 @@ exports[`ssr snapshot test renders ./examples/textarea/demos/base.vue correctly 
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入描述文案" name="description"></textarea>
     <!---->
     <!---->
+    <!---->
   </div>
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入文案，高度可自适应；autosize=true" name="description"></textarea>
     <!---->
     <!---->
+    <!---->
   </div>
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入文案，高度可自适应，最小3行，最大5行；autosize={minRows: 3, maxRows: 5}" name="description"></textarea>
+    <!---->
     <!---->
     <!---->
   </div>
@@ -43666,6 +43673,7 @@ exports[`ssr snapshot test renders ./examples/textarea/demos/events.vue correctl
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入"></textarea>
     <!---->
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -43674,8 +43682,10 @@ exports[`ssr snapshot test renders ./examples/textarea/demos/maxlength.vue corre
 <div>
   <div class="t-textarea"><textarea style="" class="t-textarea__inner t-resize-none narrow-scrollbar" placeholder="请输入描述文案，文本长度最多20，maxlength=20" maxlength="20"></textarea>
     <!----><span class="t-textarea__limit">0/20</span>
+    <!---->
   </div><br>
   <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar" placeholder="请输入描述文案，最多20字符（一个汉字占两个字符长度），maxcharacter=20"></textarea><span class="t-textarea__limit">0/20</span>
+    <!---->
     <!---->
   </div>
 </div>
@@ -43686,37 +43696,31 @@ exports[`ssr snapshot test renders ./examples/textarea/demos/type.vue correctly 
   <div class="t-textarea t-is-disabled"><textarea style="" class="t-textarea__inner t-is-disabled narrow-scrollbar" disabled>禁用状态</textarea>
     <!---->
     <!---->
+    <!---->
   </div>
   <div class="t-textarea t-is-readonly"><textarea style="" class="t-textarea__inner narrow-scrollbar" readonly>只读状态</textarea>
     <!---->
     <!---->
+    <!---->
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar">普通状态</textarea>
-      <!---->
-      <!---->
-    </div>
+  <div class="t-textarea"><textarea style="" class="t-textarea__inner narrow-scrollbar">普通状态</textarea>
+    <!---->
+    <!---->
     <div class="t-textarea__tips t-textarea__tips--normal">这是普通文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-success narrow-scrollbar">成功状态</textarea>
-      <!---->
-      <!---->
-    </div>
+  <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-success narrow-scrollbar">成功状态</textarea>
+    <!---->
+    <!---->
     <div class="t-textarea__tips t-textarea__tips--success">校验通过文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-warning narrow-scrollbar">警告状态</textarea>
-      <!---->
-      <!---->
-    </div>
+  <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-warning narrow-scrollbar">警告状态</textarea>
+    <!---->
+    <!---->
     <div class="t-textarea__tips t-textarea__tips--warning">校验不通过文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-error narrow-scrollbar">错误状态</textarea>
-      <!---->
-      <!---->
-    </div>
+  <div class="t-textarea"><textarea style="" class="t-textarea__inner t-is-error narrow-scrollbar">错误状态</textarea>
+    <!---->
+    <!---->
     <div class="t-textarea__tips t-textarea__tips--error">校验存在严重问题文本提示</div>
   </div>
 </div>
@@ -48976,8 +48980,8 @@ exports[`ssr snapshot test renders ./examples/tree/demos/expand-mutex.vue correc
 exports[`ssr snapshot test renders ./examples/tree/demos/filter.vue correctly 1`] = `
 <div class="tdesign-tree-base">
   <div class="t-addon t-addon--prepend"><span class="t-addon__prepend">filter:</span>
-    <div class="t-input__wrap">
-      <div class="t-input" modelvalue>
+    <div class="t-input__wrap" modelvalue>
+      <div class="t-input">
         <!---->
         <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
         <!---->
@@ -49701,8 +49705,8 @@ exports[`ssr snapshot test renders ./examples/tree/demos/operations.vue correctl
   </div>
   <div class="operations">
     <div class="t-addon t-addon--prepend"><span class="t-addon__prepend">filter:</span>
-      <div class="t-input__wrap">
-        <div class="t-input" modelvalue>
+      <div class="t-input__wrap" modelvalue>
+        <div class="t-input">
           <!---->
           <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
           <!---->
@@ -49980,8 +49984,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/base.vue correct
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择" type="text" value>
             <!---->
@@ -50059,8 +50063,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style="display:none;"><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->+1<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder type="text" value>
             <!---->
@@ -50135,8 +50139,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[-->更多...<!--]--><!----></span>
         <!--]-->
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder type="text" value>
             <!---->
@@ -50220,8 +50224,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/filterable.vue c
         <!----><span class="t-select__placeholder" style="display:none;">请选择 </span>
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span><span title="shenzhen" class="t-select__single">shenzhen</span>
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="shenzhen" type="text" value>
             <!---->
@@ -50283,8 +50287,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/lazy.vue correct
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="请选择" type="text" value>
             <!---->
@@ -50362,8 +50366,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/multiple.vue cor
         <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->guangzhou<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[-->shenzhen<!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style=""><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span>
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+2<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder type="text" value>
             <!---->
@@ -50440,8 +50444,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/prefix.vue corre
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="请输入" type="text" value>
             <!---->
@@ -50518,8 +50522,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/props.vue correc
         <!----><span class="t-select__placeholder" style="display:none;">请选择 </span>
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span><span title="shenzhen" class="t-select__single">shenzhen</span>
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="shenzhen" type="text" value>
             <!---->
@@ -50596,8 +50600,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue co
         <!----><span class="t-select__placeholder" style="display:none;">请选择 </span>
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span><span title="[object Object]" class="t-select__single">[object Object]</span>
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder="[object Object]" type="text" value>
             <!---->
@@ -50670,8 +50674,8 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue co
         <!--[-->
         <!--]--><span class="t-tag t-tag--default t-tag--dark t-size-m" style="display:none;"><!----><!--[-->+0<!--]--><!----></span>
         <!---->
-        <div class="t-input__wrap" style="display:none;">
-          <div class="t-input t-select__input" modelvalue>
+        <div class="t-input__wrap t-select__input" modelvalue style="display:none;">
+          <div class="t-input">
             <!---->
             <!----><input class="t-input__inner" placeholder type="text" value>
             <!---->

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -30262,13 +30262,15 @@ exports[`ssr snapshot test renders ./examples/select-input/demos/custom-tag.vue 
       <div class="t-input t-is-readonly t-input--prefix">
         <!---->
         <div class="t-input__prefix">
-          <!--[--><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[--><!--[--><span class="displaySpan"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-control-platform" style=""><path fill="currentColor" d="M14.5 4.25L8.47.77a.94.94 0 00-.94 0L1.5 4.25v6.96c0 .33.18.64.47.81L8 15.5l6.03-3.48a.94.94 0 00.47-.81V4.25zM8 7.42L3 4.54l5-2.89 5 2.89-5 2.88zm.5.87l5-2.89v5.77l-5 2.89V8.29zm-1 0v5.77l-5-2.89V5.4l5 2.89z" fill-rule="evenodd" clip-rule="evenodd"></path></svg> tdesign-vue</span>
+          <!--[--><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[--><!--[--><span class="displaySpan"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-control-platform" style=""><path fill="currentColor" d="M14.5 4.25L8.47.77a.94.94 0 00-.94 0L1.5 4.25v6.96c0 .33.18.64.47.81L8 15.5l6.03-3.48a.94.94 0 00.47-.81V4.25zM8 7.42L3 4.54l5-2.89 5 2.89-5 2.88zm.5.87l5-2.89v5.77l-5 2.89V8.29zm-1 0v5.77l-5-2.89V5.4l5 2.89z" fill-rule="evenodd" clip-rule="evenodd"></path></svg> tdesign-vue</span>
           <!--]-->
+          <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
+            <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
+          </svg></span><span class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m" style=""><!----><!--[--><!--[--><span class="displaySpan"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-control-platform" style=""><path fill="currentColor" d="M14.5 4.25L8.47.77a.94.94 0 00-.94 0L1.5 4.25v6.96c0 .33.18.64.47.81L8 15.5l6.03-3.48a.94.94 0 00.47-.81V4.25zM8 7.42L3 4.54l5-2.89 5 2.89-5 2.88zm.5.87l5-2.89v5.77l-5 2.89V8.29zm-1 0v5.77l-5-2.89V5.4l5 2.89z" fill-rule="evenodd" clip-rule="evenodd"></path></svg> tdesign-react</span>
           <!--]-->
-          <!----></span><span class="t-tag t-tag--default t-tag--dark t-size-m" style=""><!----><!--[--><!--[--><span class="displaySpan"><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-control-platform" style=""><path fill="currentColor" d="M14.5 4.25L8.47.77a.94.94 0 00-.94 0L1.5 4.25v6.96c0 .33.18.64.47.81L8 15.5l6.03-3.48a.94.94 0 00.47-.81V4.25zM8 7.42L3 4.54l5-2.89 5 2.89-5 2.88zm.5.87l5-2.89v5.77l-5 2.89V8.29zm-1 0v5.77l-5-2.89V5.4l5 2.89z" fill-rule="evenodd" clip-rule="evenodd"></path></svg> tdesign-react</span>
-          <!--]-->
-          <!--]-->
-          <!----></span>
+          <!--]--><svg fill="none" viewbox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close" style="">
+            <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
+          </svg></span>
           <!--]-->
         </div><input class="t-input__inner" readonly placeholder type="text" value>
         <!---->

--- a/test/unit/color-picker/__snapshots__/demo.test.js.snap
+++ b/test/unit/color-picker/__snapshots__/demo.test.js.snap
@@ -319,10 +319,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -352,10 +352,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -385,10 +385,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -930,10 +930,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
         >
           <div
             class="t-input__wrap"
+            modelvalue="#0052d9"
           >
             <div
               class="t-input t-input--prefix t-input--auto-width"
-              modelvalue="#0052d9"
             >
               <!---->
               <div
@@ -1229,10 +1229,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -1262,10 +1262,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -1295,10 +1295,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                           <!---->
                           <div
                             class="t-input__wrap"
+                            unselectable="off"
                           >
                             <div
                               class="t-input t-align-center"
-                              unselectable="off"
                             >
                               <!---->
                               <!---->
@@ -1840,10 +1840,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
         >
           <div
             class="t-input__wrap"
+            modelvalue="#0052d9"
           >
             <div
               class="t-input t-input--prefix t-input--auto-width"
-              modelvalue="#0052d9"
             >
               <!---->
               <div
@@ -1982,10 +1982,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                       <!---->
                       <div
                         class="t-input__wrap"
+                        unselectable="off"
                       >
                         <div
                           class="t-input"
-                          unselectable="off"
                         >
                           <!---->
                           <!---->
@@ -2204,11 +2204,11 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
                       >
                         <div
                           class="t-input__wrap"
+                          modelvalue="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)"
+                          title="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)"
                         >
                           <div
                             class="t-input t-align-center"
-                            modelvalue="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)"
-                            title="linear-gradient(45deg,rgb(79, 172, 254) 0%,rgb(0, 242, 254) 100%)"
                           >
                             <!---->
                             <!---->
@@ -2748,10 +2748,10 @@ exports[`ColorPicker ColorPicker colorModeVue demo works fine 1`] = `
         >
           <div
             class="t-input__wrap"
+            modelvalue="linear-gradient(45deg, #4facfe 0%, #00f2fe 100%)"
           >
             <div
               class="t-input t-input--prefix t-input--auto-width"
-              modelvalue="linear-gradient(45deg, #4facfe 0%, #00f2fe 100%)"
             >
               <!---->
               <div
@@ -3085,10 +3085,10 @@ exports[`ColorPicker ColorPicker enableAlphaVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -3118,10 +3118,10 @@ exports[`ColorPicker ColorPicker enableAlphaVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -3151,10 +3151,10 @@ exports[`ColorPicker ColorPicker enableAlphaVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -3184,10 +3184,10 @@ exports[`ColorPicker ColorPicker enableAlphaVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -4002,10 +4002,10 @@ exports[`ColorPicker ColorPicker panelVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -4035,10 +4035,10 @@ exports[`ColorPicker ColorPicker panelVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -4068,10 +4068,10 @@ exports[`ColorPicker ColorPicker panelVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -4890,10 +4890,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -4923,10 +4923,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -4956,10 +4956,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -5904,10 +5904,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -5937,10 +5937,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -5970,10 +5970,10 @@ exports[`ColorPicker ColorPicker recentColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -6537,10 +6537,10 @@ exports[`ColorPicker ColorPicker statusDisabledVue demo works fine 1`] = `
       >
         <div
           class="t-input__wrap"
+          modelvalue="#0052d9"
         >
           <div
             class="t-input t-is-disabled t-input--prefix t-input--auto-width"
-            modelvalue="#0052d9"
           >
             <!---->
             <div
@@ -6863,10 +6863,10 @@ exports[`ColorPicker ColorPicker statusReadonlyVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-is-disabled t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -6897,10 +6897,10 @@ exports[`ColorPicker ColorPicker statusReadonlyVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-is-disabled t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -6931,10 +6931,10 @@ exports[`ColorPicker ColorPicker statusReadonlyVue demo works fine 1`] = `
                 <!---->
                 <div
                   class="t-input__wrap"
+                  unselectable="off"
                 >
                   <div
                     class="t-input t-is-disabled t-align-center"
-                    unselectable="off"
                   >
                     <!---->
                     <!---->
@@ -7754,10 +7754,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -7787,10 +7787,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -7820,10 +7820,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -8216,10 +8216,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -8249,10 +8249,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -8282,10 +8282,10 @@ exports[`ColorPicker ColorPicker swatchColorVue demo works fine 1`] = `
                   <!---->
                   <div
                     class="t-input__wrap"
+                    unselectable="off"
                   >
                     <div
                       class="t-input t-align-center"
-                      unselectable="off"
                     >
                       <!---->
                       <!---->
@@ -8627,10 +8627,10 @@ exports[`ColorPicker ColorPicker triggerVue demo works fine 1`] = `
                         <!---->
                         <div
                           class="t-input__wrap"
+                          unselectable="off"
                         >
                           <div
                             class="t-input t-align-center"
-                            unselectable="off"
                           >
                             <!---->
                             <!---->
@@ -8660,10 +8660,10 @@ exports[`ColorPicker ColorPicker triggerVue demo works fine 1`] = `
                         <!---->
                         <div
                           class="t-input__wrap"
+                          unselectable="off"
                         >
                           <div
                             class="t-input t-align-center"
-                            unselectable="off"
                           >
                             <!---->
                             <!---->
@@ -8693,10 +8693,10 @@ exports[`ColorPicker ColorPicker triggerVue demo works fine 1`] = `
                         <!---->
                         <div
                           class="t-input__wrap"
+                          unselectable="off"
                         >
                           <div
                             class="t-input t-align-center"
-                            unselectable="off"
                           >
                             <!---->
                             <!---->
@@ -9238,10 +9238,10 @@ exports[`ColorPicker ColorPicker triggerVue demo works fine 1`] = `
       >
         <div
           class="t-input__wrap"
+          modelvalue="#0052d9"
         >
           <div
             class="t-input t-input--prefix t-input--auto-width"
-            modelvalue="#0052d9"
           >
             <!---->
             <div

--- a/test/unit/comment/__snapshots__/demo.test.js.snap
+++ b/test/unit/comment/__snapshots__/demo.test.js.snap
@@ -583,6 +583,7 @@ exports[`Comment Comment replyFormVue demo works fine 1`] = `
             />
             <!---->
             <!---->
+            <!---->
           </div>
           <button
             class="t-button t-size-m t-button--variant-base t-button--theme-primary form-submit"

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -2112,12 +2112,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -3713,12 +3714,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -4067,12 +4069,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -4706,12 +4709,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -5031,12 +5035,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -5612,12 +5617,13 @@ exports[`ConfigProvider ConfigProvider datePickerVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -6089,11 +6095,11 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
+            style="width: 400px;"
           >
             <div
               class="t-input"
-              modelvalue=""
-              style="width: 400px;"
             >
               <!---->
               <!---->
@@ -6137,11 +6143,11 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
+            style="width: 400px;"
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
-              style="width: 400px;"
             >
               <!---->
               <!---->
@@ -7439,12 +7445,12 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
           style="display: none;"
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->
@@ -7604,12 +7610,12 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
           style="display: none;"
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->
@@ -7919,11 +7925,11 @@ exports[`ConfigProvider ConfigProvider othersVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->
@@ -9456,10 +9462,10 @@ exports[`ConfigProvider ConfigProvider paginationVue demo works fine 1`] = `
       <!---->
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input"
-          unselectable="off"
         >
           <!---->
           <!---->

--- a/test/unit/date-picker/__snapshots__/demo.test.js.snap
+++ b/test/unit/date-picker/__snapshots__/demo.test.js.snap
@@ -799,12 +799,13 @@ exports[`DatePicker DatePicker baseVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue="2021-11-10"
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue="2021-11-10"
           >
             <!---->
             <!---->
@@ -1640,12 +1641,13 @@ exports[`DatePicker DatePicker customIconVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--prefix t-input--suffix"
-            modelvalue=""
           >
             <span
               class="t-input__prefix t-input__prefix-icon"
@@ -3304,12 +3306,13 @@ exports[`DatePicker DatePicker datePresetsAltVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue="2020-12-28 至 2020-12-28"
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue="2020-12-28 至 2020-12-28"
             >
               <!---->
               <!---->
@@ -4165,12 +4168,13 @@ exports[`DatePicker DatePicker datePresetsAltVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue="2020-12-28"
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue="2020-12-28"
             >
               <!---->
               <!---->
@@ -5800,12 +5804,13 @@ exports[`DatePicker DatePicker datePresetsTimeVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -7424,12 +7429,13 @@ exports[`DatePicker DatePicker datePresetsVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -9030,12 +9036,13 @@ exports[`DatePicker DatePicker dateRangeVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -10670,12 +10677,13 @@ exports[`DatePicker DatePicker dateRangeVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -11554,12 +11562,13 @@ exports[`DatePicker DatePicker dateTimeVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue="2021-05-01 11:30:20"
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue="2021-05-01 11:30:20"
           >
             <!---->
             <!---->
@@ -12401,12 +12410,13 @@ exports[`DatePicker DatePicker disableDateVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue=""
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -13239,12 +13249,13 @@ exports[`DatePicker DatePicker disableDateVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue=""
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -14077,12 +14088,13 @@ exports[`DatePicker DatePicker disableDateVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue=""
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -15681,12 +15693,13 @@ exports[`DatePicker DatePicker disableDateVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue=""
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -16519,12 +16532,13 @@ exports[`DatePicker DatePicker disableDateVue demo works fine 1`] = `
           class="t-form-controls"
         >
           <div
+            allowinput="0"
             class="t-input__wrap"
+            input="function () { [native code] }"
+            modelvalue=""
           >
             <div
-              allowinput="0"
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -17360,12 +17374,13 @@ exports[`DatePicker DatePicker firstDayOfWeekVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -17720,12 +17735,13 @@ exports[`DatePicker DatePicker monthVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->
@@ -18051,12 +18067,13 @@ exports[`DatePicker DatePicker yearVue demo works fine 1`] = `
         class="t-form-controls"
       >
         <div
+          allowinput="0"
           class="t-input__wrap"
+          input="function () { [native code] }"
+          modelvalue=""
         >
           <div
-            allowinput="0"
             class="t-input t-input--suffix"
-            modelvalue=""
           >
             <!---->
             <!---->

--- a/test/unit/date-picker/__snapshots__/index.test.js.snap
+++ b/test/unit/date-picker/__snapshots__/index.test.js.snap
@@ -284,12 +284,13 @@ exports[`DatePicker :mode 1`] = `
       class="t-form-controls"
     >
       <div
+        allowinput="0"
         class="t-input__wrap"
+        input="function () { [native code] }"
+        modelvalue=""
       >
         <div
-          allowinput="0"
           class="t-input t-input--suffix"
-          modelvalue=""
         >
           <!---->
           <!---->
@@ -924,12 +925,13 @@ exports[`DatePicker :range 1`] = `
       class="t-form-controls"
     >
       <div
+        allowinput="0"
         class="t-input__wrap"
+        input="function () { [native code] }"
+        modelvalue="2018-08-01 至 2028-04-01"
       >
         <div
-          allowinput="0"
           class="t-input t-input--suffix"
-          modelvalue="2018-08-01 至 2028-04-01"
         >
           <!---->
           <!---->
@@ -1279,12 +1281,13 @@ exports[`DatePicker :value 1`] = `
       class="t-form-controls"
     >
       <div
+        allowinput="0"
         class="t-input__wrap"
+        input="function () { [native code] }"
+        modelvalue="1998-11-11"
       >
         <div
-          allowinput="0"
           class="t-input t-input--suffix"
-          modelvalue="1998-11-11"
         >
           <!---->
           <!---->

--- a/test/unit/form/__snapshots__/demo.test.js.snap
+++ b/test/unit/form/__snapshots__/demo.test.js.snap
@@ -110,10 +110,10 @@ exports[`Form Form alignVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -157,10 +157,10 @@ exports[`Form Form alignVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -276,10 +276,10 @@ exports[`Form Form baseVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -323,10 +323,10 @@ exports[`Form Form baseVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -645,10 +645,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -696,10 +696,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -747,10 +747,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -815,10 +815,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1210,10 +1210,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1257,10 +1257,10 @@ exports[`Form Form clearValidateVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1394,10 +1394,10 @@ exports[`Form Form customValidatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1441,10 +1441,10 @@ exports[`Form Form customValidatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1513,10 +1513,10 @@ exports[`Form Form customValidatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -1675,10 +1675,10 @@ exports[`Form Form disabledVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-is-disabled"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -2123,12 +2123,12 @@ exports[`Form Form disabledVue demo works fine 1`] = `
                 </span>
                 <!---->
                 <div
-                  class="t-input__wrap"
+                  class="t-input__wrap t-select__input"
+                  modelvalue=""
                   style="display: none;"
                 >
                   <div
-                    class="t-input t-is-disabled t-select__input"
-                    modelvalue=""
+                    class="t-input t-is-disabled"
                   >
                     <!---->
                     <!---->
@@ -3116,12 +3116,13 @@ exports[`Form Form disabledVue demo works fine 1`] = `
                 class="t-form-controls"
               >
                 <div
+                  allowinput="0"
                   class="t-input__wrap"
+                  input="function () { [native code] }"
+                  modelvalue=""
                 >
                   <div
-                    allowinput="0"
                     class="t-input t-is-disabled t-input--suffix"
-                    modelvalue=""
                   >
                     <!---->
                     <!---->
@@ -3186,13 +3187,14 @@ exports[`Form Form disabledVue demo works fine 1`] = `
           
           <div
             class="t-textarea t-is-disabled"
+            clearable=""
           >
             <textarea
               class="t-textarea__inner t-is-disabled narrow-scrollbar"
-              clearable=""
               disabled=""
               placeholder="简单描述自己的经历"
             />
+            <!---->
             <!---->
             <!---->
           </div>
@@ -3446,10 +3448,10 @@ exports[`Form Form disabledVue demo works fine 1`] = `
             <!---->
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-disabled"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -3821,10 +3823,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -3872,10 +3874,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -3923,10 +3925,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -3991,10 +3993,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -4366,10 +4368,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -4413,10 +4415,10 @@ exports[`Form Form errorMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -4595,10 +4597,10 @@ exports[`Form Form layoutVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -4641,10 +4643,10 @@ exports[`Form Form layoutVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -4712,10 +4714,10 @@ exports[`Form Form loginVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--prefix"
-              modelvalue=""
             >
               <span
                 class="t-input__prefix t-input__prefix-icon"
@@ -4767,10 +4769,10 @@ exports[`Form Form loginVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--prefix t-input--suffix"
-              modelvalue=""
             >
               <span
                 class="t-input__prefix t-input__prefix-icon"
@@ -4981,10 +4983,10 @@ exports[`Form Form resetVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue="TDesign"
           >
             <div
               class="t-input"
-              modelvalue="TDesign"
             >
               <!---->
               <!---->
@@ -5028,10 +5030,10 @@ exports[`Form Form resetVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue="12345678910"
           >
             <div
               class="t-input"
-              modelvalue="12345678910"
             >
               <!---->
               <!---->
@@ -5293,10 +5295,10 @@ exports[`Form Form sizeVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue="TDesign"
           >
             <div
               class="t-input"
-              modelvalue="TDesign"
             >
               <!---->
               <!---->
@@ -5340,10 +5342,10 @@ exports[`Form Form sizeVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue="12345678910"
           >
             <div
               class="t-input"
-              modelvalue="12345678910"
             >
               <!---->
               <!---->
@@ -5853,10 +5855,10 @@ exports[`Form Form validateComplicatedDataVue demo works fine 1`] = `
                   
                   <div
                     class="t-input__wrap"
+                    modelvalue="StudentA"
                   >
                     <div
                       class="t-input"
-                      modelvalue="StudentA"
                     >
                       <!---->
                       <!---->
@@ -6221,10 +6223,10 @@ exports[`Form Form validateComplicatedDataVue demo works fine 1`] = `
                   
                   <div
                     class="t-input__wrap"
+                    modelvalue="StudentB"
                   >
                     <div
                       class="t-input"
-                      modelvalue="StudentB"
                     >
                       <!---->
                       <!---->
@@ -6699,10 +6701,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -6750,10 +6752,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -6801,10 +6803,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -6869,10 +6871,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7264,10 +7266,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7311,10 +7313,10 @@ exports[`Form Form validateMessageVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7502,10 +7504,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7549,10 +7551,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7596,10 +7598,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7643,10 +7645,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7690,10 +7692,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7737,10 +7739,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7784,10 +7786,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -7866,10 +7868,10 @@ exports[`Form Form validatorStatusVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -8063,10 +8065,10 @@ exports[`Form Form validatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -8164,10 +8166,10 @@ exports[`Form Form validatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input t-input--suffix"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -8232,10 +8234,10 @@ exports[`Form Form validatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -8626,10 +8628,10 @@ exports[`Form Form validatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->
@@ -8673,10 +8675,10 @@ exports[`Form Form validatorVue demo works fine 1`] = `
           
           <div
             class="t-input__wrap"
+            modelvalue=""
           >
             <div
               class="t-input"
-              modelvalue=""
             >
               <!---->
               <!---->

--- a/test/unit/input-number/__snapshots__/demo.test.js.snap
+++ b/test/unit/input-number/__snapshots__/demo.test.js.snap
@@ -37,10 +37,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       </button>
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -110,10 +110,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       </button>
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input t-align-center"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -183,10 +183,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       </button>
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input t-align-right"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -237,10 +237,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       <!---->
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -264,10 +264,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       <!---->
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input t-align-center"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -291,10 +291,10 @@ exports[`InputNumber InputNumber alignVue demo works fine 1`] = `
       <!---->
       <div
         class="t-input__wrap"
+        unselectable="off"
       >
         <div
           class="t-input t-align-right"
-          unselectable="off"
         >
           <!---->
           <!---->
@@ -347,10 +347,10 @@ exports[`InputNumber InputNumber autoWidthVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center t-input--auto-width"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -429,10 +429,10 @@ exports[`InputNumber InputNumber centerVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -506,10 +506,10 @@ exports[`InputNumber InputNumber defaultVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -584,10 +584,10 @@ exports[`InputNumber InputNumber disabledVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-is-disabled t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -662,10 +662,10 @@ exports[`InputNumber InputNumber emptyVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -740,10 +740,10 @@ exports[`InputNumber InputNumber formatVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -818,10 +818,10 @@ exports[`InputNumber InputNumber leftVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -873,10 +873,10 @@ exports[`InputNumber InputNumber normalVue demo works fine 1`] = `
     <!---->
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -927,10 +927,10 @@ exports[`InputNumber InputNumber sizeVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -1000,10 +1000,10 @@ exports[`InputNumber InputNumber sizeVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -1072,10 +1072,10 @@ exports[`InputNumber InputNumber sizeVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->
@@ -1174,10 +1174,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-disabled t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1275,10 +1275,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="on"
             >
               <div
                 class="t-input t-align-center t-is-readonly"
-                unselectable="on"
               >
                 <!---->
                 <!---->
@@ -1376,10 +1376,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1476,10 +1476,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-success t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1576,10 +1576,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-warning t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1676,10 +1676,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-error t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1776,10 +1776,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1880,10 +1880,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-success t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -1984,10 +1984,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-warning t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -2088,10 +2088,10 @@ exports[`InputNumber InputNumber statusVue demo works fine 1`] = `
             </button>
             <div
               class="t-input__wrap"
+              unselectable="off"
             >
               <div
                 class="t-input t-is-error t-align-center"
-                unselectable="off"
               >
                 <!---->
                 <!---->
@@ -2178,10 +2178,10 @@ exports[`InputNumber InputNumber stepVue demo works fine 1`] = `
     </button>
     <div
       class="t-input__wrap"
+      unselectable="off"
     >
       <div
         class="t-input t-align-center"
-        unselectable="off"
       >
         <!---->
         <!---->

--- a/test/unit/input-number/__snapshots__/index.test.js.snap
+++ b/test/unit/input-number/__snapshots__/index.test.js.snap
@@ -30,10 +30,10 @@ exports[`InputNumber :props :defaultValue, default value 6 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -105,10 +105,10 @@ exports[`InputNumber :props :disabled, function can not be call 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-is-disabled t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -181,10 +181,10 @@ exports[`InputNumber :props :format, with 6% 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -256,10 +256,10 @@ exports[`InputNumber :props :max, value 6 < max 10 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -331,10 +331,10 @@ exports[`InputNumber :props :max, value 16 > max 10 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-is-error t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -406,10 +406,10 @@ exports[`InputNumber :props :min, value -1 < min 1 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-is-error t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -481,10 +481,10 @@ exports[`InputNumber :props :min, value 6 > min 1 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -556,10 +556,10 @@ exports[`InputNumber :props :mode, without class t-is-controls-right 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -631,10 +631,10 @@ exports[`InputNumber :props :mode:column, with class t-is-controls-right 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -706,10 +706,10 @@ exports[`InputNumber :props :mode:row, without class t-is-controls-right 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -780,10 +780,10 @@ exports[`InputNumber :props :size:large, with class t-size-l 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -854,10 +854,10 @@ exports[`InputNumber :props :size:medium, with class t-size-m 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -928,10 +928,10 @@ exports[`InputNumber :props :size:small, with class t-size-s 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -1002,10 +1002,10 @@ exports[`InputNumber :props :step, 2 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -1077,10 +1077,10 @@ exports[`InputNumber :props :value, 6 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->
@@ -1152,10 +1152,10 @@ exports[`InputNumber :props class, with class t-input-number 1`] = `
   </button>
   <div
     class="t-input__wrap"
+    unselectable="off"
   >
     <div
       class="t-input t-align-center"
-      unselectable="off"
     >
       <!---->
       <!---->

--- a/test/unit/input/__snapshots__/demo.test.js.snap
+++ b/test/unit/input/__snapshots__/demo.test.js.snap
@@ -221,10 +221,10 @@ exports[`Input Input baseVue demo works fine 1`] = `
   </div>
   <div
     class="t-input__wrap"
+    modelvalue="有默认值"
   >
     <div
       class="t-input"
-      modelvalue="有默认值"
     >
       <!---->
       <!---->
@@ -276,10 +276,10 @@ exports[`Input Input clearableVue demo works fine 1`] = `
 >
   <div
     class="t-input__wrap"
+    modelvalue="Hello TDesign"
   >
     <div
       class="t-input"
-      modelvalue="Hello TDesign"
     >
       <!---->
       <!---->
@@ -331,10 +331,10 @@ exports[`Input Input formatVue demo works fine 1`] = `
 >
   <div
     class="t-input__wrap"
+    modelvalue=""
   >
     <div
       class="t-input"
-      modelvalue=""
     >
       <!---->
       <!---->
@@ -364,10 +364,10 @@ exports[`Input Input groupVue demo works fine 1`] = `
       
       <div
         class="t-input__wrap"
+        style="width: 100px;"
       >
         <div
           class="t-input"
-          style="width: 100px;"
         >
           <!---->
           <!---->
@@ -503,10 +503,10 @@ exports[`Input Input groupVue demo works fine 1`] = `
       
       <div
         class="t-input__wrap"
+        style="width: 100px;"
       >
         <div
           class="t-input"
-          style="width: 100px;"
         >
           <!---->
           <!---->
@@ -528,10 +528,10 @@ exports[`Input Input groupVue demo works fine 1`] = `
       </span>
       <div
         class="t-input__wrap"
+        style="width: 100px;"
       >
         <div
           class="t-input"
-          style="width: 100px;"
         >
           <!---->
           <!---->
@@ -548,10 +548,10 @@ exports[`Input Input groupVue demo works fine 1`] = `
       </div>
       <div
         class="t-input__wrap"
+        style="width: 100px;"
       >
         <div
           class="t-input"
-          style="width: 100px;"
         >
           <!---->
           <!---->
@@ -568,10 +568,10 @@ exports[`Input Input groupVue demo works fine 1`] = `
       </div>
       <div
         class="t-input__wrap"
+        style="width: 100px;"
       >
         <div
           class="t-input"
-          style="width: 100px;"
         >
           <!---->
           <!---->
@@ -599,10 +599,10 @@ exports[`Input Input maxLengthCountVue demo works fine 1`] = `
 >
   <div
     class="t-input__wrap"
+    modelvalue=""
   >
     <div
       class="t-input t-input--suffix"
-      modelvalue=""
     >
       <!---->
       <!---->
@@ -1056,6 +1056,7 @@ exports[`Input Input textareaVue demo works fine 1`] = `
       class="t-textarea__inner narrow-scrollbar"
       placeholder="请输入内容"
     />
+    <!---->
     <!---->
     <!---->
   </div>

--- a/test/unit/input/__snapshots__/index.test.js.snap
+++ b/test/unit/input/__snapshots__/index.test.js.snap
@@ -3,10 +3,10 @@
 exports[`Input $attrs input attrs should pass to input element 1`] = `
 <div
   class="t-input__wrap"
+  maxlength="20"
 >
   <div
     class="t-input t-input--suffix"
-    maxlength="20"
   >
     <!---->
     <!---->

--- a/test/unit/message/__snapshots__/demo.test.js.snap
+++ b/test/unit/message/__snapshots__/demo.test.js.snap
@@ -454,10 +454,10 @@ exports[`Message Message placementVue demo works fine 1`] = `
   >
     <div
       class="t-input__wrap"
+      modelvalue=""
     >
       <div
         class="t-input"
-        modelvalue=""
       >
         <!---->
         <!---->
@@ -474,10 +474,10 @@ exports[`Message Message placementVue demo works fine 1`] = `
     </div>
     <div
       class="t-input__wrap"
+      modelvalue=""
     >
       <div
         class="t-input"
-        modelvalue=""
       >
         <!---->
         <!---->

--- a/test/unit/notification/__snapshots__/demo.test.js.snap
+++ b/test/unit/notification/__snapshots__/demo.test.js.snap
@@ -1092,10 +1092,10 @@ exports[`Notification Notification placementVue demo works fine 1`] = `
   >
     <div
       class="t-input__wrap"
+      modelvalue=""
     >
       <div
         class="t-input"
-        modelvalue=""
       >
         <!---->
         <!---->
@@ -1112,10 +1112,10 @@ exports[`Notification Notification placementVue demo works fine 1`] = `
     </div>
     <div
       class="t-input__wrap"
+      modelvalue=""
     >
       <div
         class="t-input"
-        modelvalue=""
       >
         <!---->
         <!---->

--- a/test/unit/pagination/__snapshots__/demo.test.js.snap
+++ b/test/unit/pagination/__snapshots__/demo.test.js.snap
@@ -678,10 +678,10 @@ exports[`Pagination Pagination jumpVue demo works fine 1`] = `
         <!---->
         <div
           class="t-input__wrap"
+          unselectable="off"
         >
           <div
             class="t-input"
-            unselectable="off"
           >
             <!---->
             <!---->

--- a/test/unit/select-input/__snapshots__/demo.test.js.snap
+++ b/test/unit/select-input/__snapshots__/demo.test.js.snap
@@ -268,10 +268,10 @@ exports[`SelectInput SelectInput autowidthMultipleVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-input--suffix t-input--auto-width t-tag-input"
+        class="t-input t-input--prefix t-input--suffix t-input--auto-width"
       >
         <!---->
         <div
@@ -622,10 +622,10 @@ exports[`SelectInput SelectInput borderlessMultipleVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-tag-input"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -933,10 +933,10 @@ exports[`SelectInput SelectInput collapsedItemsVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-tag-input"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -1160,10 +1160,10 @@ exports[`SelectInput SelectInput collapsedItemsVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-tag-input"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -1409,10 +1409,10 @@ exports[`SelectInput SelectInput collapsedItemsVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-tag-input"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -1692,10 +1692,10 @@ exports[`SelectInput SelectInput customTagVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-readonly t-input--prefix t-tag-input"
+        class="t-input t-is-readonly t-input--prefix"
       >
         <!---->
         <div
@@ -1805,10 +1805,10 @@ exports[`SelectInput SelectInput customTagVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-readonly t-input--prefix t-tag-input"
+        class="t-input t-is-readonly t-input--prefix"
       >
         <!---->
         <div
@@ -2142,10 +2142,10 @@ exports[`SelectInput SelectInput excessTagsDisplayTypeVue demo works fine 1`] = 
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-input--prefix t-tag-input"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -2468,10 +2468,10 @@ exports[`SelectInput SelectInput excessTagsDisplayTypeVue demo works fine 1`] = 
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input t-tag-input--break-line"
     >
       <div
-        class="t-input t-input--prefix t-tag-input t-tag-input--break-line"
+        class="t-input t-input--prefix"
       >
         <!---->
         <div
@@ -3085,10 +3085,10 @@ exports[`SelectInput SelectInput multipleVue demo works fine 1`] = `
     </transition-stub>
     
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input t-tag-input--break-line"
     >
       <div
-        class="t-input t-input--prefix t-input--suffix t-tag-input t-tag-input--break-line"
+        class="t-input t-input--prefix t-input--suffix"
       >
         <!---->
         <div

--- a/test/unit/select-input/__snapshots__/demo.test.js.snap
+++ b/test/unit/select-input/__snapshots__/demo.test.js.snap
@@ -1703,7 +1703,7 @@ exports[`SelectInput SelectInput customTagVue demo works fine 1`] = `
         >
           
           <span
-            class="t-tag t-tag--default t-tag--dark t-size-m"
+            class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m"
           >
             <!---->
             
@@ -1729,10 +1729,22 @@ exports[`SelectInput SelectInput customTagVue demo works fine 1`] = `
             </span>
             
             
-            <!---->
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
           </span>
           <span
-            class="t-tag t-tag--default t-tag--dark t-size-m"
+            class="t-tag t-tag--default t-tag--dark t-tag--close t-size-m"
           >
             <!---->
             
@@ -1758,7 +1770,19 @@ exports[`SelectInput SelectInput customTagVue demo works fine 1`] = `
             </span>
             
             
-            <!---->
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
           </span>
           
         </div>

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -1160,11 +1160,11 @@ exports[`Select Select creatableVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -3309,11 +3309,11 @@ exports[`Select Select filterableVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -3509,11 +3509,11 @@ exports[`Select Select filterableVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -3748,11 +3748,11 @@ exports[`Select Select groupVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -3990,11 +3990,11 @@ exports[`Select Select groupVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -5833,6 +5833,7 @@ exports[`Select Select panelVue demo works fine 1`] = `
                   />
                   <!---->
                   <!---->
+                  <!---->
                 </div>
               </div>
               
@@ -6571,11 +6572,11 @@ exports[`Select Select remoteSearchVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->
@@ -6702,11 +6703,11 @@ exports[`Select Select remoteSearchVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
         >
           <div
-            class="t-input t-is-readonly t-select__input"
-            modelvalue=""
+            class="t-input t-is-readonly"
           >
             <!---->
             <!---->

--- a/test/unit/slider/__snapshots__/demo.test.js.snap
+++ b/test/unit/slider/__snapshots__/demo.test.js.snap
@@ -456,10 +456,10 @@ exports[`Slider Slider inputNumberVerticalVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->
@@ -636,10 +636,10 @@ exports[`Slider Slider inputNumberVerticalVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->
@@ -711,10 +711,10 @@ exports[`Slider Slider inputNumberVerticalVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->
@@ -860,10 +860,10 @@ exports[`Slider Slider inputNumberVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->
@@ -1039,10 +1039,10 @@ exports[`Slider Slider inputNumberVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->
@@ -1114,10 +1114,10 @@ exports[`Slider Slider inputNumberVue demo works fine 1`] = `
           </button>
           <div
             class="t-input__wrap"
+            unselectable="off"
           >
             <div
               class="t-input"
-              unselectable="off"
             >
               <!---->
               <!---->

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -4162,12 +4162,13 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
                                         class="t-form-controls"
                                       >
                                         <div
+                                          allowinput="0"
                                           class="t-input__wrap"
+                                          input="function () { [native code] }"
+                                          modelvalue=""
                                         >
                                           <div
-                                            allowinput="0"
                                             class="t-input t-input--suffix"
-                                            modelvalue=""
                                           >
                                             <!---->
                                             <!---->

--- a/test/unit/tag-input/__snapshots__/demo.test.js.snap
+++ b/test/unit/tag-input/__snapshots__/demo.test.js.snap
@@ -6,10 +6,10 @@ exports[`TagInput TagInput autoWidthVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-input--auto-width t-tag-input"
+      class="t-input t-input--prefix t-input--auto-width"
     >
       <!---->
       <div
@@ -84,10 +84,10 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -150,10 +150,10 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -221,10 +221,10 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -300,10 +300,10 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -356,10 +356,10 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
   <!-- 方式一：使用渲染函数自定义折叠项 -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -434,10 +434,10 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
   <!-- 方式二：使用插槽自定义折叠项 -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -585,10 +585,10 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
 >
   <!-- 方式一：使用 tag 定义标签内部内容。也可以使用同名渲染函数 tag -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -680,10 +680,10 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
   <br />
   <!-- 方式二：使用 valueDisplay 定义全部内容。也可以使用同名渲染函数 valueDisplay -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -801,10 +801,10 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
 >
   <!-- 标签数量超出时，滚动显示 -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -873,10 +873,10 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
   </div>
   <!-- 标签数量超出时，换行显示 -->
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input t-tag-input--break-line"
   >
     <div
-      class="t-input t-input--prefix t-tag-input t-tag-input--break-line"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -951,10 +951,10 @@ exports[`TagInput TagInput maxVue demo works fine 1`] = `
   style="width: 100%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -983,10 +983,10 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-size-s t-input--prefix t-tag-input"
+      class="t-input t-size-s t-input--prefix"
     >
       <!---->
       <div
@@ -1049,10 +1049,10 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -1115,10 +1115,10 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-size-l t-input--prefix t-tag-input"
+      class="t-input t-size-l t-input--prefix"
     >
       <!---->
       <div
@@ -1195,10 +1195,10 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
       禁用状态：
     </label>
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-disabled t-input--prefix t-tag-input"
+        class="t-input t-is-disabled t-input--prefix"
       >
         <!---->
         <div
@@ -1254,10 +1254,10 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
       只读状态：
     </label>
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-readonly t-input--prefix t-tag-input"
+        class="t-input t-is-readonly t-input--prefix"
       >
         <!---->
         <div
@@ -1317,10 +1317,10 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
       成功状态：
     </label>
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-success t-input--prefix t-tag-input"
+        class="t-input t-is-success t-input--prefix"
       >
         <!---->
         <div
@@ -1415,10 +1415,10 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
       告警状态：
     </label>
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-warning t-input--prefix t-tag-input"
+        class="t-input t-is-warning t-input--prefix"
       >
         <!---->
         <div
@@ -1513,10 +1513,10 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
       错误状态：
     </label>
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
-        class="t-input t-is-error t-input--prefix t-tag-input"
+        class="t-input t-is-error t-input--prefix"
       >
         <!---->
         <div
@@ -1613,10 +1613,10 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -1700,10 +1700,10 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -1787,10 +1787,10 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div
@@ -1874,10 +1874,10 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
     <!---->
   </div>
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
-      class="t-input t-input--prefix t-tag-input"
+      class="t-input t-input--prefix"
     >
       <!---->
       <div

--- a/test/unit/textarea/__snapshots__/demo.test.js.snap
+++ b/test/unit/textarea/__snapshots__/demo.test.js.snap
@@ -14,6 +14,7 @@ exports[`Textarea Textarea baseVue demo works fine 1`] = `
     />
     <!---->
     <!---->
+    <!---->
   </div>
   <div
     class="t-textarea"
@@ -25,6 +26,7 @@ exports[`Textarea Textarea baseVue demo works fine 1`] = `
     />
     <!---->
     <!---->
+    <!---->
   </div>
   <div
     class="t-textarea"
@@ -34,6 +36,7 @@ exports[`Textarea Textarea baseVue demo works fine 1`] = `
       name="description"
       placeholder="请输入文案，高度可自适应，最小3行，最大5行；autosize={minRows: 3, maxRows: 5}"
     />
+    <!---->
     <!---->
     <!---->
   </div>
@@ -51,6 +54,7 @@ exports[`Textarea Textarea eventsVue demo works fine 1`] = `
       class="t-textarea__inner narrow-scrollbar"
       placeholder="请输入"
     />
+    <!---->
     <!---->
     <!---->
   </div>
@@ -73,6 +77,7 @@ exports[`Textarea Textarea maxlengthVue demo works fine 1`] = `
     >
       0/20
     </span>
+    <!---->
   </div>
   <br />
   <div
@@ -87,6 +92,7 @@ exports[`Textarea Textarea maxlengthVue demo works fine 1`] = `
     >
       0/20
     </span>
+    <!---->
     <!---->
   </div>
 </div>
@@ -105,6 +111,7 @@ exports[`Textarea Textarea typeVue demo works fine 1`] = `
     />
     <!---->
     <!---->
+    <!---->
   </div>
   <div
     class="t-textarea t-is-readonly"
@@ -115,19 +122,16 @@ exports[`Textarea Textarea typeVue demo works fine 1`] = `
     />
     <!---->
     <!---->
+    <!---->
   </div>
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner narrow-scrollbar"
-      />
-      <!---->
-      <!---->
-    </div>
+    <textarea
+      class="t-textarea__inner narrow-scrollbar"
+    />
+    <!---->
+    <!---->
     <div
       class="t-textarea__tips t-textarea__tips--normal"
     >
@@ -135,17 +139,13 @@ exports[`Textarea Textarea typeVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-success narrow-scrollbar"
-      />
-      <!---->
-      <!---->
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-success narrow-scrollbar"
+    />
+    <!---->
+    <!---->
     <div
       class="t-textarea__tips t-textarea__tips--success"
     >
@@ -153,17 +153,13 @@ exports[`Textarea Textarea typeVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-warning narrow-scrollbar"
-      />
-      <!---->
-      <!---->
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-warning narrow-scrollbar"
+    />
+    <!---->
+    <!---->
     <div
       class="t-textarea__tips t-textarea__tips--warning"
     >
@@ -171,17 +167,13 @@ exports[`Textarea Textarea typeVue demo works fine 1`] = `
     </div>
   </div>
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-error narrow-scrollbar"
-      />
-      <!---->
-      <!---->
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-error narrow-scrollbar"
+    />
+    <!---->
+    <!---->
     <div
       class="t-textarea__tips t-textarea__tips--error"
     >

--- a/test/unit/textarea/__snapshots__/index.test.js.snap
+++ b/test/unit/textarea/__snapshots__/index.test.js.snap
@@ -3,13 +3,14 @@
 exports[`Textarea $attrs textarea attrs should pass to textarea element 1`] = `
 <div
   class="t-textarea"
+  maxlength="20"
 >
   <textarea
     class="t-textarea__inner narrow-scrollbar"
-    maxlength="20"
     name="description"
     placeholder="please text"
   />
+  <!---->
   <!---->
   <!---->
 </div>
@@ -23,6 +24,7 @@ exports[`Textarea :props :disabled 1`] = `
     class="t-textarea__inner t-is-disabled narrow-scrollbar"
     disabled=""
   />
+  <!---->
   <!---->
   <!---->
 </div>
@@ -42,6 +44,7 @@ exports[`Textarea :props :maxlength 1`] = `
   >
     0/10
   </span>
+  <!---->
 </div>
 `;
 
@@ -53,6 +56,7 @@ exports[`Textarea :props :readonly 1`] = `
     class="t-textarea__inner narrow-scrollbar"
     readonly=""
   />
+  <!---->
   <!---->
   <!---->
 </div>

--- a/test/unit/tree-select/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/demo.test.js.snap
@@ -249,12 +249,12 @@ exports[`TreeSelect TreeSelect baseVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
           style="display: none;"
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->
@@ -481,12 +481,12 @@ exports[`TreeSelect TreeSelect lazyVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
           style="display: none;"
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->
@@ -823,12 +823,12 @@ exports[`TreeSelect TreeSelect prefixVue demo works fine 1`] = `
         </span>
         <!---->
         <div
-          class="t-input__wrap"
+          class="t-input__wrap t-select__input"
+          modelvalue=""
           style="display: none;"
         >
           <div
-            class="t-input t-select__input"
-            modelvalue=""
+            class="t-input"
           >
             <!---->
             <!---->

--- a/test/unit/tree/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree/__snapshots__/demo.test.js.snap
@@ -3905,10 +3905,10 @@ exports[`Tree Tree filterVue demo works fine 1`] = `
     </span>
     <div
       class="t-input__wrap"
+      modelvalue=""
     >
       <div
         class="t-input"
-        modelvalue=""
       >
         <!---->
         <!---->
@@ -7347,10 +7347,10 @@ exports[`Tree Tree operationsVue demo works fine 1`] = `
       </span>
       <div
         class="t-input__wrap"
+        modelvalue=""
       >
         <div
           class="t-input"
-          modelvalue=""
         >
           <!---->
           <!---->


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

关联common PR https://github.com/Tencent/tdesign-common/pull/325
- [x] 新特性提交

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

**TimePicker focused 态样式修复**

before

<img width="342" alt="image" src="https://user-images.githubusercontent.com/35833812/159638926-09341ff2-40fe-45a1-a138-e5ced14d5478.png">

after

<img width="345" alt="image" src="https://user-images.githubusercontent.com/35833812/159639015-3deb4a0b-3c36-4dbe-8a3e-c7fad15cfe2e.png">

**DatePicker focused 态样式修复**

before
<img width="340" alt="image" src="https://user-images.githubusercontent.com/35833812/159639172-288dc8a8-2b84-4d8a-9895-53b21a182230.png">

after
<img width="354" alt="image" src="https://user-images.githubusercontent.com/35833812/159639133-a193abd1-df21-44a1-bd4f-cc63919c6e5f.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(input):
  -  外部传入样式挂载至 `t-input__wrap`, breaking-change
  -  feat(input): 增加 inputClass API，用于透传class到 t-input 同级
- refactor(textarea): 去除 `t-textarea__wrap`, breaking-change
- fix(date-picker): focused 态样式修复
- fix(time-picker): focused 态样式修复
- fix(upload): 修复upload组件 method props 失效
- fix(select-input): 
   - 修复在非输入状态下无focused态
   - 修复在非输入状态下不能显示清除按钮
   - 修复在`single`模式下inputValue 的受控表现

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
