### PR TITLE
fix(form): scroll to first error

### DIFF
--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -105,9 +105,10 @@ export default defineComponent({
         .map((child) => child.validate(trigger, showErrorMessage));
       const arr = await Promise.all(list);
       const result = formatValidateResult(arr);
+      const firstError = getFirstError(result);
       props.onValidate?.({
         validateResult: result,
-        firstError: getFirstError(result),
+        firstError,
       });
       return result;
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#1112 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- fix(Form): 修复不传 `form.onSubmit` 回调函数导致的 `scrollToFirstError` 参数失效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
