### PR TITLE
fix(#505): 修复 form-item 值校验响应问题

### DIFF
--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -66,6 +66,7 @@ export default defineComponent({
       resetValidating: false as boolean,
       needResetField: false as boolean,
       initialValue: undefined as ValueType,
+      value: undefined as ValueType,
     };
   },
 
@@ -133,10 +134,6 @@ export default defineComponent({
 
       return contentStyle;
     },
-    value(): ValueType {
-      const parent = this.form;
-      return parent && parent.data && lodashGet(parent.data, this.name);
-    },
     hasColon(): boolean {
       const parent = this.form;
       return !!(parent && parent.colon && this.getLabelContent());
@@ -163,8 +160,18 @@ export default defineComponent({
   },
 
   watch: {
-    value() {
-      this.validate('change');
+    'form.data': {
+      deep: true,
+      immediate: true,
+      handler(val) {
+        this.value = lodashGet(val, this.name);
+      },
+    },
+    value: {
+      deep: true,
+      handler() {
+        this.validate('change');
+      },
     },
   },
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#505 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

之前的代码中，因为 form 的 data 是一个对象，form-item 的 computed value 检测不到对象内属性的变化，需要使用 watch deep。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(formItem): 解决有 select 在 form-item 中时，无法检测 value 变化，导致无法及时进行 validate 的问题。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
