### PR TITLE
fix: message组件onDurationEnd冲突

### DIFF
--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -63,7 +63,7 @@ export const MessageList = defineComponent({
       );
     };
 
-    const getListeners = (index: number, item: MessageOptions) => {
+    const getProps = (index: number, item: MessageOptions) => {
       return {
         ...item,
         onCloseBtnClick: () => remove(index),
@@ -90,7 +90,7 @@ export const MessageList = defineComponent({
       return (
         <div class="t-message__list" style={styles.value}>
           {list.value.map((item, index) => (
-            <TMessage key={item.key} style={msgStyles(item)} ref={addChild} {...getListeners(index, item)} />
+            <TMessage key={item.key} style={msgStyles(item)} ref={addChild} {...getProps(index, item)} />
           ))}
         </div>
       );

--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -63,10 +63,15 @@ export const MessageList = defineComponent({
       );
     };
 
-    const getListeners = (index: number) => {
+    const getListeners = (index: number, item: MessageOptions) => {
       return {
         onCloseBtnClick: () => remove(index),
-        onDurationEnd: () => remove(index),
+        onDurationEnd: () => {
+          if (item.onDurationEnd) {
+            item.onDurationEnd();
+          }
+          return remove(index);
+        },
       };
     };
 
@@ -83,9 +88,21 @@ export const MessageList = defineComponent({
 
       return (
         <div class="t-message__list" style={styles.value}>
-          {list.value.map((item, index) => (
-            <TMessage key={item.key} style={msgStyles(item)} ref={addChild} {...item} {...getListeners(index)} />
-          ))}
+          {list.value.map((item, index) => {
+            const itemClone = JSON.parse(JSON.stringify(item));
+            if (item.onDurationEnd) {
+              delete itemClone.onDurationEnd;
+            }
+            return (
+              <TMessage
+                key={item.key}
+                style={msgStyles(item)}
+                ref={addChild}
+                {...itemClone}
+                {...getListeners(index, item)}
+              />
+            );
+          })}
         </div>
       );
     };

--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -65,6 +65,7 @@ export const MessageList = defineComponent({
 
     const getListeners = (index: number, item: MessageOptions) => {
       return {
+        ...item,
         onCloseBtnClick: () => remove(index),
         onDurationEnd: () => {
           if (item.onDurationEnd) {
@@ -88,21 +89,9 @@ export const MessageList = defineComponent({
 
       return (
         <div class="t-message__list" style={styles.value}>
-          {list.value.map((item, index) => {
-            const itemClone = JSON.parse(JSON.stringify(item));
-            if (item.onDurationEnd) {
-              delete itemClone.onDurationEnd;
-            }
-            return (
-              <TMessage
-                key={item.key}
-                style={msgStyles(item)}
-                ref={addChild}
-                {...itemClone}
-                {...getListeners(index, item)}
-              />
-            );
-          })}
+          {list.value.map((item, index) => (
+            <TMessage key={item.key} style={msgStyles(item)} ref={addChild} {...getListeners(index, item)} />
+          ))}
         </div>
       );
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

1. 插件式调用onDurationEnd事件报错


### 💡 需求背景和解决方案

1. 因为onDurationEnd事件冲突，导致两个函数合并成了数组，尝试在绑定事件前，先处理掉onDurationEnd，满足之后的回调。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
