### PR TITLE
fix(slider): fix slider inputNumber decrease value bug

### DIFF
--- a/src/slider/hooks/useSliderInput.tsx
+++ b/src/slider/hooks/useSliderInput.tsx
@@ -49,13 +49,19 @@ export const useSliderInput = (config: Ref<useSliderInputProps>) => {
   });
 
   const renderInputNumber = (val: number, changeFn: (val: number) => void) => {
+    // if exist min or max prop, onChange callback function will pass undefined value when decrease
+    const normalizeChangeFn = (num: number | undefined) => {
+      if (num && !isNaN(num)) {
+        changeFn(num);
+      }
+    };
     return (
       <InputNumber
         {...sliderInputState.value}
         class={sliderNumberClass.value}
         value={val}
         step={config.value.step}
-        onChange={changeFn}
+        onChange={normalizeChangeFn}
         disabled={config.value.disabled}
         min={config.value.min}
         max={config.value.max}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题：使用数字输入框的情况下，同时传入range和min或max其中之一的属性，手动输入某个值会导致渲染出NaN
原因：当存在min或max时，进行删减操作会导致inputNumber组件的onChange函数回传undefined值
解决办法：对于传入inputNumber的onChange函数进行一层格式化封装避免非数字回传值更新
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Slider): 使用 `InputNumber` 时在使用 `range` 属性情况下传入 `min` 或 `max` 会导致手动输入显示NaN问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
