### PR TITLE
chore: use cz-git commitizen adapter

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,18 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+const fs = require('fs');
+const path = require('path');
+
+const packages = fs.readdirSync(path.resolve(__dirname, 'src'));
+
+/** @type {import('cz-git').UserConfig} */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  prompt: {
+    scopes: [...packages],
+    customScopesAlign: 'top-bottom',
+    scopeOverrides: {
+      test: ['unit', 'e2e'],
+    },
+    allowEmptyIssuePrefixs: false,
+    allowCustomIssuePrefixs: false,
+  },
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,17 +1,29 @@
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
-const packages = fs.readdirSync(path.resolve(__dirname, 'src'));
+const packages = fs
+  .readdirSync(path.resolve(__dirname, 'src'))
+  .filter((r) => ['.DS_Store', '_common'].indexOf(r) === -1);
+
+// precomputed scope
+const scopeComplete = execSync("git status -s | grep 'src' 2> /dev/null")
+  .toString()
+  .trim()
+  .split('\n')
+  .find((r) => r.indexOf('M  ') !== -1)
+  ?.match(/src\/(\S*)\//)?.[1];
 
 /** @type {import('cz-git').UserConfig} */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   prompt: {
     scopes: [...packages],
-    customScopesAlign: 'top-bottom',
+    customScopesAlign: !scopeComplete ? 'top-bottom' : 'bottom',
     scopeOverrides: {
       test: ['unit', 'e2e'],
     },
+    defaultScope: scopeComplete,
     allowEmptyIssuePrefixs: false,
     allowCustomIssuePrefixs: false,
   },

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,8 +3,9 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 const packages = fs
-  .readdirSync(path.resolve(__dirname, 'src'))
-  .filter((r) => ['.DS_Store', '_common'].indexOf(r) === -1);
+  .readdirSync(path.resolve(__dirname, 'src'), { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => dirent.name);
 
 // precomputed scope
 const scopeComplete = execSync("git status -s | grep 'src' 2> /dev/null")

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "commitizen": "^4.0.3",
     "cross-env": "^7.0.2",
     "cypress": "^9.1.1",
-    "cz-conventional-changelog": "^3.0.2",
+    "cz-git": "^1.3.2",
     "esbuild": "^0.14.11",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -172,7 +172,7 @@
   },
   "config": {
     "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
+      "path": "./node_modules/cz-git"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案
Hi 我是 `cz-git` commitizen 适配器的作者，偶尔之间我查看了这个项目，发现他非常适合使用`cz-git`, 来提升你们的日常开发
- github: https://github.com/Zhengqbbb/cz-git
- 文档：https://cz-git.qbenben.com/zh/

#### 主要特点：
1. **交互体验**。支持搜索，和上下选择的交互模式，减少 commit 过程中出现的拼写错误
2. **高度自定义**，cz-git 提供了丰富的自定义功能，让 工具 更契合团队整体习惯
3. **与 commitiint 联动**，可以读取和编写配置在 commitiint 配置文件
4. **轻量化**：只有一个独立依赖，1.8 MB

欢迎尝试使用体验，有任何问题或需求可以告诉我

![demo](https://user-images.githubusercontent.com/40693636/169730873-8decd876-37ab-47e4-a1de-7029e8e4ccc9.gif)


#### 随带一提
可以考虑删除 `.husky/prepare-commit-msg` 文件
我在提交的过程中发现了你们使用 强制转换的 git hook `.husky/prepare-commit-msg`。
我个人认为这个是非常不好的。这会改变原有 git commit 命令的行为，并且在每次commit过后会自动打开编辑模式。这**丧失了使用命令行工具提供的便利性**。
BTW： 使用`cz-git` 可以在最终提交确认时输入 `e` 进入编辑模式。直接回车就提交



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
