### PR TITLE
fix: control hook

### DIFF
--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -160,7 +160,6 @@ export default defineComponent({
         class={this.formClass}
         onSubmit={(e) => this.submitHandler(e as MouseEvent)}
         onReset={(e) => this.resetHandler(e as MouseEvent)}
-        {...this.$attrs}
       >
         {this.$slots.default ? this.$slots.default() : []}
       </form>

--- a/src/hooks/useDefaultValue.ts
+++ b/src/hooks/useDefaultValue.ts
@@ -17,13 +17,10 @@ export default function useDefaultValue<T, P extends any[]>(
     internalValue.value = value.value;
   }
 
-  // 监听value与modelValue的变化
-  watch(
-    () => value.value,
-    (newVal) => {
-      internalValue.value = newVal;
-    },
-  );
+  // 监听value变化
+  watch(value, (newVal) => {
+    internalValue.value = newVal;
+  });
 
   // 非受控模式
   return [

--- a/src/hooks/useDefaultValue.ts
+++ b/src/hooks/useDefaultValue.ts
@@ -1,4 +1,4 @@
-import { ref, Ref, getCurrentInstance } from 'vue';
+import { ref, Ref, getCurrentInstance, watch } from 'vue';
 import { ChangeHandler } from './useVModel';
 
 // 用于实现 v-model:propsName
@@ -12,23 +12,30 @@ export default function useDefaultValue<T, P extends any[]>(
   const internalValue = ref();
   internalValue.value = defaultValue;
 
-  // 受控模式
   if (typeof value.value !== 'undefined') {
-    return [
-      value,
-      (newValue, ...args) => {
-        emit?.(`update:${propsName}`, newValue, ...args);
-        onChange?.(newValue, ...args);
-      },
-    ];
+    // 受控模式 v-model:propName
+    internalValue.value = value.value;
   }
+
+  // 监听value与modelValue的变化
+  watch(
+    () => value.value,
+    (newVal) => {
+      internalValue.value = newVal;
+    },
+  );
 
   // 非受控模式
   return [
     internalValue,
     (newValue, ...args) => {
-      internalValue.value = newValue;
-      onChange?.(newValue, ...args);
+      if (typeof value.value !== 'undefined') {
+        emit?.(`update:${propsName}`, newValue, ...args);
+        onChange?.(newValue, ...args);
+      } else {
+        internalValue.value = newValue;
+        onChange?.(newValue, ...args);
+      }
     },
   ];
 }

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -1,4 +1,4 @@
-import { ref, Ref, getCurrentInstance } from 'vue';
+import { ref, Ref, getCurrentInstance, watch } from 'vue';
 
 export type ChangeHandler<T, P extends any[]> = (value: T, ...args: P) => void;
 
@@ -11,37 +11,48 @@ export default function useVModel<T, P extends any[]>(
   // emit 和 eventName 用于支持 v-model 和 xxx.sync 语法糖
 ): [Ref<T>, ChangeHandler<T, P>] {
   const { emit } = getCurrentInstance();
-  const internalValue = ref<T>();
+  const internalValue: Ref<T> = ref();
+
+  // 非受控模式,defaultValue 只消费一次
   internalValue.value = defaultValue;
 
-  // 受控模式 v-model:propName
   if (typeof value.value !== 'undefined') {
-    return [
-      value,
-      (newValue, ...args) => {
-        emit?.(`update:${propName}`, newValue, ...args);
-        onChange?.(newValue, ...args);
-      },
-    ];
+    // 受控模式 v-model:propName
+    internalValue.value = value.value;
+  } else if (typeof modelValue.value !== 'undefined') {
+    // 受控模式:modelValue v-model
+    internalValue.value = modelValue.value;
   }
 
-  // 受控模式:modelValue v-model
-  if (typeof modelValue.value !== 'undefined') {
-    return [
-      modelValue,
-      (newValue, ...args) => {
-        emit?.(`update:modelValue`, newValue, ...args);
-        onChange?.(newValue, ...args);
-      },
-    ];
-  }
+  // 监听value与modelValue的变化
+  watch(
+    () => value.value,
+    (newVal) => {
+      internalValue.value = newVal;
+    },
+  );
+  watch(
+    () => modelValue.value,
+    (newVal) => {
+      internalValue.value = newVal;
+    },
+  );
 
-  // 非受控模式
   return [
     internalValue,
     (newValue, ...args) => {
-      internalValue.value = newValue;
-      onChange?.(newValue, ...args);
+      // 受控模式 v-model:propName
+      if (typeof value.value !== 'undefined') {
+        emit?.(`update:${propName}`, newValue, ...args);
+        onChange?.(newValue, ...args);
+      } else if (typeof modelValue.value !== 'undefined') {
+        // 受控模式:modelValue v-model
+        emit?.(`update:modelValue`, newValue, ...args);
+        onChange?.(newValue, ...args);
+      } else {
+        internalValue.value = newValue;
+        onChange?.(newValue, ...args);
+      }
     },
   ];
 }

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -25,18 +25,12 @@ export default function useVModel<T, P extends any[]>(
   }
 
   // 监听value与modelValue的变化
-  watch(
-    () => value.value,
-    (newVal) => {
-      internalValue.value = newVal;
-    },
-  );
-  watch(
-    () => modelValue.value,
-    (newVal) => {
-      internalValue.value = newVal;
-    },
-  );
+  watch(value, (newVal) => {
+    internalValue.value = newVal;
+  });
+  watch(modelValue, (newVal) => {
+    internalValue.value = newVal;
+  });
 
   return [
     internalValue,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

`useVModel` 与 `useDefaultValue` 在之前的实现中，通过判断value 是否为undefined来判断组件的非受控与受控，且这个执行时间在组件初始化阶段，当用户传入 value 为 undefined，会进入非受控模式。后续用户从外部对value的变化将不会驱动组件进行innerValue的变化。

### 下面代码可复现问题

```vue
<template>
  <div class="tdesign-demo-block-column" style="max-width: 500px">
    <t-input v-model="input" @change="onChange" />
    <t-input :value="input" placeholder="请输入内容（有默认值）" @enter="onEnter" @change="onChange" />
  </div>
</template>
<script setup>
import { ref } from 'vue';

const input = ref(undefined);
const onChange = (val) => {
  input.value = val;
};
</script>
```
### 修复前
![May-12-2022 23-27-27](https://user-images.githubusercontent.com/35833812/168112406-f9fc2904-e547-4dd9-b315-38be3f90e7d0.gif)


### 修复后

![May-12-2022 23-29-49](https://user-images.githubusercontent.com/35833812/168112431-15b22422-c5cc-42a7-a8cb-28611462fcf0.gif)



timePicker 修复

修复前

![May-12-2022 23-31-52](https://user-images.githubusercontent.com/35833812/168112887-d2d12fe4-6df4-4045-8fc7-341c8a37aa51.gif)


修复后

![May-12-2022 23-31-21](https://user-images.githubusercontent.com/35833812/168112872-b98707b9-2121-441e-b392-259bd7ebb9ab.gif)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(form): 修复当modelValue为外部传入的undefined时，双向绑定失效 ([issue #712](https://github.com/Tencent/tdesign-vue-next/issues/712))
- fix(form): 修复 `attrs` 注入异常 ([issue #671](https://github.com/Tencent/tdesign-vue-next/issues/671))
- fix(timePicker): 修复当modelValue为外部传入的undefined时，clearable失效 ([issue #722](https://github.com/Tencent/tdesign-vue-next/issues/722))


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
