### PR TITLE
fix(slider): fix slider label prop

### DIFF
--- a/examples/slider/slider.md
+++ b/examples/slider/slider.md
@@ -7,7 +7,7 @@
 -- | -- | -- | -- | --
 disabled | Boolean | false | 是否禁用组件 | N
 inputNumberProps | Boolean / Object | false | 用于控制数字输入框组件，值为 false 表示不显示数字输入框；值为 true 表示呈现默认数字输入框；值类型为 Object 表示透传属性到数字输入框组件。TS 类型：`InputNumberProps`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/slider/type.ts) | N
-label | String / Boolean / Slot / Function | false | 滑块当前值文本。值为 true 显示默认文案，值为 false 不显示滑块当前值文本，值为 `\${value}%` 则表示组件会根据占位符渲染文案。TS 类型：`string | boolean | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+label | String | - | 滑块当前值文本。值为 `${value}%` 则表示组件会根据占位符渲染文案。 | N
 layout | String | horizontal | 滑块布局方向。可选项：vertical/horizontal | N
 marks | Object / Array | - | 刻度标记，示例：[0, 10, 40, 200] 或者 `{ 10: (val) => val + '%', 50: (h, val) => <button>{val}</button> }`。TS 类型：`Array<number> | SliderMarks`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/slider/type.ts) | N
 max | Number | 100 | 滑块范围最大值 | N

--- a/examples/slider/usage/props.json
+++ b/examples/slider/usage/props.json
@@ -12,12 +12,6 @@
     "options": []
   },
   {
-    "name": "label",
-    "type": "Boolean",
-    "defaultValue": true,
-    "options": []
-  },
-  {
     "name": "layout",
     "type": "enum",
     "defaultValue": "horizontal",

--- a/src/slider/hooks/useSliderTooltip.tsx
+++ b/src/slider/hooks/useSliderTooltip.tsx
@@ -1,6 +1,7 @@
 import { TooltipProps } from '@src/tooltip';
-import { ref, computed, ComputedRef } from 'vue';
+import { ref, computed, ComputedRef, Ref } from 'vue';
 import { TdSliderProps } from '../type';
+import { formatLabel } from '../util/common';
 
 const initialProps: TooltipProps & { overlayClassName: string } = {
   visible: false,
@@ -12,32 +13,48 @@ const initialProps: TooltipProps & { overlayClassName: string } = {
   theme: 'default',
 };
 
+export interface TooltipConfig {
+  tooltipProps: boolean | TooltipProps;
+  vertical: boolean;
+  value: number;
+  label: TdSliderProps['label'];
+}
+
 /**
  * 聚合管理滑块tooltip内容hook
  * @param tooltipProps tooltip属性配置
  * @param vertical 是否垂直展示
  * @returns
  */
-export const useSliderTooltip = (tooltipProps: boolean | TooltipProps, vertical: boolean) => {
+export const useSliderTooltip = (tooltipConfig: Ref<TooltipConfig>) => {
   const tooltipRef = ref();
-  const showTooltip = ref(!tooltipProps === false);
+  const showTooltip = computed({
+    get() {
+      return !tooltipConfig.value.tooltipProps === false;
+    },
+    set(val) {
+      return val;
+    },
+  });
   const normalizeProps = ref<TooltipProps & { overlayClassName: string }>({ ...initialProps });
-
   /** 开关显示tooltip */
   const toggleTooltip = (toState: boolean) => {
+    if (!showTooltip.value) return;
     normalizeProps.value.visible = toState;
   };
 
   /** 合并最终tooltip属性，以外部同名属性覆盖初始化属性 */
   const validProps = computed(() => {
+    const { vertical, tooltipProps, label, value } = tooltipConfig.value;
     const placement = vertical ? 'right' : 'top';
+    const content = formatLabel(label, value);
     if (tooltipProps instanceof Object) {
       if (!tooltipProps?.placement) {
         normalizeProps.value.placement = placement;
       }
-      return { ...normalizeProps.value, ...tooltipProps };
+      return { ...normalizeProps.value, ...tooltipProps, content };
     }
-    return { ...normalizeProps.value, placement };
+    return { ...normalizeProps.value, placement, content };
   });
 
   return {

--- a/src/slider/props.ts
+++ b/src/slider/props.ts
@@ -16,7 +16,7 @@ export default {
     type: [Boolean, Object] as PropType<TdSliderProps['inputNumberProps']>,
     default: false,
   },
-  /** 滑块当前值文本。值为 true 显示默认文案，值为 false 不显示滑块当前值文本，值为 `\${value}%` 则表示组件会根据占位符渲染文案 */
+  /** 滑块当前值文本。不传则默认显示当前数值，值为 `${value}%` 则表示组件会根据占位符渲染文案 */
   label: {
     type: [String, Boolean, Function] as PropType<TdSliderProps['label']>,
     default: false,

--- a/src/slider/slider-button.tsx
+++ b/src/slider/slider-button.tsx
@@ -1,5 +1,17 @@
-import { defineComponent, ComponentPublicInstance, ref, computed, reactive, nextTick, watchEffect, inject } from 'vue';
+import {
+  PropType,
+  defineComponent,
+  ComponentPublicInstance,
+  ref,
+  computed,
+  reactive,
+  nextTick,
+  watchEffect,
+  inject,
+  toRefs,
+} from 'vue';
 import TTooltip from '../tooltip/index';
+import { TdSliderProps } from './type';
 
 import { usePrefixClass } from '../hooks/useConfig';
 import { useSliderTooltip } from './hooks/useSliderTooltip';
@@ -20,14 +32,16 @@ export default defineComponent({
       type: [Boolean, Object],
       default: true,
     },
+    label: {
+      type: [String, Boolean, Function] as PropType<TdSliderProps['label']>,
+      default: false,
+    },
   },
   emits: ['input'],
   setup(props, ctx) {
     const COMPONENT_NAME = usePrefixClass('slider__button');
-    const { tooltipRef, tooltipProps, toggleTooltip, showTooltip } = useSliderTooltip(
-      props.tooltipProps,
-      props.vertical,
-    );
+    const tooltipConfig = computed(() => props);
+    const { tooltipRef, tooltipProps, toggleTooltip, showTooltip } = useSliderTooltip(tooltipConfig);
     const parentProps = inject(sliderPropsInjectKey);
     const buttonRef = ref();
 
@@ -210,9 +224,15 @@ export default defineComponent({
         onblur={handleMouseLeave}
         onKeydown={onNativeKeyDown}
       >
-        <TTooltip ref={tooltipRef} disabled={!showTooltip.value} content={String(props.value)} {...tooltipProps.value}>
-          <div class={[COMPONENT_NAME.value, { [`${COMPONENT_NAME.value}--dragging`]: slideButtonProps.dragging }]} />
-        </TTooltip>
+        {showTooltip.value ? (
+          <TTooltip ref={tooltipRef} disabled={!showTooltip.value} {...tooltipProps.value}>
+            <div class={[COMPONENT_NAME.value, { [`${COMPONENT_NAME.value}--dragging`]: slideButtonProps.dragging }]} />
+          </TTooltip>
+        ) : (
+          <div
+            class={[COMPONENT_NAME.value, { [`${COMPONENT_NAME.value}--dragging`]: slideButtonProps.dragging }]}
+          ></div>
+        )}
       </div>
     );
   },

--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -393,6 +393,7 @@ export default defineComponent({
               ref={firstButtonRef}
               disabled={disabled.value}
               tooltip-props={props.tooltipProps}
+              label={props.label}
               onInput={(v: number) => {
                 firstValue.value = v;
               }}
@@ -403,6 +404,7 @@ export default defineComponent({
                 value={secondValue.value}
                 ref={secondButtonRef}
                 disabled={disabled.value}
+                label={props.label}
                 tooltip-props={props.tooltipProps}
                 onInput={(v: number) => {
                   secondValue.value = v;

--- a/src/slider/type.ts
+++ b/src/slider/type.ts
@@ -21,10 +21,10 @@ export interface TdSliderProps {
    */
   inputNumberProps?: InputNumberProps;
   /**
-   * 滑块当前值文本。值为 true 显示默认文案，值为 false 不显示滑块当前值文本，值为 `\${value}%` 则表示组件会根据占位符渲染文案
+   * 滑块当前值文本。不传则默认显示当前数值，值为 `${value}%` 则表示组件会根据占位符渲染文案
    * @default false
    */
-  label?: string | boolean | TNode;
+  label?: string | TNode;
   /**
    * 滑块布局方向
    * @default horizontal

--- a/src/slider/util/common.ts
+++ b/src/slider/util/common.ts
@@ -1,3 +1,4 @@
+import { TNode } from '../../common';
 /**
  * 计算刻度区间值停止坐标
  * @param position 刻度坐标值 ;
@@ -25,4 +26,32 @@ export const formatSlderValue = (val: number | number[], type: 'first' | 'second
     return val[1];
   }
   return 0;
+};
+
+/**
+ * 格式化label参数
+ * @param label slider传入的label属性
+ * @param val slider传入的value
+ */
+export const formatLabel = (label: TNode | string, val: number) => {
+  if (Boolean(label) === false) {
+    return String(val);
+  }
+  if (typeof label === 'string') {
+    let text = String(val);
+    try {
+      const rule = /\${value}%/g;
+      const enableToReplace = rule.test(label);
+      if (enableToReplace) {
+        text = label.replace(rule, String(val));
+      } else {
+        text = label;
+        throw new Error();
+      }
+    } catch (e) {
+      console.warn(`fail to parse label prop, please pass string such as '\${value}%'`);
+    }
+    return text;
+  }
+  return () => label;
 };

--- a/test/unit/slider/base.test.jsx
+++ b/test/unit/slider/base.test.jsx
@@ -2,13 +2,7 @@ import { mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import { describe, expect, it } from 'vitest';
 import Slider from '@/src/slider/index.ts';
-
-const inputNumberPropsInitData = {
-  decimalPlaces: 0,
-  format: (val) => `${val}%`,
-  placeholder: '',
-  theme: 'normal',
-};
+import { formatLabel } from '@/src/slider/util/common.ts';
 
 // ui test
 describe('Slider', () => {
@@ -84,7 +78,58 @@ describe('Slider', () => {
       });
     });
     // test prop label
-    // describe(':props.label', () => {});
+    describe(':props.label', () => {
+      it('label default value is undefined', () => {
+        const testValue = Math.floor(Math.random() * 100);
+        const wrapper = mount(
+          {
+            render() {
+              return <Slider modelValue={testValue} />;
+            },
+          },
+          { attachTo: document.getElementById('#app') },
+        );
+        const sliderTooltipVm = wrapper.findComponent({ name: 'TTooltip' });
+        sliderTooltipVm.trigger('mouseenter').then((val) => {
+          const tooltipContent = sliderTooltipVm.componentVM.content;
+          expect(String(tooltipContent) === String(testValue)).toBeTruthy();
+        });
+      });
+      it(`label={string} without \${value}% works fine`, () => {
+        const testLabel = 'test label';
+        const wrapper = mount(
+          {
+            render() {
+              return <Slider label={testLabel} />;
+            },
+          },
+          { attachTo: document.getElementById('#app') },
+        );
+        const sliderTooltipVm = wrapper.findComponent({ name: 'TTooltip' });
+        sliderTooltipVm.trigger('mouseenter').then((val) => {
+          const tooltipContent = sliderTooltipVm.componentVM.content;
+          expect(String(tooltipContent) === String(testLabel)).toBeTruthy();
+        });
+      });
+      it(`label={string} with \${value}% works fine`, () => {
+        const testLabel = `label:\${value}%`;
+        const testValue = Math.floor(Math.random() * 100);
+        const wrapper = mount(
+          {
+            render() {
+              return <Slider modelValue={testValue} label={testLabel} />;
+            },
+          },
+          { attachTo: document.getElementById('#app') },
+        );
+        const sliderTooltipVm = wrapper.findComponent({ name: 'TTooltip' });
+        sliderTooltipVm.trigger('mouseenter').then((val) => {
+          const tooltipContent = sliderTooltipVm.componentVM.content;
+          const normalizeValue = formatLabel(testLabel, testValue);
+          expect(String(tooltipContent) === String(normalizeValue)).toBeTruthy();
+        });
+      });
+    });
     // test prop range
     describe(':props.range', () => {
       it('range default value is false', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
解决问题： 补充原来slider漏开发的label属性逻辑
设计思路：原文档上的label属性说明解释该属性支持`boolean`|`string`|`slot`|`function`四种类型用法，但是开发过程中发现，首先布尔值的支持就是不合理的，因为slider值的文案显示控制权已经交由`tooltipProps`来控制，因此这次去除了`boolean`的支持。另外，label支持`slot`用法也不太符合组件层级直觉，因为slider的首个嵌套子组件是内部的滑块button，如果另外开个`slot`来配置tooltip的显示内容，在层级上会稍显混乱，且过高的内容自定义控制权会影响tooltip本身的内部样式变得难以维护；再者，如果需要高度自定义tooltip的内容，代码中也留了后门可以传入`TNode`来渲染。综合考虑下来，对于slider滑块的tooltip内容显示，更多场景下是使用模版替换功能来定制数值以外的文案提示，因此前期先支持`string` 类型传入和模版替换特性已经可以满足大部分需求，也便于编写单元测试。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Slider): 修复 `label` 属性不生效 `bug`
- fix(Slider): 修复 `tooltipProps` 为布尔值时丢失响应性问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
