### PR TITLE
fix: issues 0830

### DIFF
--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, computed } from 'vue';
+import omit from 'lodash/omit';
 import Panel from './components/Panel';
 import SelectInput from '../select-input';
 import FakeArrow from '../common-components/fake-arrow';
@@ -77,7 +78,7 @@ export default defineComponent({
           popupProps={{
             ...(props.popupProps as TdCascaderProps['popupProps']),
             overlayInnerStyle: panels.value.length ? { width: 'auto' } : '',
-            overlayClassName: [
+            overlayInnerClassName: [
               overlayClassName.value,
               (props.popupProps as TdCascaderProps['popupProps'])?.overlayClassName,
             ],
@@ -88,37 +89,39 @@ export default defineComponent({
             ...(props.tagInputProps as TdCascaderProps['tagInputProps']),
           }}
           tagProps={{ ...(props.tagProps as TdCascaderProps['tagProps']) }}
-          {...(props.selectInputProps as TdSelectInputProps)}
-          onInputChange={(value) => {
+          onInputChange={(value, ctx) => {
             if (!isFilterable.value) return;
             setInputVal(`${value}`);
+            (props?.selectInputProps as TdSelectInputProps)?.onInputChange?.(value, ctx);
           }}
           onTagChange={(val: CascaderValue, ctx) => {
-            if (!(val as []).length && ctx.trigger === 'clear') {
-              ctx.e?.stopPropagation();
-              closeIconClickEffect(cascaderContext.value);
-              return;
-            }
+            // 按 enter 键不处理
+            if (ctx.trigger === 'enter') return;
             handleRemoveTagEffect(cascaderContext.value, ctx.index, props.onRemove);
+            (props?.selectInputProps as TdSelectInputProps)?.onTagChange?.(val, ctx);
           }}
           onPopupVisibleChange={(val: boolean, context) => {
             if (disabled.value) return;
             setVisible(val, context);
+            (props?.selectInputProps as TdSelectInputProps)?.onPopupVisibleChange?.(val, context);
           }}
           onBlur={(val, context) => {
             props.onBlur?.({
               value: cascaderContext.value.value,
               e: context.e,
             });
+            (props?.selectInputProps as TdSelectInputProps)?.onBlur?.(val, context);
           }}
           onFocus={(val, context) => {
             props.onFocus?.({
               value: cascaderContext.value.value,
               e: context.e,
             });
+            (props?.selectInputProps as TdSelectInputProps)?.onFocus?.(val, context);
           }}
-          onClear={() => {
+          onClear={(...arg) => {
             closeIconClickEffect(cascaderContext.value);
+            (props?.selectInputProps as TdSelectInputProps)?.onClear?.(...arg);
           }}
           v-slots={{
             panel: () => (
@@ -132,7 +135,14 @@ export default defineComponent({
             ),
             collapsedItems: slots.collapsedItems,
           }}
-          {...(props.selectInputProps as TdSelectInputProps)}
+          {...omit(props.selectInputProps as TdSelectInputProps, [
+            'onTagChange',
+            'onInputChange',
+            'onPopupVisibleChange',
+            'onBlur',
+            'onFocus',
+            'onClear',
+          ])}
         />
       );
     };

--- a/src/popup/container.tsx
+++ b/src/popup/container.tsx
@@ -48,6 +48,8 @@ function observeResize(elm: HTMLElement, cb: (rect: DOMRectReadOnly) => void) {
     }
   });
 
+  if (elm.nodeType !== 1) return;
+
   ro.observe(elm);
   return function () {
     ro.unobserve(elm);
@@ -79,7 +81,7 @@ const Trigger = defineComponent({
     });
   },
   unmounted() {
-    this.cleanOR();
+    this.cleanOR?.();
   },
   render() {
     const children = filterEmpty(this.$slots.default());

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -275,7 +275,7 @@ export default defineComponent({
     );
 
     watch(
-      () => [props.overlayStyle, overlayEl.value],
+      () => [props.overlayStyle, props.overlayInnerStyle, overlayEl.value],
       () => {
         updateOverlayInnerStyle();
         updatePopper();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复在输入时 `entry` 键会默认全选第一个选项的全部内容 ([issue #1529](https://github.com/Tencent/tdesign-vue-next/issues/1529))
- fix(Cascader): 修复通过 `SelectInputProps ` 透传方法属性导致传入 `SelectInput` 的数据变成的数组 ([issue #1502](https://github.com/Tencent/tdesign-vue-next/issues/1502))
- fix(Popup): 修复 `overlayInnerStyle ` 未监听变化，增强 `container` 健壮性 ([issue #1442](https://github.com/Tencent/tdesign-vue-next/issues/1442))

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
