### PR TITLE
fix(table): 允许在表头分割线一定范围内触发列宽调整逻辑

### DIFF
--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -123,8 +123,14 @@ export default function useColumnResize(
     const onDragEnd = () => {
       if (resizeLineParams.isDragging) {
         // 结束拖拽，更新列宽
-        const width = Math.ceil(parseInt(resizeLineStyle.left, 10) - colLeft) || 0;
+        let width = Math.ceil(parseInt(resizeLineStyle.left, 10) - colLeft) || 0;
         // 为了避免精度问题，导致 width 宽度超出 [minColWidth, maxColWidth] 的范围，需要对比目标宽度和最小/最大宽度
+        if (width <= minColWidth) {
+          width = minColWidth;
+        } else if (width >= maxColWidth) {
+          width = maxColWidth;
+        }
+        // 更新列宽
         if (resizeLineParams.effectCol === 'next') {
           setThWidthListByColumnDrag(col, width, effectNextCol);
         } else if (resizeLineParams.effectCol === 'prev') {

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -26,7 +26,12 @@ export interface TheadProps {
     resizeLineRef: Ref<HTMLDivElement>;
     resizeLineStyle: CSSProperties;
     onColumnMouseover: (e: MouseEvent) => void;
-    onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>, nearCol: BaseTableCol<TableRowData>) => void;
+    onColumnMousedown: (
+      e: MouseEvent,
+      col: BaseTableCol<TableRowData>,
+      effectNextCol: BaseTableCol<TableRowData>,
+      effectPrevCol: BaseTableCol<TableRowData>,
+    ) => void;
   };
   resizable: Boolean;
 }
@@ -114,6 +119,7 @@ export default defineComponent({
                     e,
                     col,
                     index < row.length - 1 ? row[index + 1] : row[index - 1],
+                    index > 0 ? row[index - 1] : row[index + 1],
                   ),
                 onMousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e),
               }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. 鼠标hover在表头分割线上的时候也是能显示拖拽光标的

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 新增左侧判定距离，并调整对应列

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 允许在表头分割线一定范围内触发列宽调整逻辑

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
