### PR TITLE
fix(menu): submenu nuxt3 onmouseenter invalid

### DIFF
--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -298,8 +298,8 @@ export default defineComponent({
 
     if (this.mode === 'popup') {
       events = {
-        onmouseenter: this.handleMouseEnter,
-        onmouseleave: this.handleMouseLeave,
+        onMouseenter: this.handleMouseEnter,
+        onMouseleave: this.handleMouseLeave,
       };
     }
     if (Object.keys(this.$slots).length > 0) {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

[Menu]在nuxt3里面鼠标悬浮或者点击子菜单不出现 元素代码里面出现一瞬间就消失了: https://github.com/Tencent/tdesign-vue-next/issues/937

### 💡 需求背景和解决方案

详细的背景和解决方案在 issue 中有详述

### 📝 更新日志

- fix(menu): submenu nuxt3 onmouseenter invalid

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
