### PR TITLE
fix(_common): 修复slider输入框无法输入0以及刻度下移问题

### DIFF
--- a/src/slider/hooks/useSliderInput.tsx
+++ b/src/slider/hooks/useSliderInput.tsx
@@ -51,7 +51,7 @@ export const useSliderInput = (config: Ref<useSliderInputProps>) => {
   const renderInputNumber = (val: number, changeFn: (val: number) => void) => {
     // if exist min or max prop, onChange callback function will pass undefined value when decrease
     const normalizeChangeFn = (num: number | undefined) => {
-      if (num && !isNaN(num)) {
+      if (num !== undefined && !isNaN(num)) {
         changeFn(num);
       }
     };


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#1499](https://github.com/Tencent/tdesign-vue-next/issues/1449)
 [#1437](https://github.com/Tencent/tdesign-vue-next/issues/1449)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. inputNumber逻辑中判断输入值时发生了隐式转换，因此输入0时不会出发onChange。目前已特别处理
2. slider的刻度向下偏移，原因是公共样式里的样式变量未找到，导致margin-top的值无效。目前已增加了条件判断取值

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(Slider): 修复Slider输入框无法输入0问题
fix(Slider): 修复Slider刻度值下偏移问题
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
