### PR TITLE
chore: update precomputed scope for cz-git

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,12 +8,13 @@ const packages = fs
   .map((dirent) => dirent.name);
 
 // precomputed scope
-const scopeComplete = execSync("git status -s | grep 'src' 2> /dev/null")
+const scopeComplete = execSync('git status --porcelain || true')
   .toString()
   .trim()
   .split('\n')
   .find((r) => r.indexOf('M  ') !== -1)
-  ?.match(/src\/(\S*)\//)?.[1];
+  ?.replace(/(\/)/g, '%%')
+  ?.match(/src%%((\w|-)*)/)?.[1];
 
 /** @type {import('cz-git').UserConfig} */
 module.exports = {


### PR DESCRIPTION
- fix command throw error
- handle folder path

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 💡 需求背景和解决方案
#### 简要：
1. 替换命令 `git status --porcelain`: 
   Give the output in an easy-to-parse format for scripts. This is similar to the short output, but will remain stable
   across Git versions and regardless of user configuration. See below for details.
2. 修复`grep` 命令返回非成功导致捕获异常报错问题
3. 将获取到暂存区路径转换一层更好处理截取工作

#### 主要思路：
1. 获取暂存区所有文件路径 
2. 进行字符串截取`src`相关路径
<img width="318" alt="image" src="https://user-images.githubusercontent.com/40693636/170021762-ea6b19e1-7157-4443-9f92-63d5c7b76dad.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->


- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
