### PR TITLE
feat(slider): add showStep prop

### DIFF
--- a/examples/slider/demos/min-and-max.vue
+++ b/examples/slider/demos/min-and-max.vue
@@ -7,7 +7,6 @@
         :max="max"
         :min="min"
         :marks="marks"
-        show-step
         :input-number-props="false"
       />
     </div>

--- a/examples/slider/demos/min-and-max.vue
+++ b/examples/slider/demos/min-and-max.vue
@@ -7,6 +7,7 @@
         :max="max"
         :min="min"
         :marks="marks"
+        show-step
         :input-number-props="false"
       />
     </div>

--- a/examples/slider/slider.md
+++ b/examples/slider/slider.md
@@ -14,6 +14,7 @@ max | Number | 100 | 滑块范围最大值 | N
 min | Number | 0 | 滑块范围最小值 | N
 range | Boolean | false | 双游标滑块 | N
 step | Number | 1 | 步长 | N
+showStep | Boolean | false | 是否显示步长刻度 | N
 tooltipProps | Object | - | 透传提示组件属性。TS 类型：`TooltipProps`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/slider/type.ts) | N
 value | Number / Array | - | 滑块值。支持语法糖 `v-model` 或 `v-model:value`。TS 类型：`SliderValue`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/slider/type.ts) | N
 defaultValue | Number / Array | - | 滑块值。非受控属性。TS 类型：`SliderValue`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/slider/type.ts) | N

--- a/src/slider/props.ts
+++ b/src/slider/props.ts
@@ -50,6 +50,11 @@ export default {
     type: Number,
     default: 1,
   },
+  /** 是否显示步长刻度 */
+  showStep: {
+    type: Boolean,
+    default: false,
+  },
   modelValue: {
     type: [Number, Array] as PropType<TdSliderProps['value']>,
     default: undefined,

--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -45,10 +45,10 @@ export default defineComponent({
     const firstButtonRef = ref<SliderButtonType>();
     const secondButtonRef = ref<SliderButtonType>();
 
-    const sliderState = reactive({
-      // TODO: 该属性应该是暴露出来的api供用户配置才对
-      showSteps: false,
-    });
+    // const sliderState = reactive({
+    //   // TODO: 该属性应该是暴露出来的api供用户配置才对
+    //   showSteps: true,
+    // });
     const firstValue = ref(formatSlderValue(sliderValue.value, 'first'));
     const secondValue = ref(formatSlderValue(sliderValue.value, 'second'));
     const dragging = ref(false);
@@ -105,7 +105,7 @@ export default defineComponent({
       return Math.max(firstValue.value, secondValue.value);
     });
     const steps = computed(() => {
-      if (!sliderState.showSteps || props.min > props.max) return [];
+      if (!props.showStep || props.min > props.max) return [];
       if (props.step === 0) {
         console.warn('[Element Warn][Slider]step should not be 0.');
         return [];
@@ -117,11 +117,12 @@ export default defineComponent({
         result.push(i * stepWidth);
       }
       if (props.range) {
-        return result.filter(
+        const r = result.filter(
           (step) =>
             step < (100 * (minValue.value - props.min)) / rangeDiff.value ||
-            props.step > (100 * (maxValue.value - props.min)) / rangeDiff.value,
+            props.step > (100 * (maxValue.value - props.max)) / rangeDiff.value,
         );
+        return r;
       }
       return result.filter((step) => step > (100 * (firstValue.value - props.min)) / rangeDiff.value);
     });
@@ -411,7 +412,7 @@ export default defineComponent({
                 }}
               />
             )}
-            {sliderState.showSteps && (
+            {props.showStep && (
               <div>
                 {steps.value.map((item, key) => (
                   <div class={`${COMPONENT_NAME.value}__stop`} key={key} style={getStopStyle(item, vertical.value)} />

--- a/src/slider/type.ts
+++ b/src/slider/type.ts
@@ -55,6 +55,10 @@ export interface TdSliderProps {
    */
   step?: number;
   /**
+   * 是否显示步长刻度
+   */
+  showStep?: boolean;
+  /**
    * 透传提示组件属性
    */
   tooltipProps?: TooltipProps;

--- a/test/unit/slider/base.test.jsx
+++ b/test/unit/slider/base.test.jsx
@@ -151,6 +151,45 @@ describe('Slider', () => {
         expect(buttons.length === 2).toBeTruthy();
       });
     });
+    // test prop showStep
+    describe(':props.showStep', () => {
+      it('showStep default value is false', async () => {
+        const wrapper = mount({
+          render() {
+            return <Slider />;
+          },
+        });
+        await nextTick();
+        const stopElements = wrapper.findAll('.t-slider__stop');
+        expect(stopElements.length <= 0).toBeTruthy();
+      });
+      it('showStep={true} works fine', async () => {
+        const wrapper = mount({
+          render() {
+            return <Slider showStep />;
+          },
+        });
+        await nextTick();
+        const stopElements = wrapper.findAll('.t-slider__stop');
+        expect(stopElements.length > 0).toBeTruthy();
+      });
+      it('showStep={true} works fine with prop.step={number}', async () => {
+        const step = Math.floor(Math.random() * 100);
+        const stepCount = 100 / step;
+        const result = [];
+        for (let i = 1; i < stepCount; i++) {
+          result.push(i);
+        }
+        const wrapper = mount({
+          render() {
+            return <Slider showStep step={step} />;
+          },
+        });
+        await nextTick();
+        const stopElements = wrapper.findAll('.t-slider__stop');
+        expect(stopElements.length === result.length).toBeTruthy();
+      });
+    });
     // test prop marks
     describe(':props.marks', () => {
       it('marks default value is empty array', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
slider内部本身早已实现了showStep的属性及其功能UI，但因为一直没有开放出来，因此内部一直以默认值false运行着。本次pr主要将该属性暴露给用户配置，并且补充对该属性表现层的单元测试及文档说明。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Slider): Slider新增showStep属性控制步长刻度值显示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
