### PR TITLE
fix: 分页情况下selectedRowData只返回本页数据的问题(#1364)

### DIFF
--- a/src/table/primary-table-props.ts
+++ b/src/table/primary-table-props.ts
@@ -4,6 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
+import { TableRowData } from './type';
 import { TdPrimaryTableProps } from '../table/type';
 import { PropType } from 'vue';
 
@@ -105,6 +106,11 @@ export default {
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制 */
   selectedRowKeys: {
     type: Array as PropType<TdPrimaryTableProps['selectedRowKeys']>,
+    default: undefined,
+  },
+  /** 选中行的数据集，非控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制 */
+  selectedRowData: {
+    type: Array as PropType<TableRowData>,
     default: undefined,
   },
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制，非受控属性 */

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -411,6 +411,11 @@ export interface TdPrimaryTableProps<T extends TableRowData = TableRowData>
    */
   selectedRowKeys?: Array<string | number>;
   /**
+   * 选中行的数据集，非控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制
+   * @default []
+   */
+  selectedRowData?: Array<TableRowData>;
+  /**
    * 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制，非受控属性
    * @default []
    */

--- a/src/table/utils.ts
+++ b/src/table/utils.ts
@@ -70,11 +70,16 @@ export function formatRowClassNames(
 }
 
 export function filterDataByIds(
-  data: Array<object> = [],
+  data: Array<TableRowData> = [],
   ids: Array<string | number> = [],
   byId = 'id',
-): Array<object> {
+): Array<TableRowData> {
   return data.filter((d: Record<string, any> = {}) => ids.includes(d[byId]));
+}
+
+export function dataDeDuplication(data: Array<TableRowData> = []): Array<TableRowData> {
+  const map = new Map();
+  return data.filter((item) => !map.has(item.id) && map.set(item.id, 1));
 }
 
 export const INNER_PRE_NAME = '@@inner-';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/1364
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
**问题原因**
问题场景出现在对 [可分页的表格-远程数据分页](https://tdesign.tencent.com/vue-next/components/table#远程数据分页) 增加可选中行的多选属性(`type: 'multiple'`)时。  
`selectChange()`返回中的`selectedRowData`，是通过用户已选中的行(`selectedRowKeys`)在`props.data`中筛选得到：
```ts
// src/table/hooks/useRowSelect.tsx
selectedRowData: filterDataByIds(props.data, selectedRowKeys, reRowKey)

// src/table/itils.ts
function filterDataByIds(
  data: Array<TableRowData> = [],
  ids: Array<string | number> = [],
  byId = 'id',
): Array<TableRowData> {
  return data.filter((d: Record<string, any> = {}) => ids.includes(d[byId]));
}
```

这种写法在`props.data`固定的情况下没有问题，但是当`props.data`变成动态的时候，`selectedRowData`就无法访问之前的`props.data`，只能显示当前页已选的数据。

**解决方案**
API props增加一个`selectedRowData`，既可以保存已选的数据，也可以方便用户绑定。

<img width="1506" alt="image" src="https://user-images.githubusercontent.com/15711610/185763580-55881b8a-f9d5-475d-927c-ae0e825c5b96.png">

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): props增加selectedRowData,修复远程数据分页只返回本页数据的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
