### PR TITLE
fix(tree): 取消getRightData, 修改传入TCheckBox组件的name类型

### DIFF
--- a/src/tree/tree-item.tsx
+++ b/src/tree/tree-item.tsx
@@ -286,7 +286,7 @@ export default defineComponent({
             checked={node.checked}
             indeterminate={node.indeterminate}
             disabled={node.isDisabled()}
-            name={node.value}
+            name={node.value.toString()}
             onChange={() => handleChange()}
             ignore="expand,active"
             needRipple={true}

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -201,7 +201,7 @@ export default function useTree(props: TdTreeProps) {
     renderTreeNodeViews();
   };
 
-  // ------- 监听start -------
+  // ------ 监听start ------
 
   // data变化，重构 tree
   watch(

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -8,7 +8,7 @@ import TreeNode from '../_common/js/tree/tree-node';
 import useDefaultValue from '../hooks/useDefaultValue';
 import useVModel from '../hooks/useVModel';
 import useOnDrag from './hooks/useOnDrag';
-import { getMark, getNode, getStoreConfig, getRightData } from './util';
+import { getMark, getNode, getStoreConfig } from './util';
 
 import { TypeEventState, TypeTreeNodeModel } from './interface';
 
@@ -162,7 +162,7 @@ export default function useTree(props: TdTreeProps) {
 
   // 初始化
   const init = () => {
-    let options = getRightData(props.data, props.keys?.value);
+    let options = props.data;
     const store = new TreeStore({
       ...getStoreConfig(props),
       onLoad: (info: TypeEventState) => {
@@ -207,7 +207,7 @@ export default function useTree(props: TdTreeProps) {
   watch(
     () => props.data,
     (list) => {
-      list = getRightData(props.data, props.keys?.value);
+      list = props.data;
       cacheMap.clear();
 
       treeStore.value.reload(list);

--- a/src/tree/util.ts
+++ b/src/tree/util.ts
@@ -128,17 +128,3 @@ export const getStoreConfig = (props: TdTreeProps) => {
   ]);
   return storeProps;
 };
-
-export const getRightData = (list: TdTreeProps['data'], valueAlias: TdTreeProps['keys']['value']) => {
-  const ds = Array.isArray(list) ? list : [];
-  const key = valueAlias || 'value';
-  return ds.map((item) => {
-    if (item[key]) {
-      item[key] = item[key].toString();
-    }
-    if (item.children && Array.isArray(item.children)) {
-      item.children = getRightData(item.children, key);
-    }
-    return item;
-  });
-};


### PR DESCRIPTION
#1171

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/1171

### 💡 需求背景和解决方案

1. 问题：控制台报 props （name）类型校验失败的 warn
2. 解决办法：将 name 转换为 string 类型

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 取消修改 `value` 类型, 将传入 `TCheckBox` 组件的 `name` 转为 `string` 类型

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
