### PR TITLE
feat(table): `validateTableData`增加`Promise`返回

### DIFF
--- a/examples/table/demos/editable-row.vue
+++ b/examples/table/demos/editable-row.vue
@@ -96,6 +96,8 @@ const onRowValidate = (params) => {
 function onValidateTableData() {
   // 执行结束后触发事件 validate
   tableRef.value.validateTableData();
+  // with async validate
+  // tableRef.value.validateTableData().then((result) => console.log(result));
 }
 
 // 表格全量数据校验反馈事件，tableRef.value.validateTableData() 执行结束后触发

--- a/examples/table/table.en-US.md
+++ b/examples/table/table.en-US.md
@@ -277,7 +277,7 @@ name | type | default | description | required
 abortEditOnEvent | Array | - | Typescript：`string[]` | N
 component | \- | - | component definition。Typescript：`ComponentType`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 onEdited | Function | - | trigger on finishing editing。Typescript：`(context: { trigger: string; newRowData: T; rowIndex: number }) => void` | N
-props | Object | - | props of `edit.component`。Typescript：`{ [key: string]: any }` | N
+props | Object / Function | - | props of `edit.component`。Typescript：`TableEditableCellProps<T> | TableEditableCellFunctionalProps<T>`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/table/type.ts) | N
 rules | Array | - | form rules。Typescript：`FormRule[]`，[Form API Documents](./form?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 showEditIcon | Boolean | true | show edit icon | N
 

--- a/examples/table/table.md
+++ b/examples/table/table.md
@@ -167,7 +167,7 @@ validate | `(context: PrimaryTableValidateContext)` | 可编辑行表格，全�
 名称 | 参数 | 返回值 | 描述
 -- | -- | -- | --
 validateRowData | `(rowValue: any)` | \- | 必需。校验行信息，校验完成后，会触发事件 `onRowValidate`。参数 `rowValue` 表示行唯一标识的值
-validateTableData | \- | \- | 必需。校验表格全部数据，校验完成后，会触发事件 `onValidate`
+validateTableData | \- | `Promise<PrimaryTableValidateContext>` | 必需。校验表格全部数据，校验完成后，会触发事件 `onValidate`，并返回校验结果。
 
 ### PrimaryTableCol
 

--- a/examples/table/table.md
+++ b/examples/table/table.md
@@ -277,7 +277,7 @@ placement | String | top-right | 列配置按钮基于表格的放置位置：�
 abortEditOnEvent | Array | - | 除了点击非自身元素退出编辑态之外，还有哪些事件退出编辑态。示例：`abortEditOnEvent: ['onChange']`。TS 类型：`string[]` | N
 component | \- | - | 组件定义，如：`Input` `Select`。对于完全自定义的组件（非组件库内的组件），组件需要支持 `value` 和 `onChange` ；如果还需要支持校验规则，则组件还需实现 `tips` 和 `status` 两个 API，实现规则可参考 `Input` 组件。TS 类型：`ComponentType`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 onEdited | Function | - | 编辑完成后，退出编辑模式时触发。TS 类型：`(context: { trigger: string; newRowData: T; rowIndex: number }) => void` | N
-props | Object | - | 透传给组件 `edit.component` 的属性。TS 类型：`{ [key: string]: any }` | N
+props | Object / Function | - | 透传给组件 `edit.component` 的属性。TS 类型：`TableEditableCellProps<T> | TableEditableCellFunctionalProps<T>`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/table/type.ts)  | N
 rules | Array | - | 校验规则。TS 类型：`FormRule[]`，[Form API Documents](./form?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 showEditIcon | Boolean | true | 是否显示编辑图标 | N
 

--- a/src/table/hooks/useEditableRow.ts
+++ b/src/table/hooks/useEditableRow.ts
@@ -6,11 +6,11 @@ import { AllValidateResult } from '../../form/type';
 import { validate } from '../../form/form-model';
 import { PrimaryTableRowEditContext, PrimaryTableRowValidateContext, TableRowData, TableErrorListMap } from '../type';
 
-const cellRuleMap = new Map<any, PrimaryTableRowEditContext<TableRowData>[]>();
-
 export type ErrorListObjectType = PrimaryTableRowEditContext<TableRowData> & { errorList: AllValidateResult[] };
 
 export default function useRowEdit(props: PrimaryTableProps) {
+  // 当前表格列校验规则
+  const cellRuleMap = new Map<any, PrimaryTableRowEditContext<TableRowData>[]>();
   // 校验不通过的错误信息，其中 key 值为 [rowValue, col.colKey].join('__')
   const errorListMap = ref<TableErrorListMap>({});
   // 处于编辑态的表格行

--- a/src/table/hooks/useEditableRow.ts
+++ b/src/table/hooks/useEditableRow.ts
@@ -72,16 +72,17 @@ export default function useRowEdit(props: PrimaryTableProps) {
   /**
    * 校验整个表格数据（对外开放方法，修改时需慎重）
    */
-  const validateTableData = () => {
+  const validateTableData = async () => {
     const promiseList = [];
     const data = props.data || [];
     for (let i = 0, len = data.length; i < len; i++) {
       const rowValue = get(data[i], props.rowKey || 'id');
       promiseList.push(validateOneRowData(rowValue));
     }
-    Promise.all(promiseList).then(() => {
-      props.onValidate?.({ result: errorListMap.value });
-    });
+    await Promise.all(promiseList);
+    const result = { result: errorListMap.value };
+    props.onValidate?.(result);
+    return result;
   };
 
   const onRuleChange = (context: PrimaryTableRowEditContext<TableRowData>) => {

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -772,6 +772,22 @@ export interface TableColumnController {
   placement?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 }
 
+/** 可编辑表格单元格props **/
+export type TableEditableCellProps<T> = { [key: string]: any };
+
+/** 可编辑表格单元格props为function时的入参 **/
+export interface TableEditableCellPropsParams<T> extends PrimaryTableCellParams<T> {
+  /**
+   * 当前编辑的表格行数据
+   */
+  editedRow: T;
+}
+
+/** 可编辑表格单元格functional props **/
+export type TableEditableCellFunctionalProps<T> = (
+  params: TableEditableCellPropsParams<T>,
+) => TableEditableCellProps<T>;
+
 export interface TableEditableCellConfig<T extends TableRowData = TableRowData> {
   /**
    * 除了点击非自身元素退出编辑态之外，还有哪些事件退出编辑态。示例：`abortEditOnEvent: ['onChange']`
@@ -788,7 +804,7 @@ export interface TableEditableCellConfig<T extends TableRowData = TableRowData> 
   /**
    * 透传给组件 `edit.component` 的属性
    */
-  props?: { [key: string]: any };
+  props?: TableEditableCellProps<T> | TableEditableCellFunctionalProps<T>;
   /**
    * 校验规则
    */

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -504,7 +504,7 @@ export interface PrimaryTableInstanceFunctions<T extends TableRowData = TableRow
   /**
    * 校验表格全部数据，校验完成后，会触发事件 `onValidate`
    */
-  validateTableData: () => void;
+  validateTableData: () => Promise<PrimaryTableValidateContext>;
 }
 
 export interface PrimaryTableCol<T extends TableRowData = TableRowData>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. `validateTableData`现在不支持同步返回结果，对于某些特殊场景，例如`form`及多个可编辑`table`同时校验通过后才能提交的场景无法满足。
2. `validateTableData`由返回`void`变为`Promise<PrimaryTableValidateContext>`
3. 可编辑表格列属性`edit.props`ts及文档介绍与实际代码不符，应为对象及方法兼容类型
4. 同时存在多个table，校验规则未独立管理，即`cellRuleMap`为全局共用map，实际使用时同时存在多个`table`组件都有校验规则时会有异常

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(table): `validateTableData`增加`Promise`返回
- fix(table): 同时存在多个table，校验规则未独立管理
- fix(table): 可编辑表格列属性edit.propsts及文档类型错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
