### PR TITLE
fix(table): reset lazy load children state in map; resetData support

### DIFF
--- a/examples/table/demos/tree.vue
+++ b/examples/table/demos/tree.vue
@@ -2,7 +2,7 @@
   <div>
     <div>
       <t-button @click="appendToRoot">添加根节点</t-button>
-      <t-button theme="default" style="margin-left: 16px" @click="setData1">重置数据</t-button>
+      <t-button theme="default" style="margin-left: 16px" @click="resetData">重置数据</t-button>
       <t-button theme="default" style="margin-left: 16px" @click="onRowToggle">任意节点展开/收起</t-button>
       <t-button theme="default" style="margin-left: 16px" @click="onExpandAllToggle">{{
         expandAll ? '收起全部' : '展开全部'
@@ -130,9 +130,10 @@ const table = ref(null);
 const data = ref(getData());
 const lazyLoadingData = ref(null);
 
-const setData1 = () => {
+const resetData = () => {
   // 需要更新数据地址空间
   data.value = getData();
+  table.value.resetData(data.value);
 };
 
 const onEditClick = (row) => {

--- a/src/table/hooks/tree-store.ts
+++ b/src/table/hooks/tree-store.ts
@@ -143,6 +143,19 @@ class TableTreeStore<T extends TableRowData = TableRowData> {
       });
       return;
     }
+
+    // 懒加载处理：children 为 true，则需清空子元素在 map 中的值，而后方便重新加载
+    if (get(newRowData, keys.childrenKey) === true) {
+      const oldChildren = get(rowState.row, keys.childrenKey);
+      if (oldChildren?.length) {
+        for (let i = 0, len = oldChildren.length; i < len; i++) {
+          const rowValue = get(oldChildren[i], keys.rowKey);
+          const state = this.treeDataMap.get(rowValue);
+          state && this.treeDataMap.delete(rowValue);
+        }
+      }
+    }
+
     const currentRowIndex = rowState.rowIndex;
     rowState.row = newRowData;
     rowState.id = newRowValue;

--- a/src/table/hooks/useTreeData.tsx
+++ b/src/table/hooks/useTreeData.tsx
@@ -66,12 +66,7 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
         dataSource.value = data.value;
         return;
       }
-      let newVal = cloneDeep(data.value);
-      store.value.initialTreeStore(newVal, props.columns, rowDataKeys.value);
-      if (props.tree?.defaultExpandAll) {
-        newVal = store.value.expandAll(newVal, rowDataKeys.value);
-      }
-      dataSource.value = newVal;
+      resetData(data.value);
     },
     { immediate: true },
   );
@@ -94,6 +89,15 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
     },
     { immediate: true },
   );
+
+  function resetData(data: TableRowData[]) {
+    let newVal = cloneDeep(data);
+    store.value.initialTreeStore(newVal, props.columns, rowDataKeys.value);
+    if (props.tree?.defaultExpandAll) {
+      newVal = store.value.expandAll(newVal, rowDataKeys.value);
+    }
+    dataSource.value = newVal;
+  }
 
   function getTreeNodeStyle(level: number) {
     if (level === undefined) return;
@@ -280,5 +284,6 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
     expandAll,
     foldAll,
     getTreeNode,
+    resetData,
   };
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 树形结构，懒加载节点重置时（即调用 `setData`）没有清空子节点信息问题
- feat(Table): 树形结构，支持 `resetData` 重置整个树形结构数据

重置数据放在这个 PR 时因为，这是个很小的基础特性，不会引入任何升级相关的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
