### PR TITLE
affix兼容<keep-alive/>

### DIFF
--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -46,7 +46,7 @@ export default defineComponent({
       const icon = props.loading ? <TLoading inheritColor={true} /> : renderTNodeJSX('icon');
       const iconOnly = icon && !buttonContent;
 
-      buttonContent = buttonContent ? <span class={`${COMPONENT_NAME}__text`}>{buttonContent}</span> : '';
+      buttonContent = buttonContent ? <span class={`${COMPONENT_NAME.value}__text`}>{buttonContent}</span> : '';
       if (icon) {
         buttonContent = [icon, buttonContent];
       }
@@ -54,9 +54,9 @@ export default defineComponent({
       return (
         <button
           ref="btnRef"
-          class={[...buttonClass.value, { [`${COMPONENT_NAME}--icon-only`]: iconOnly }]}
+          class={[...buttonClass.value, { [`${COMPONENT_NAME.value}--icon-only`]: iconOnly }]}
           type={props.type}
-          disabled={props.disabled}
+          disabled={isDisabled.value}
           {...attrs}
           onClick={props.onClick}
         >


### PR DESCRIPTION
当前`affix`仅在`unmount`时取消事件绑定，在`<keep-alive/>`场景下会出现页面隐藏后，仍在监听滚动事件的问题，下次回到页面时`affix`会异常展示；

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next-starter/pull/158 
https://preview-pr158-tdesign-vue-next-starter.surge.sh/
以上预览链接能复现出问题；当多个包含滚动列表的页面在`<keep-alive/>`下来回切换时，`affix`异常

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

分析出问题在于在`<keep-alive/>`下，组件隐藏后不会触发`unmount`，所以`affix`不会取消滚动事件的绑定，导致展示异常

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Affix): 兼容`<keep-alive/>`场景

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
