### PR TITLE
feat(table): set return value type of validateRowData  to be a Promise

### DIFF
--- a/examples/table/table.en-US.md
+++ b/examples/table/table.en-US.md
@@ -43,18 +43,18 @@ tableContentWidth | String | - | \- | N
 tableLayout | String | fixed | table-layout css properties。options：auto/fixed | N
 topContent | String / Slot / Function | - | Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 verticalAlign | String | middle | vertical align。options：top/middle/bottom | N
-onCellClick | Function |  | TS 类型：`(context: BaseTableCellEventContext<T>) => void`<br/>trigger on cell clicked。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface BaseTableCellEventContext<T> { row: T; col: BaseTableCol; rowIndex: number; colIndex: number; e: MouseEvent }`<br/> | N
-onPageChange | Function |  | TS 类型：`(pageInfo: PageInfo, newDataSource: Array<T>) => void`<br/>trigger on pagination changing | N
-onRowClick | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row click。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface RowEventContext<T> { row: T; index: number; e: MouseEvent }`<br/> | N
-onRowDblclick | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on double click | N
-onRowMousedown | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row mousedown | N
-onRowMouseenter | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseenter | N
-onRowMouseleave | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseenter | N
-onRowMouseover | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseover | N
-onRowMouseup | Function |  | TS 类型：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseup | N
-onScroll | Function |  | TS 类型：`(params: { e: WheelEvent }) => void`<br/>trigger on table content scroll | N
-onScrollX | Function |  | TS 类型：`(params: { e: WheelEvent }) => void`<br/>`deprecated`。trigger on scroll horizontal | N
-onScrollY | Function |  | TS 类型：`(params: { e: WheelEvent }) => void`<br/>`deprecated`。trigger on scroll vertical | N
+onCellClick | Function |  | Typescript：`(context: BaseTableCellEventContext<T>) => void`<br/>trigger on cell clicked。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface BaseTableCellEventContext<T> { row: T; col: BaseTableCol; rowIndex: number; colIndex: number; e: MouseEvent }`<br/> | N
+onPageChange | Function |  | Typescript：`(pageInfo: PageInfo, newDataSource: Array<T>) => void`<br/>trigger on pagination changing | N
+onRowClick | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row click。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface RowEventContext<T> { row: T; index: number; e: MouseEvent }`<br/> | N
+onRowDblclick | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on double click | N
+onRowMousedown | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row mousedown | N
+onRowMouseenter | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseenter | N
+onRowMouseleave | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseenter | N
+onRowMouseover | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseover | N
+onRowMouseup | Function |  | Typescript：`(context: RowEventContext<T>) => void`<br/>trigger on row mouseup | N
+onScroll | Function |  | Typescript：`(params: { e: WheelEvent }) => void`<br/>trigger on table content scroll | N
+onScrollX | Function |  | Typescript：`(params: { e: WheelEvent }) => void`<br/>`deprecated`。trigger on scroll horizontal | N
+onScrollY | Function |  | Typescript：`(params: { e: WheelEvent }) => void`<br/>`deprecated`。trigger on scroll vertical | N
 
 ### BaseTable Events
 
@@ -126,21 +126,21 @@ defaultSort | Object / Array | - | sort configs。uncontrolled property。Typesc
 sortIcon | Slot / Function | - | sort icon。Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 sortOnRowDraggable | Boolean | false | `deprecated`。sort on row draggable | N
 `Omit<BaseTableProps<T>, 'columns' | 'onCellClick'>` | \- | - | \- | N
-onAsyncLoadingClick | Function |  | TS 类型：`(context: { status: 'loading' | 'load-more' }) => void`<br/>trigger on async loading text clicked | N
-onCellClick | Function |  | TS 类型：`(context: PrimaryTableCellEventContext<T>) => void`<br/>trigger on cell clicked。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableCellEventContext<T> { row: T; col: PrimaryTableCol; rowIndex: number; colIndex: number; e: MouseEvent }`<br/> | N
-onChange | Function |  | TS 类型：`(data: TableChangeData, context: TableChangeContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableChangeData { sorter?: TableSort; filter?: FilterValue; pagination?: PaginationProps }`<br/><br/>`interface TableChangeContext<T> { trigger: TableChangeTrigger; currentData?: T[] }`<br/><br/>`type TableChangeTrigger = 'filter' | 'sorter' | 'pagination'`<br/> | N
-onColumnChange | Function |  | TS 类型：`(context: PrimaryTableColumnChange<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableColumnChange<T> { columns?: CheckboxGroupValue; currentColumn?: PrimaryTableCol<T>; type?: 'check' | 'uncheck'; e?: Event }`<br/> | N
-onColumnControllerVisibleChange | Function |  | TS 类型：`(visible: boolean, context: { trigger: 'cancel' | 'confirm' }) => void`<br/> | N
-onDataChange | Function |  | TS 类型：`(data: Array<T>, context: TableDataChangeContext) => void`<br/>trigger on data changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableDataChangeContext { trigger: 'sort' }`<br/> | N
-onDisplayColumnsChange | Function |  | TS 类型：`(value: CheckboxGroupValue) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`import { CheckboxGroupValue } from '@Checkbox'`<br/> | N
-onDragSort | Function |  | TS 类型：`(context: DragSortContext<T>) => void`<br/>trigger on drag sort。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface DragSortContext<T> { currentIndex: number; current: T; targetIndex: number; target: T; data: T[]; newData: T[]; currentData?: T[]; e: SortableEvent; sort: 'row' | 'col' }`<br/><br/>`import { SortableEvent, SortableOptions } from 'sortablejs'`<br/> | N
-onExpandChange | Function |  | TS 类型：`(expandedRowKeys: Array<string | number>, options: ExpandOptions<T>) => void`<br/>trigger on expand row keys changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface ExpandOptions<T> { expandedRowData: Array<T> }`<br/> | N
-onFilterChange | Function |  | TS 类型：`(filterValue: FilterValue, context: { col?: PrimaryTableCol<T> }) => void`<br/>trigger on filter value changing | N
-onRowEdit | Function |  | TS 类型：`(context: PrimaryTableRowEditContext<T>) => void`<br/>trigger on row data is editing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`type PrimaryTableRowEditContext<T> = PrimaryTableCellParams<T> & { value: any }`<br/> | N
-onRowValidate | Function |  | TS 类型：`(context: PrimaryTableRowValidateContext<T>) => void`<br/>trigger after row data validated。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`type PrimaryTableRowValidateContext<T> = { result: TableRowValidateResult<T>[]; trigger: TableValidateTrigger }`<br/><br/>`type TableValidateTrigger = 'self' | 'parent'`<br/><br/>`export type TableRowValidateResult<T> = PrimaryTableCellParams<T> & { errorList: AllValidateResult[]; value: any }`<br/> | N
-onSelectChange | Function |  | TS 类型：`(selectedRowKeys: Array<string | number>, options: SelectOptions<T>) => void`<br/>trigger on select changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface SelectOptions<T> { selectedRowData: Array<T>; type: 'uncheck' | 'check'; currentRowKey?: string; currentRowData?: T }`<br/> | N
-onSortChange | Function |  | TS 类型：`(sort: TableSort, options: SortOptions<T>) => void`<br/>trigger on sort changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface SortOptions<T> { currentDataSource?: Array<T>; col: PrimaryTableCol }`<br/> | N
-onValidate | Function |  | TS 类型：`(context: PrimaryTableValidateContext) => void`<br/>trigger after row data validated。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableValidateContext { result: TableErrorListMap }`<br/><br/>`type TableErrorListMap = { [key: string]: AllValidateResult[] }`<br/> | N
+onAsyncLoadingClick | Function |  | Typescript：`(context: { status: 'loading' | 'load-more' }) => void`<br/>trigger on async loading text clicked | N
+onCellClick | Function |  | Typescript：`(context: PrimaryTableCellEventContext<T>) => void`<br/>trigger on cell clicked。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableCellEventContext<T> { row: T; col: PrimaryTableCol; rowIndex: number; colIndex: number; e: MouseEvent }`<br/> | N
+onChange | Function |  | Typescript：`(data: TableChangeData, context: TableChangeContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableChangeData { sorter?: TableSort; filter?: FilterValue; pagination?: PaginationProps }`<br/><br/>`interface TableChangeContext<T> { trigger: TableChangeTrigger; currentData?: T[] }`<br/><br/>`type TableChangeTrigger = 'filter' | 'sorter' | 'pagination'`<br/> | N
+onColumnChange | Function |  | Typescript：`(context: PrimaryTableColumnChange<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableColumnChange<T> { columns?: CheckboxGroupValue; currentColumn?: PrimaryTableCol<T>; type?: 'check' | 'uncheck'; e?: Event }`<br/> | N
+onColumnControllerVisibleChange | Function |  | Typescript：`(visible: boolean, context: { trigger: 'cancel' | 'confirm' }) => void`<br/> | N
+onDataChange | Function |  | Typescript：`(data: Array<T>, context: TableDataChangeContext) => void`<br/>trigger on data changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableDataChangeContext { trigger: 'sort' }`<br/> | N
+onDisplayColumnsChange | Function |  | Typescript：`(value: CheckboxGroupValue) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`import { CheckboxGroupValue } from '@Checkbox'`<br/> | N
+onDragSort | Function |  | Typescript：`(context: DragSortContext<T>) => void`<br/>trigger on drag sort。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface DragSortContext<T> { currentIndex: number; current: T; targetIndex: number; target: T; data: T[]; newData: T[]; currentData?: T[]; e: SortableEvent; sort: 'row' | 'col' }`<br/><br/>`import { SortableEvent, SortableOptions } from 'sortablejs'`<br/> | N
+onExpandChange | Function |  | Typescript：`(expandedRowKeys: Array<string | number>, options: ExpandOptions<T>) => void`<br/>trigger on expand row keys changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface ExpandOptions<T> { expandedRowData: Array<T> }`<br/> | N
+onFilterChange | Function |  | Typescript：`(filterValue: FilterValue, context: { col?: PrimaryTableCol<T> }) => void`<br/>trigger on filter value changing | N
+onRowEdit | Function |  | Typescript：`(context: PrimaryTableRowEditContext<T>) => void`<br/>trigger on row data is editing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`type PrimaryTableRowEditContext<T> = PrimaryTableCellParams<T> & { value: any }`<br/> | N
+onRowValidate | Function |  | Typescript：`(context: PrimaryTableRowValidateContext<T>) => void`<br/>trigger after row data validated。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`type PrimaryTableRowValidateContext<T> = { result: TableRowValidateResult<T>[]; trigger: TableValidateTrigger }`<br/><br/>`type TableValidateTrigger = 'self' | 'parent'`<br/><br/>`export type TableRowValidateResult<T> = PrimaryTableCellParams<T> & { errorList: AllValidateResult[]; value: any }`<br/> | N
+onSelectChange | Function |  | Typescript：`(selectedRowKeys: Array<string | number>, options: SelectOptions<T>) => void`<br/>trigger on select changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface SelectOptions<T> { selectedRowData: Array<T>; type: 'uncheck' | 'check'; currentRowKey?: string; currentRowData?: T }`<br/> | N
+onSortChange | Function |  | Typescript：`(sort: TableSort, options: SortOptions<T>) => void`<br/>trigger on sort changing。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface SortOptions<T> { currentDataSource?: Array<T>; col: PrimaryTableCol }`<br/> | N
+onValidate | Function |  | Typescript：`(context: PrimaryTableValidateContext) => void`<br/>trigger after row data validated。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface PrimaryTableValidateContext { result: TableErrorListMap }`<br/><br/>`type TableErrorListMap = { [key: string]: AllValidateResult[] }`<br/> | N
 
 ### PrimaryTable Events
 
@@ -195,8 +195,8 @@ beforeDragSort | Function | - | stop to drag sort。Typescript：`(context: Drag
 tree | Object | - | tree data configs。Typescript：`TableTreeConfig` | N
 treeExpandAndFoldIcon | Function | - | sort icon。Typescript：`TNode<{ type: 'expand' | 'fold' }>`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 `PrimaryTableProps<T>` | \- | - | \- | N
-onAbnormalDragSort | Function |  | TS 类型：`(context: TableAbnormalDragSortContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableAbnormalDragSortContext<T> { code: number; reason: string }`<br/> | N
-onTreeExpandChange | Function |  | TS 类型：`(context: TableTreeExpandChangeContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableTreeExpandChangeContext<T> { row: T; rowIndex: number; rowState: TableRowState<T>; trigger?: 'expand-fold-icon' }`<br/> | N
+onAbnormalDragSort | Function |  | Typescript：`(context: TableAbnormalDragSortContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableAbnormalDragSortContext<T> { code: number; reason: string }`<br/> | N
+onTreeExpandChange | Function |  | Typescript：`(context: TableTreeExpandChangeContext<T>) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts)。<br/>`interface TableTreeExpandChangeContext<T> { row: T; rowIndex: number; rowState: TableRowState<T>; trigger?: 'expand-fold-icon' }`<br/> | N
 
 ### EnhancedTable Events
 
@@ -277,7 +277,7 @@ name | type | default | description | required
 abortEditOnEvent | Array | - | Typescript：`string[]` | N
 component | \- | - | component definition。Typescript：`ComponentType`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 onEdited | Function | - | trigger on finishing editing。Typescript：`(context: { trigger: string; newRowData: T; rowIndex: number }) => void` | N
-props | Object | - | props of `edit.component`。Typescript：`{ [key: string]: any }` | N
+props | Object | - | props of `edit.component`。Typescript：`TableEditableCellProps<T>` `type TableEditableCellProps<T> = TablePlainObject | ((params: TableEditableCellPropsParams<T>) => TablePlainObject)` `interface TableEditableCellPropsParams<T> extends PrimaryTableCellParams<T> { editedRow: T }` `interface TablePlainObject{ [key: string]: any }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 rules | Array | - | form rules。Typescript：`FormRule[]`，[Form API Documents](./form?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 showEditIcon | Boolean | true | show edit icon | N
 

--- a/examples/table/table.md
+++ b/examples/table/table.md
@@ -277,7 +277,7 @@ placement | String | top-right | 列配置按钮基于表格的放置位置：�
 abortEditOnEvent | Array | - | 除了点击非自身元素退出编辑态之外，还有哪些事件退出编辑态。示例：`abortEditOnEvent: ['onChange']`。TS 类型：`string[]` | N
 component | \- | - | 组件定义，如：`Input` `Select`。对于完全自定义的组件（非组件库内的组件），组件需要支持 `value` 和 `onChange` ；如果还需要支持校验规则，则组件还需实现 `tips` 和 `status` 两个 API，实现规则可参考 `Input` 组件。TS 类型：`ComponentType`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 onEdited | Function | - | 编辑完成后，退出编辑模式时触发。TS 类型：`(context: { trigger: string; newRowData: T; rowIndex: number }) => void` | N
-props | Object | - | 透传给组件 `edit.component` 的属性。TS 类型：`{ [key: string]: any }` | N
+props | Object | - | 透传给组件 `edit.component` 的属性。TS 类型：`TableEditableCellProps<T>` `type TableEditableCellProps<T> = TablePlainObject | ((params: TableEditableCellPropsParams<T>) => TablePlainObject)` `interface TableEditableCellPropsParams<T> extends PrimaryTableCellParams<T> { editedRow: T }` `interface TablePlainObject{ [key: string]: any }`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 rules | Array | - | 校验规则。TS 类型：`FormRule[]`，[Form API Documents](./form?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/table/type.ts) | N
 showEditIcon | Boolean | true | 是否显示编辑图标 | N
 

--- a/src/table/editable-cell.tsx
+++ b/src/table/editable-cell.tsx
@@ -225,6 +225,14 @@ export default defineComponent({
       if (!isEdit.value) return;
       // @ts-ignore
       if (e.path?.includes(tableEditableCellRef.value?.$el)) return;
+      // @ts-ignore 如果点击到 Popup 复层也直接返回
+      for (let i = 0, len = e.path.length; i < len; i++) {
+        // @ts-ignore
+        const node = e.path[i];
+        if (node.classList?.value?.includes('popup__content')) {
+          return;
+        }
+      }
       const outsideAbortEvent = col.value.edit.onEdited;
       updateAndSaveAbort(outsideAbortEvent, {
         trigger: 'document',

--- a/src/table/hooks/useEditableRow.ts
+++ b/src/table/hooks/useEditableRow.ts
@@ -6,15 +6,34 @@ import { AllValidateResult } from '../../form/type';
 import { validate } from '../../form/form-model';
 import { PrimaryTableRowEditContext, TableRowData, TableErrorListMap } from '../type';
 
-const cellRuleMap = new Map<any, PrimaryTableRowEditContext<TableRowData>[]>();
-
 export type ErrorListObjectType = PrimaryTableRowEditContext<TableRowData> & { errorList: AllValidateResult[] };
+
+export interface TablePromiseErrorData {
+  errors: ErrorListObjectType[];
+  errorMap: TableErrorListMap;
+}
+
+const cellRuleMap = new Map<any, PrimaryTableRowEditContext<TableRowData>[]>();
 
 export default function useRowEdit(props: PrimaryTableProps) {
   // 校验不通过的错误信息，其中 key 值为 [rowValue, col.colKey].join('__')
   const errorListMap = ref<TableErrorListMap>({});
   // 处于编辑态的表格行
   const editableKeysMap = computed(() => getEditableKeysMap(props.editableRowKeys, props.data, props.rowKey || 'id'));
+
+  const getErrorListMapByErrors = (errors: ErrorListObjectType[]): TableErrorListMap => {
+    const errorMap: TableErrorListMap = {};
+    errors.forEach(({ row, col, errorList }) => {
+      const rowValue = get(row, props.rowKey || 'id');
+      const key = [rowValue, col.colKey].join('__');
+      if (errorList?.length) {
+        errorMap[key] = errorList;
+      } else {
+        delete errorMap[key];
+      }
+    });
+    return errorMap;
+  };
 
   // 校验一行的数据
   const validateOneRowData = (rowValue: any) => {
@@ -33,25 +52,11 @@ export default function useRowEdit(props: PrimaryTableProps) {
           });
         }),
     );
-    return new Promise<{
-      errors: ErrorListObjectType[];
-      errorMap: TableErrorListMap;
-    }>((resolve, reject) => {
+    return new Promise<TablePromiseErrorData>((resolve, reject) => {
       Promise.all(list).then((errors) => {
-        const errorMap: TableErrorListMap = { ...errorListMap.value };
-        errors.forEach(({ row, col, errorList }) => {
-          const rowValue = get(row, props.rowKey || 'id');
-          const key = [rowValue, col.colKey].join('__');
-          if (errorList?.length) {
-            errorMap[key] = errorList;
-          } else {
-            delete errorMap[key];
-          }
-        });
-        errorListMap.value = errorMap;
         resolve({
           errors: errors.filter((t) => t.errorList?.length),
-          errorMap,
+          errorMap: getErrorListMapByErrors(errors),
         });
       }, reject);
     });
@@ -61,26 +66,37 @@ export default function useRowEdit(props: PrimaryTableProps) {
    * 校验表格单行数据（对外开放方法，修改时需慎重）
    * @param rowValue 行唯一标识
    */
-  const validateRowData = (rowValue: any) => {
-    validateOneRowData(rowValue).then(({ errors }) => {
-      // 缺少校验文本显示
-      const tTrigger = 'parent';
-      props.onRowValidate?.({ trigger: tTrigger, result: errors });
+  const validateRowData = (rowValue: any) =>
+    new Promise((resolve, reject) => {
+      validateOneRowData(rowValue).then(({ errors, errorMap }) => {
+        errorListMap.value = errorMap;
+        // 缺少校验文本显示
+        const tTrigger = 'parent';
+        props.onRowValidate?.({ trigger: tTrigger, result: errors });
+        resolve({ trigger: tTrigger, result: errors });
+      }, reject);
     });
-  };
 
   /**
    * 校验整个表格数据（对外开放方法，修改时需慎重）
    */
   const validateTableData = () => {
-    const promiseList = [];
+    const promiseList: Promise<TablePromiseErrorData>[] = [];
     const data = props.data || [];
     for (let i = 0, len = data.length; i < len; i++) {
       const rowValue = get(data[i], props.rowKey || 'id');
       promiseList.push(validateOneRowData(rowValue));
     }
-    Promise.all(promiseList).then(() => {
-      props.onValidate?.({ result: errorListMap.value });
+    return new Promise((resolve, reject) => {
+      Promise.all(promiseList).then((rList) => {
+        const allErrorListMap: TableErrorListMap = {};
+        rList.forEach(({ errorMap } = { errors: [], errorMap: {} }) => {
+          errorMap && Object.assign(allErrorListMap, errorMap);
+        });
+        errorListMap.value = allErrorListMap;
+        props.onValidate?.({ result: allErrorListMap });
+        resolve({ result: allErrorListMap });
+      }, reject);
     });
   };
 

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -788,7 +788,7 @@ export interface TableEditableCellConfig<T extends TableRowData = TableRowData> 
   /**
    * 透传给组件 `edit.component` 的属性
    */
-  props?: { [key: string]: any };
+  props?: TableEditableCellProps<T>;
   /**
    * 校验规则
    */
@@ -1032,3 +1032,15 @@ export interface SwapParams<T> {
 export type FilterProps = RadioProps | CheckboxProps | InputProps | { [key: string]: any };
 
 export type FilterType = 'input' | 'single' | 'multiple';
+
+export type TableEditableCellProps<T> =
+  | TablePlainObject
+  | ((params: TableEditableCellPropsParams<T>) => TablePlainObject);
+
+export interface TableEditableCellPropsParams<T> extends PrimaryTableCellParams<T> {
+  editedRow: T;
+}
+
+export interface TablePlainObject {
+  [key: string]: any;
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 可编辑行功能，校验函数 `validateRowData` 和 `validateTableData` 返回值支持 `Promise` 对象
- fix(Table): 可编辑单元格，多选和日期选择，点击下拉浮层中的内容会导致退出编辑，[tdesign-vue-next#issue1384](https://github.com/Tencent/tdesign-vue-next/issues/1384)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
