### PR TITLE
fix(menu): submenu beyond 8 will overflow

### DIFF
--- a/examples/menu/demos/multiple.vue
+++ b/examples/menu/demos/multiple.vue
@@ -20,6 +20,13 @@
           <t-menu-item value="1-5-1"> 子菜单1-5-1 </t-menu-item>
           <t-menu-item value="1-5-2"> 子菜单1-5-2 </t-menu-item>
           <t-menu-item value="1-5-3"> 子菜单1-5-3 </t-menu-item>
+          <t-menu-item value="1-5-4"> 子菜单1-5-4 </t-menu-item>
+          <t-menu-item value="1-5-5"> 子菜单1-5-5 </t-menu-item>
+          <t-menu-item value="1-5-6"> 子菜单1-5-6 </t-menu-item>
+          <t-menu-item value="1-5-7"> 子菜单1-5-7 </t-menu-item>
+          <t-menu-item value="1-5-8"> 子菜单1-5-8 </t-menu-item>
+          <t-menu-item value="1-5-9"> 子菜单1-5-9 </t-menu-item>
+          <t-menu-item value="1-5-10"> 子菜单1-5-10 </t-menu-item>
         </t-submenu>
       </t-submenu>
       <t-submenu value="2" title="菜单2">

--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -59,6 +59,7 @@ export default defineComponent({
       {
         [`${classPrefix.value}-is-opened`]: popupVisible.value,
       },
+      'narrow-scrollbar',
     ]);
     const submenuClass = computed(() => [
       `${classPrefix.value}-menu__item`,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

t-menu-item 大于8个将会溢出：https://github.com/Tencent/tdesign-vue-next/issues/1249

### 💡 需求背景和解决方案

1. 当 t-menu-item大于 8 个时出现滚动条 
2. 对 exapmle multiple 增加 t-menu-item  用于演示

<div>
<img src="https://user-images.githubusercontent.com/44194929/183824185-90548225-59a4-48a7-814e-5af47fd159b4.png"   width="30%"/>
</div>


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): t-menu-item 大于 8 个将会溢出

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
