### PR TITLE
fix(RadioGroup): 修复RadioGroup多次赋予不存在的值时文字不能正常显示

### DIFF
--- a/src/radio/group.tsx
+++ b/src/radio/group.tsx
@@ -43,7 +43,10 @@ export default defineComponent({
       if (props.variant === 'outline') return;
 
       const checkedRadio: HTMLElement = radioGroupRef.value.querySelector(checkedClassName.value);
-      if (!checkedRadio) return;
+      if (!checkedRadio) {
+        barStyle.value = { width: '0px', left: '0px' };
+        return;
+      }
 
       const { offsetWidth, offsetLeft } = checkedRadio;
       // current node is not rendered，fallback to default render


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 组件样式/交互改进

### 🔗 相关 Issue
closed #1107 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(RadioGroup): 修复 `RadioGroup` 多次赋予不存在的值时文字不能正常显示

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
