### PR TITLE
feat(input-number): 透传 Input 组件全部特性，即 inputProps

### DIFF
--- a/examples/input-number/input-number.md
+++ b/examples/input-number/input-number.md
@@ -10,6 +10,7 @@ autoWidth | Boolean | false | 宽度随内容自适应 | N
 decimalPlaces | Number | undefined | [小数位数](https://en.wiktionary.org/wiki/decimal_place) | N
 disabled | Boolean | false | 禁用组件 | N
 format | Function | - | 指定输入框展示值的格式。TS 类型：`(value: number) => number | string` | N
+inputProps | Object | - | 透传 Input 输入框组件全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/input-number/type.ts) | N
 max | Number | Infinity | 最大值 | N
 min | Number | -Infinity | 最小值 | N
 placeholder | String | undefined | 占位符 | N

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -58,6 +58,7 @@ export default defineComponent({
         <t-input
           {...inputAttrs.value}
           {...inputEvents.value}
+          props={props.inputProps}
           value={displayValue.value}
           onChange={(val: string, { e }: { e: InputEvent }) => handleInput(val, e)}
         />

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -58,7 +58,7 @@ export default defineComponent({
         <t-input
           {...inputAttrs.value}
           {...inputEvents.value}
-          props={props.inputProps}
+          {...props.inputProps}
           value={displayValue.value}
           onChange={(val: string, { e }: { e: InputEvent }) => handleInput(val, e)}
         />

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -1,7 +1,7 @@
 import { computed, defineComponent } from 'vue';
 import { AddIcon, RemoveIcon, ChevronDownIcon, ChevronUpIcon } from 'tdesign-icons-vue-next';
 import TButton from '../button';
-import TInput from '../input';
+import TInput, { InputProps } from '../input';
 import props from './props';
 
 // hooks
@@ -58,7 +58,7 @@ export default defineComponent({
         <t-input
           {...inputAttrs.value}
           {...inputEvents.value}
-          {...props.inputProps}
+          {...(props.inputProps as InputProps)}
           value={displayValue.value}
           onChange={(val: string, { e }: { e: InputEvent }) => handleInput(val, e)}
         />

--- a/src/input-number/props.ts
+++ b/src/input-number/props.ts
@@ -29,6 +29,10 @@ export default {
   format: {
     type: Function as PropType<TdInputNumberProps['format']>,
   },
+  /** 透传 Input 输入框组件全部属性 */
+  inputProps: {
+    type: Object as PropType<TdInputNumberProps['inputProps']>,
+  },
   /** 最大值 */
   max: {
     type: Number,

--- a/src/input-number/type.ts
+++ b/src/input-number/type.ts
@@ -4,6 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
+import { InputProps } from '../input';
 import { TNode } from '../common';
 
 export interface TdInputNumberProps {
@@ -29,6 +30,10 @@ export interface TdInputNumberProps {
    * 指定输入框展示值的格式
    */
   format?: (value: number) => number | string;
+  /**
+   * 透传 Input 输入框组件全部属性
+   */
+  inputProps?: InputProps;
   /**
    * 最大值
    * @default Infinity


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [✅] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 希望在 t-input-number 中能自定义 t-input 的属性
2. 将 props 透传给 t-input
3. { suffix: "元" }

<img width="216" alt="image" src="https://user-images.githubusercontent.com/11224001/170860715-a5bfbf85-feac-44be-896e-0c4f167a1233.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [✅] 代码演示已提供或无须提供
- [✅] TypeScript 定义已补充或无须补充
- [✅] Changelog 已提供或无须提供
