### PR TITLE
fix(slider): fix slider click event bug

### DIFF
--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -46,7 +46,7 @@ export default defineComponent({
     const secondButtonRef = ref<SliderButtonType>();
 
     const sliderState = reactive({
-      prevValue: 0 as SliderValue,
+      // TODO: 该属性应该是暴露出来的api供用户配置才对
       showSteps: false,
     });
     const firstValue = ref(formatSlderValue(sliderValue.value, 'first'));
@@ -173,7 +173,7 @@ export default defineComponent({
         if (props.range) {
           changeValue = [firstValue.value, secondValue.value];
         } else {
-          changeValue = sliderState.prevValue;
+          changeValue = firstValue.value;
         }
       }
       const fixValue: SliderValue = setValues(changeValue);
@@ -199,7 +199,6 @@ export default defineComponent({
           firstValue.value = props.min || 0;
           secondValue.value = props.max || 100;
         }
-        sliderState.prevValue = [firstValue.value, secondValue.value];
         valuetext = `${firstValue.value}-${secondValue.value}`;
       } else {
         if (typeof sliderValue.value !== 'number') {
@@ -207,7 +206,6 @@ export default defineComponent({
         } else {
           firstValue.value = Math.min(props.max, Math.max(props.min, sliderValue.value as number));
         }
-        sliderState.prevValue = firstValue.value;
         valuetext = String(firstValue.value);
       }
       if (sliderContainerRef.value) {
@@ -330,10 +328,9 @@ export default defineComponent({
     const renderInputNumber = useSliderInput(inputConfig);
 
     const renderInputButton = (): VNode => {
-      const firstInputVal = props.range ? firstValue.value : (sliderState.prevValue as number);
+      const firstInputVal = firstValue.value;
       const firstInputOnChange = (v: number) => {
         firstValue.value = v;
-        props.range ? (firstValue.value = v) : (sliderState.prevValue = v);
       };
       const secondInputVal = secondValue.value;
       const secondInputOnChange = (v: number) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题：Slider组件使用inputNumberProp时，点击滑动条无法把值同步到InputNumber组件
原因：InputNumber组件有个判断是否使用当下Slider上一次渲染值，但click逻辑中没有在每次完成操作后同步更新该值，并且把该值用作渲染InputNumber组件的参数
解决办法：排查发现旧版逻辑中存在prevValue属性来记录上一次的滑动值，但该值只在拖拽时被同步且被用于赋值给sliderButton的位置计算属性。经过考虑和调试，完全可以移除该值，直接以Slider的value值去替代来避免每次click滑动条导致值同步差异问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Slider): 修复Slider组件使用inputNumberProp时，点击滑动条无法把值同步到InputNumber组件问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
