### PR TITLE
完善message组件插件式调用传入事件方法；完善notification出现退出动画，替换先前的transitionGroup写法

### DIFF
--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -66,7 +66,12 @@ export const MessageList = defineComponent({
     const getProps = (index: number, item: MessageOptions) => {
       return {
         ...item,
-        onCloseBtnClick: () => remove(index),
+        onCloseBtnClick: (e: any) => {
+          if (item.onCloseBtnClick) {
+            item.onCloseBtnClick(e);
+          }
+          return remove(index);
+        },
         onDurationEnd: () => {
           if (item.onDurationEnd) {
             item.onDurationEnd();

--- a/src/notification/animate.ts
+++ b/src/notification/animate.ts
@@ -1,0 +1,99 @@
+import { PLACEMENT_LIST } from './const';
+
+interface Keyframe {
+  composite?: CompositeOperationOrAuto;
+  easing?: string;
+  offset?: number | null;
+  [property: string]: string | number | null | undefined;
+}
+type CompositeOperationOrAuto = 'accumulate' | 'add' | 'auto' | 'replace';
+
+const ANIMATION_OPTION = {
+  duration: 200,
+  easing: 'linear',
+};
+
+const fadeIn = (dom: HTMLElement, placement: string) => {
+  if (!dom) return;
+  const offsetHeight = dom?.offsetHeight || 0;
+  const offsetWidth = dom?.offsetWidth || 0;
+  const keyframes: Array<Keyframe> | null = getFadeInKeyframes(placement, offsetWidth, offsetHeight);
+  if (!keyframes) return;
+  dom.animate && dom.animate(keyframes, ANIMATION_OPTION);
+};
+
+const fadeOut = (dom: HTMLElement, placement: string, onFinish: Function) => {
+  if (!dom) return;
+  const offsetHeight = dom?.offsetHeight || 0;
+  const offsetWidth = dom?.offsetWidth || 0;
+  const keyframes: Array<Keyframe> | null = getFadeOutKeyframes(placement, offsetWidth, offsetHeight);
+  if (!keyframes) return onFinish();
+
+  const animate = dom.animate && dom.animate(keyframes, ANIMATION_OPTION);
+  if (animate) {
+    animate.onfinish = () => {
+      onFinish();
+    };
+  } else {
+    dom.style.display = 'none';
+    onFinish();
+  }
+};
+
+const getFadeInKeyframes = (placement: string, offsetWidth: Number, offsetHeight: Number): Array<Keyframe> | null => {
+  if (!PLACEMENT_LIST.includes(placement)) return null;
+  if (placement === 'top-right') {
+    return [
+      { opacity: 0, transform: `translateX(${offsetWidth}px)` },
+      { opacity: 1, transform: `translateX(0px)` },
+    ];
+  }
+  if (placement === 'bottom-right') {
+    return [
+      { opacity: 0, transform: `translateX(${offsetWidth}px)`, marginBottom: `-${offsetHeight}px` },
+      { opacity: 1, transform: `translateX(0px)` },
+    ];
+  }
+  if (placement === 'top-left') {
+    return [
+      { opacity: 0, transform: `translateX(-${offsetWidth}px)` },
+      { opacity: 1, transform: `translateX(0px)` },
+    ];
+  }
+  if (placement === 'bottom-left') {
+    return [
+      { opacity: 0, transform: `translateX(-${offsetWidth}px)`, marginBottom: `-${offsetHeight}px` },
+      { opacity: 1, transform: `translateX(0px)` },
+    ];
+  }
+};
+
+const getFadeOutKeyframes = (placement: string, offsetWidth: Number, offsetHeight: Number): Array<Keyframe> | null => {
+  if (!PLACEMENT_LIST.includes(placement)) return null;
+  if (placement === 'top-right') {
+    return [
+      { opacity: 1, transform: `translateX(0px)` },
+      { opacity: 0, transform: `translateX(${offsetWidth}px)`, marginBottom: `-${offsetHeight}px` },
+    ];
+  }
+  if (placement === 'bottom-right') {
+    return [
+      { opacity: 1, transform: `translateX(0px)` },
+      { opacity: 0, transform: `translateX(${offsetWidth}px)` },
+    ];
+  }
+  if (placement === 'top-left') {
+    return [
+      { opacity: 1, transform: `translateX(0px)` },
+      { opacity: 0, transform: `translateX(-${offsetWidth}px)`, marginBottom: `-${offsetHeight}px` },
+    ];
+  }
+  if (placement === 'bottom-left') {
+    return [
+      { opacity: 1, transform: `translateX(0px)` },
+      { opacity: 0, transform: `translateX(-${offsetWidth}px)` },
+    ];
+  }
+};
+
+export { fadeIn, fadeOut };

--- a/src/notification/notification.tsx
+++ b/src/notification/notification.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, h, onMounted } from 'vue';
+import { defineComponent, h, onMounted, ref } from 'vue';
 import { InfoCircleFilledIcon, CheckCircleFilledIcon, CloseIcon } from 'tdesign-icons-vue-next';
 import isFunction from 'lodash/isFunction';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
@@ -14,6 +14,7 @@ export default defineComponent({
     const { classPrefix } = useConfig('classPrefix');
     const renderTNode = useTNodeJSX();
     const renderContent = useContent();
+    const timer = ref(null);
 
     const close = (e?: MouseEvent) => {
       props.onCloseBtnClick?.({ e });
@@ -51,18 +52,29 @@ export default defineComponent({
       return <div class={`${COMPONENT_NAME.value}__content`}>{renderContent('default', 'content')}</div>;
     };
 
-    onMounted(() => {
-      if (props.duration > 0) {
-        const timer = setTimeout(() => {
-          clearTimeout(timer);
-          props.onDurationEnd?.();
-        }, props.duration);
+    const clearTimer = () => {
+      props.duration && clearTimeout(timer.value);
+    };
+
+    const setTimer = () => {
+      if (!props.duration) {
+        return;
       }
+      timer.value = Number(
+        setTimeout(() => {
+          clearTimer();
+          props.onDurationEnd?.();
+        }, props.duration),
+      );
+    };
+
+    onMounted(() => {
+      props.duration && setTimer();
     });
 
     expose({ close });
     return () => (
-      <div class={`${COMPONENT_NAME.value}`}>
+      <div class={`${COMPONENT_NAME.value}`} onMouseenter={clearTimer} onMouseleave={setTimer}>
         {renderIcon()}
         <div class={`${COMPONENT_NAME.value}__main`}>
           <div class={`${COMPONENT_NAME.value}__title__wrap`}>

--- a/src/notification/notificationList.tsx
+++ b/src/notification/notificationList.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, computed, TransitionGroup, Ref } from 'vue';
+import { defineComponent, ref, computed, Ref } from 'vue';
 import Notification from './notification';
 import { TdNotificationProps, NotificationOptions } from './type';
 import { Styles } from '../common';
@@ -88,12 +88,10 @@ export default defineComponent({
       if (!list.value.length) return;
 
       return (
-        <div class={`${COMPONENT_NAME.value}__show-transition--${placement}`} style={styles.value}>
-          <TransitionGroup name="notification-slide-fade">
-            {list.value.map((item: { offset: NotificationOptions['offset']; zIndex: number; id: number }, index) => (
-              <Notification ref={addChild} key={item.id} style={notificationStyles(item)} {...getProps(index, item)} />
-            ))}
-          </TransitionGroup>
+        <div class={`${COMPONENT_NAME.value}__show`} style={styles.value}>
+          {list.value.map((item: { offset: NotificationOptions['offset']; zIndex: number; id: number }, index) => (
+            <Notification ref={addChild} key={item.id} style={notificationStyles(item)} {...getProps(index, item)} />
+          ))}
         </div>
       );
     };

--- a/src/notification/plugin.ts
+++ b/src/notification/plugin.ts
@@ -51,9 +51,10 @@ const NotificationFunction = (options: NotificationOptions): Promise<Notificatio
   }
 
   return new Promise((resolve) => {
+    const ins = instanceMap.get(attachEl)[hackOptions.placement];
     nextTick(() => {
-      const lastChild = tmpInstance.$refs?.notification0 as NotificationInstance;
-      resolve(lastChild);
+      const { notificationList } = ins;
+      resolve(notificationList[notificationList.length - 1]);
     });
   });
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/720 完善message组件插件式调用传入事件方法

https://github.com/Tencent/tdesign-vue-next/issues/58 完善notification出现退出动画，替换先前的transitionGroup写法
### 💡 需求背景和解决方案


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
- fix(message): 修复插件式调用时，用户传入`onCloseBtnClick`事件时，无法触发回调。

- feat(notification): 使用项目中已有的js动画方案，替换先前的`transitionGroup`方案，完善了组件出现和回收动画效果。其中涉及到**common**子仓库的修改，删除之前transition相关的类名，添加了一个`&-list__showt`类名。
相关PR: https://github.com/Tencent/tdesign-common/pull/450。

- feat(notification): 增加`onMouseenter`和`onMouseleave`事件，保证鼠标移入移出组件时，`duration`时间的停止和重新计时。

- fix(notification): 修复插件式调用时，用户传入`onCloseBtnClick` `onDurationEnd`事件时，无法触发回调。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
