### PR TITLE
feat: 支持原生的esm exports, 方便运行基于esm的工具运行(例如vitest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,15 @@
     "tdesign",
     "typescript"
   ],
+  "exports": {
+    ".": {
+      "import": "./es/index.mjs",
+      "require": "./lib/index-lib.js"
+    },
+    "./es/*": "./es/*",
+    "./esm/*": "./esm/*",
+    "./lib/*": "./lib/*"
+  },
   "main": "lib/index-lib.js",
   "module": "es/index.mjs",
   "typings": "es/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE :
因为esm不支持folder as module, 在使用esm时候不再支持以目录作为引用的路径,而要写完整的路径和扩展名

closed #1295

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#1295

### 💡 需求背景和解决方案

支持原生的esm，方便使用基于esm的工具

### 📝 更新日志

1、exports不支持目录作为入口，基于esm以后引用的时候的时候必须写全路径。
2、影响到`unplugin-vue-components`的tdesign resolver，因为它引用样式的方式是目录引用，需要改成全路径引用。而最新的版本，都已经默认自己去引用组件了，引用样式的sideEffect可以删除。

https://github.com/antfu/unplugin-vue-components/blob/main/src/core/resolvers/tdesign.ts

需要删除掉，请你们到`unplugin-vue-components`那里提交一个pr
```typescript
  if (importStyle === 'less')
    return `tdesign-${library}/esm/${fileName}/style`

  return `tdesign-${library}/es/${fileName}/style`
```


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
