### PR TITLE
fix(tree): setdata interception parameters

### DIFF
--- a/test/unit/tree/treeNodeModel.test.jsx
+++ b/test/unit/tree/treeNodeModel.test.jsx
@@ -561,11 +561,11 @@ describe('Tree:treeNodeModel', () => {
       const data = [
         {
           value: 't1',
-          info: 'a',
+          label: 'a',
           children: [
             {
               value: 't1.1',
-              info: 'b',
+              label: 'b',
             },
           ],
         },
@@ -573,7 +573,7 @@ describe('Tree:treeNodeModel', () => {
       const wrapper = mount({
         methods: {
           label(createElement, node) {
-            return `${node.value}-${node.data.info}`;
+            return `${node.value}-${node.data.label}`;
           },
         },
         render() {
@@ -584,7 +584,7 @@ describe('Tree:treeNodeModel', () => {
       expect(el.text()).toBe('t1.1-b');
       const node = wrapper.vm.$refs.tree.getItem('t1.1');
       node.setData({
-        info: 'c',
+        label: 'c',
       });
       await delay(1);
       expect(el.text()).toBe('t1.1-c');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/1205
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 需求背景
使用 node.setData 时，传入错误的参数可能会导致程序崩溃。

2. 优化方案
在尽量少改动的前提下，可以在 setData 做一层拦截，至少避免因传参错误导致程序崩溃

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): `setData` 方法参数过滤保护

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
