### PR TITLE
Fix/pagination inputnumber placeholder

### DIFF
--- a/src/pagination/pagination.tsx
+++ b/src/pagination/pagination.tsx
@@ -311,6 +311,7 @@ export default defineComponent({
               max={this.pageCount}
               min={min}
               theme="normal"
+              placeholder=""
             />
             {this.t(this.global.page)}
           </div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -11787,7 +11787,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/pagination.v
       <div class="t-input__wrap" unselectable="off">
         <div class="t-input">
           <!---->
-          <!----><input class="t-input__inner" placeholder="请输入" type="text" value="1">
+          <!----><input class="t-input__inner" placeholder type="text" value="1">
           <!---->
           <!---->
           <!---->
@@ -26057,7 +26057,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/jump.vue correctl
         <div class="t-input__wrap" unselectable="off">
           <div class="t-input">
             <!---->
-            <!----><input class="t-input__inner" placeholder="请输入" type="text" value="1">
+            <!----><input class="t-input__inner" placeholder type="text" value="1">
             <!---->
             <!---->
             <!---->

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -9448,7 +9448,7 @@ exports[`ConfigProvider ConfigProvider paginationVue demo works fine 1`] = `
           <!---->
           <input
             class="t-input__inner"
-            placeholder="请输入"
+            placeholder=""
             type="text"
           />
           <!---->

--- a/test/unit/pagination/__snapshots__/demo.test.js.snap
+++ b/test/unit/pagination/__snapshots__/demo.test.js.snap
@@ -687,7 +687,7 @@ exports[`Pagination Pagination jumpVue demo works fine 1`] = `
             <!---->
             <input
               class="t-input__inner"
-              placeholder="请输入"
+              placeholder=""
               type="text"
             />
             <!---->


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
inputnumber 未配置 placeholder 时会有默认文案填充：
![image](https://user-images.githubusercontent.com/7600149/160551237-964f5da6-2823-4569-8941-bdb5c7a85100.png)
pagination 中引入 inputnumber 时需要手动设置 placeholder 为空

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Pagination): 修复跳转页输入框展示了额外 placeholder 默认内容的问题

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
