### PR TITLE
fix(menu): 子级菜单默认选中，父级没有回显

### DIFF
--- a/src/menu/const.ts
+++ b/src/menu/const.ts
@@ -19,6 +19,7 @@ export interface TdMenuInterface {
   vMenu?: VMenu;
   select: (val: MenuValue) => void;
   open?: (val: MenuValue, type?: TdOpenType) => boolean | void;
+  updateActiveValues?: (val: MenuValue) => void;
 }
 
 export interface TdSubMenuInterface {

--- a/src/menu/head-menu.tsx
+++ b/src/menu/head-menu.tsx
@@ -34,6 +34,9 @@ export default defineComponent({
     const submenu = reactive([]);
     const vMenu = new VMenu({ isMutex: true, expandValues: expandValues.value });
 
+    const updateActiveValues = (value: MenuValue) => {
+      activeValues.value = vMenu.select(value);
+    };
     provide<TdMenuInterface>('TdMenu', {
       mode,
       theme,
@@ -66,6 +69,7 @@ export default defineComponent({
         }
         setExpanded(expanded);
       },
+      updateActiveValues,
     });
 
     // methods
@@ -85,9 +89,6 @@ export default defineComponent({
         handleSubmenuExpand(value[0]);
       }
     });
-    const updateActiveValues = (value: MenuValue) => {
-      activeValues.value = vMenu.select(value);
-    };
     watch(activeValue, updateActiveValues);
     watch(
       () => props.expandType,

--- a/src/menu/menu-item.tsx
+++ b/src/menu/menu-item.tsx
@@ -30,6 +30,7 @@ export default defineComponent({
     // lifetimes
     onMounted(() => {
       menu?.vMenu?.add({ value: props.value, parent: submenu?.value, vnode: ctx.slots.default });
+      menu?.updateActiveValues?.(menu.activeValue.value);
     });
 
     return {

--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -148,7 +148,7 @@ export default defineComponent({
       menu?.vMenu?.add({ value: props.value, parent: submenu?.value, vnode: ctx.slots.default });
       const instance = getCurrentInstance();
 
-      isNested.value = !/^t(head)?menu/i.test(instance.parent?.type.name);
+      isNested.value = /^T(Head)?Menu/i.test(instance.parent?.type.name);
     });
 
     return {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix [914](https://github.com/Tencent/tdesign-vue-next/issues/914)
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu):  修复子级菜单默认选中，父级没有回显

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
