### PR TITLE
fix: 修复input组件clearable问题

### DIFF
--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -3,7 +3,6 @@ import _Input from './input';
 import _InputGroup from './input-group';
 import { withInstall, WithInstallType } from '../utils/withInstall';
 import { TdInputProps } from './type';
-import mapProps from '../utils/map-props';
 
 import './style';
 
@@ -11,15 +10,7 @@ export * from './type';
 export type InputProps = TdInputProps;
 
 export const Addon: WithInstallType<typeof _Addon> = withInstall(_Addon);
-export const Input: WithInstallType<typeof _Input> = withInstall(
-  mapProps([
-    {
-      name: 'value',
-      event: ['change'],
-      alias: ['modelValue'],
-    },
-  ])(_Input),
-);
+export const Input: WithInstallType<typeof _Input> = withInstall(_Input);
 export const InputGroup: WithInstallType<typeof _InputGroup> = withInstall(_InputGroup);
 
 export default Input;

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -3,6 +3,7 @@ import _Input from './input';
 import _InputGroup from './input-group';
 import { withInstall, WithInstallType } from '../utils/withInstall';
 import { TdInputProps } from './type';
+import mapProps from '../utils/map-props';
 
 import './style';
 
@@ -10,7 +11,15 @@ export * from './type';
 export type InputProps = TdInputProps;
 
 export const Addon: WithInstallType<typeof _Addon> = withInstall(_Addon);
-export const Input: WithInstallType<typeof _Input> = withInstall(_Input);
+export const Input: WithInstallType<typeof _Input> = withInstall(
+  mapProps([
+    {
+      name: 'value',
+      event: ['change'],
+      alias: ['modelValue'],
+    },
+  ])(_Input),
+);
 export const InputGroup: WithInstallType<typeof _InputGroup> = withInstall(_InputGroup);
 
 export default Input;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -69,7 +69,6 @@ export default defineComponent({
     };
 
     const prefixIcon = renderIcon(props.prefixIcon, 'prefix-icon');
-    let suffixIcon = renderIcon(props.suffixIcon, 'suffix-icon');
 
     const label = renderTNodeJSX('label', { silent: true });
     const suffix = renderTNodeJSX('suffix');
@@ -77,38 +76,44 @@ export default defineComponent({
     const labelContent = label ? <div class={`${COMPONENT_NAME.value}__prefix`}>{label}</div> : null;
     const suffixContent = suffix ? <div class={`${COMPONENT_NAME.value}__suffix`}>{suffix}</div> : null;
 
-    if (showClear.value) {
-      suffixIcon = <CloseCircleFilledIcon class={`${COMPONENT_NAME}__suffix-clear`} onClick={inputHandle.emitClear} />;
-    }
-
-    if (props.type === 'password') {
-      if (renderType.value === 'password') {
-        suffixIcon = (
-          <BrowseOffIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={inputHandle.emitPassword} />
-        );
-      } else if (renderType.value === 'text') {
-        suffixIcon = <BrowseIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={inputHandle.emitPassword} />;
-      }
-    }
-
-    const classes = computed(() => [
-      COMPONENT_NAME.value,
-      props.inputClass,
-      {
-        [SIZE.value[props.size]]: props.size !== 'medium',
-        [STATUS.value.disabled]: disabled.value,
-        [STATUS.value.focused]: focused.value,
-        [`${classPrefix.value}-is-${props.status}`]: props.status,
-        [`${classPrefix.value}-align-${props.align}`]: props.align !== 'left',
-        [`${classPrefix.value}-is-readonly`]: props.readonly,
-        [`${COMPONENT_NAME.value}--prefix`]: prefixIcon || labelContent,
-        [`${COMPONENT_NAME.value}--suffix`]: suffixIcon || suffixContent,
-        [`${COMPONENT_NAME.value}--focused`]: focused.value,
-        [`${COMPONENT_NAME.value}--auto-width`]: props.autoWidth,
-      },
-    ]);
-
     return () => {
+      let suffixIcon = renderIcon(props.suffixIcon, 'suffix-icon');
+
+      if (showClear.value && isHover.value) {
+        suffixIcon = (
+          <CloseCircleFilledIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={inputHandle.emitClear} />
+        );
+      }
+
+      if (props.type === 'password') {
+        if (renderType.value === 'password') {
+          suffixIcon = (
+            <BrowseOffIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={inputHandle.emitPassword} />
+          );
+        } else if (renderType.value === 'text') {
+          suffixIcon = (
+            <BrowseIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={inputHandle.emitPassword} />
+          );
+        }
+      }
+
+      const classes = [
+        COMPONENT_NAME.value,
+        props.inputClass,
+        {
+          [SIZE.value[props.size]]: props.size !== 'medium',
+          [STATUS.value.disabled]: disabled.value,
+          [STATUS.value.focused]: focused.value,
+          [`${classPrefix.value}-is-${props.status}`]: props.status,
+          [`${classPrefix.value}-align-${props.align}`]: props.align !== 'left',
+          [`${classPrefix.value}-is-readonly`]: props.readonly,
+          [`${COMPONENT_NAME.value}--prefix`]: prefixIcon || labelContent,
+          [`${COMPONENT_NAME.value}--suffix`]: suffixIcon || suffixContent,
+          [`${COMPONENT_NAME.value}--focused`]: focused.value,
+          [`${COMPONENT_NAME.value}--auto-width`]: props.autoWidth,
+        },
+      ];
+
       const inputEvents = getValidAttrs({
         onFocus: (e: FocusEvent) => inputHandle.emitFocus(e),
         onBlur: inputHandle.formatAndEmitBlur,
@@ -122,10 +127,10 @@ export default defineComponent({
 
       const renderInputNode = () => (
         <div
-          class={classes.value}
+          class={classes}
           onClick={inputHandle.onRootClick}
-          onMouseEnter={inputEventHandler.onInputMouseenter}
-          onMouseLeave={inputEventHandler.onInputMouseleave}
+          onMouseenter={inputEventHandler.onInputMouseenter}
+          onMouseleave={inputEventHandler.onInputMouseleave}
           onWheel={inputEventHandler.onHandleMousewheel}
         >
           {prefixIcon ? (
@@ -153,7 +158,7 @@ export default defineComponent({
               class={[
                 `${COMPONENT_NAME.value}__suffix`,
                 `${COMPONENT_NAME.value}__suffix-icon`,
-                { [`${COMPONENT_NAME.value}__clear`]: showClear.value },
+                { [`${COMPONENT_NAME.value}__clear`]: isHover.value && showClear.value },
               ]}
             >
               {suffixIcon}

--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -15,11 +15,9 @@ export default function useInput(props: TdInputProps) {
   const renderType = ref(props.type);
   const inputRef = ref(null);
 
-  const showClear = computed(
-    () =>
-      (props.value && !props.disabled && props.clearable && isHover.value && !props.readonly) ||
-      props.showClearIconOnEmpty,
-  );
+  const showClear = computed(() => {
+    return (innerValue.value && !props.disabled && props.clearable && !props.readonly) || props.showClearIconOnEmpty;
+  });
 
   const focus = () => inputRef.value?.focus();
   const blur = () => inputRef.value?.blur();

--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -31,6 +31,9 @@ export default function useInput(props: TdInputProps) {
   const emitClear = ({ e }: { e: MouseEvent }) => {
     emitEvent('clear', { e });
     emitEvent('change', '', { e });
+    if (typeof modelValue.value !== 'undefined') {
+      emitEvent('update:modelValue', '');
+    }
     focus();
     emitFocus(e);
   };

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -74,8 +74,9 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
       readonly: !props.allowInput,
       placeholder: singleValueDisplay ? '' : props.placeholder,
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
-      showClearIconOnEmpty: Boolean(props.clearable && inputValue.value),
+      showClearIconOnEmpty: Boolean(props.clearable && displayedValue),
     };
+
     return (
       <Input
         ref="inputRef"


### PR DESCRIPTION
调整suffixIcon展示逻辑

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/519

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

背景： 目前input组件suffixIcon仅在组件初次渲染时进行赋值

方案：将suffixIcon逻辑移至render函数，另外select-input的clear按钮展示根据displayValue，并且，为了防止在选中选项后clearIcon闪烁，根据isHover决定是否className为 ${COMPONENT_NAME.value}__clear 


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(input): 修复input组件clearable问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
