### PR TITLE
feat(select): 支持基础功能「全选」(#1503)

### DIFF
--- a/examples/select/select.en-US.md
+++ b/examples/select/select.en-US.md
@@ -24,12 +24,13 @@ loadingText | String / Slot / Function | - | Typescript：`string | TNode`。[se
 max | Number | 0 | \- | N
 minCollapsedNum | Number | 0 | \- | N
 multiple | Boolean | false | \- | N
-options | Array | - | Typescript：`Array<T>` | N
+options | Array | [] | Typescript：`Array<T>` | N
 panelBottomContent | String / Slot / Function | - | Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 panelTopContent | String / Slot / Function | - | Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 placeholder | String | undefined | \- | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select/type.ts) | N
-popupVisible | Boolean | - | \- | N
+popupVisible | Boolean | - | `v-model:popupVisible` is supported | N
+defaultPopupVisible | Boolean | - | uncontrolled property | N
 prefixIcon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | \- | N
 reserveKeyword | Boolean | false | \- | N

--- a/examples/select/select.md
+++ b/examples/select/select.md
@@ -24,12 +24,13 @@ loadingText | String / Slot / Function | - | 远程加载时显示的文字，�
 max | Number | 0 | 用于控制多选数量，值为 0 则不限制 | N
 minCollapsedNum | Number | 0 | 最小折叠数量，用于多选情况下折叠选中项，超出该数值的选中项折叠。值为 0 则表示不折叠 | N
 multiple | Boolean | false | 是否允许多选 | N
-options | Array | - | 数据化配置选项内容。TS 类型：`Array<T>` | N
+options | Array | [] | 数据化配置选项内容。TS 类型：`Array<T>` | N
 panelBottomContent | String / Slot / Function | - | 面板内的底部内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 panelTopContent | String / Slot / Function | - | 面板内的顶部内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 placeholder | String | undefined | 占位符 | N
 popupProps | Object | - | 透传给 popup 组件的全部属性。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select/type.ts) | N
-popupVisible | Boolean | - | 是否显示下拉框 | N
+popupVisible | Boolean | - | 是否显示下拉框。支持语法糖 `v-model:popupVisible` | N
+defaultPopupVisible | Boolean | - | 是否显示下拉框。非受控属性 | N
 prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | 只读状态，值为真会隐藏输入框，且无法打开下拉框 | N
 reserveKeyword | Boolean | false | 多选且可搜索时，是否在选中一个选项后保留当前的搜索关键词 | N

--- a/src/select/_example/multiple.vue
+++ b/src/select/_example/multiple.vue
@@ -7,6 +7,7 @@
 
     <!-- 方式二：使用 t-option 输出下拉选项。options 和 t-option 两种实现方式二选一即可 -->
     <t-select v-model="value2" placeholder="请选择云产品" multiple>
+      <t-option label="全选" :check-all="true" />
       <t-option v-for="item in options2" :key="item.value" :value="item.value" :label="item.label"></t-option>
     </t-select>
 
@@ -20,6 +21,7 @@
 import { ref } from 'vue';
 
 const options1 = [
+  { label: '全选', checkAll: true },
   { label: '架构云', value: '1' },
   { label: '大数据', value: '2' },
   { label: '区块链', value: '3' },

--- a/src/select/helper.ts
+++ b/src/select/helper.ts
@@ -15,6 +15,10 @@ export const selectInjectKey: InjectionKey<
     handlerInputChange: TdSelectProps['onInputChange'];
     handlePopupVisibleChange: TdSelectProps['onPopupVisibleChange'];
     popupContentRef: ComputedRef<HTMLElement>;
+    indeterminate: boolean;
+    isCheckAll: boolean;
+    onCheckAllChange: (checked: boolean) => void;
+    getSelectedOptions: (selectValue?: SelectValue[] | SelectValue) => TdOptionProps[];
   }>
 > = Symbol('selectProvide');
 

--- a/src/select/option-props.ts
+++ b/src/select/option-props.ts
@@ -8,6 +8,8 @@ import { TdOptionProps } from '../select/type';
 import { PropType } from 'vue';
 
 export default {
+  /** 当前选项是否为全选，全选可以在顶部，也可以在底部。点击当前选项会选中禁用态除外的全部选项，即使是分组选择器也会选中全部选项 */
+  checkAll: Boolean,
   /** 用于定义复杂的选项内容 */
   content: {
     type: [String, Function] as PropType<TdOptionProps['content']>,

--- a/src/select/props.ts
+++ b/src/select/props.ts
@@ -30,7 +30,6 @@ export default {
   /** 当下拉列表为空时显示的内容 */
   empty: {
     type: [String, Function] as PropType<TdSelectProps['empty']>,
-    default: '',
   },
   /** 自定义过滤方法，用于对现有数据进行搜索过滤，判断是否过滤某一项数据 */
   filter: {
@@ -60,7 +59,6 @@ export default {
   /** 远程加载时显示的文字，支持自定义。如加上超链接 */
   loadingText: {
     type: [String, Function] as PropType<TdSelectProps['loadingText']>,
-    default: '',
   },
   /** 用于控制多选数量，值为 0 则不限制 */
   max: {
@@ -101,6 +99,8 @@ export default {
     type: Boolean,
     default: undefined,
   },
+  /** 是否显示下拉框，非受控属性 */
+  defaultPopupVisible: Boolean,
   /** 组件前置图标 */
   prefixIcon: {
     type: Function as PropType<TdSelectProps['prefixIcon']>,
@@ -179,7 +179,7 @@ export default {
   },
   /** 输入框失去焦点时触发 */
   onBlur: Function as PropType<TdSelectProps['onBlur']>,
-  /** 选中值变化时触发，`context. trigger` 表示触发变化的来源 */
+  /** 选中值变化时触发，`context.trigger` 表示触发变化的来源，`context.selectedOptions` 表示选中值的完整对象 */
   onChange: Function as PropType<TdSelectProps['onChange']>,
   /** 点击清除按钮时触发 */
   onClear: Function as PropType<TdSelectProps['onClear']>,

--- a/src/select/select.en-US.md
+++ b/src/select/select.en-US.md
@@ -24,12 +24,13 @@ loadingText | String / Slot / Function | - | Typescript：`string | TNode`。[se
 max | Number | 0 | \- | N
 minCollapsedNum | Number | 0 | \- | N
 multiple | Boolean | false | \- | N
-options | Array | - | Typescript：`Array<T>` | N
+options | Array | [] | Typescript：`Array<T>` | N
 panelBottomContent | String / Slot / Function | - | Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 panelTopContent | String / Slot / Function | - | Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 placeholder | String | undefined | \- | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select/type.ts) | N
-popupVisible | Boolean | - | \- | N
+popupVisible | Boolean | - | `v-model:popupVisible` is supported | N
+defaultPopupVisible | Boolean | - | uncontrolled property | N
 prefixIcon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | \- | N
 reserveKeyword | Boolean | false | \- | N

--- a/src/select/select.md
+++ b/src/select/select.md
@@ -24,12 +24,13 @@ loadingText | String / Slot / Function | - | 远程加载时显示的文字，�
 max | Number | 0 | 用于控制多选数量，值为 0 则不限制 | N
 minCollapsedNum | Number | 0 | 最小折叠数量，用于多选情况下折叠选中项，超出该数值的选中项折叠。值为 0 则表示不折叠 | N
 multiple | Boolean | false | 是否允许多选 | N
-options | Array | - | 数据化配置选项内容。TS 类型：`Array<T>` | N
+options | Array | [] | 数据化配置选项内容。TS 类型：`Array<T>` | N
 panelBottomContent | String / Slot / Function | - | 面板内的底部内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 panelTopContent | String / Slot / Function | - | 面板内的顶部内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 placeholder | String | undefined | 占位符 | N
 popupProps | Object | - | 透传给 popup 组件的全部属性。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select/type.ts) | N
-popupVisible | Boolean | - | 是否显示下拉框 | N
+popupVisible | Boolean | - | 是否显示下拉框。支持语法糖 `v-model:popupVisible` | N
+defaultPopupVisible | Boolean | - | 是否显示下拉框。非受控属性 | N
 prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | 只读状态，值为真会隐藏输入框，且无法打开下拉框 | N
 reserveKeyword | Boolean | false | 多选且可搜索时，是否在选中一个选项后保留当前的搜索关键词 | N

--- a/src/select/type.ts
+++ b/src/select/type.ts
@@ -46,12 +46,10 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
   creatable?: boolean;
   /**
    * 是否禁用组件
-   * @default false
    */
   disabled?: boolean;
   /**
    * 当下拉列表为空时显示的内容
-   * @default ''
    */
   empty?: string | TNode;
   /**
@@ -60,7 +58,6 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
   filter?: (filterWords: string, option: T) => boolean | Promise<boolean>;
   /**
    * 是否可搜索
-   * @default false
    */
   filterable?: boolean;
   /**
@@ -86,7 +83,6 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
   loading?: boolean;
   /**
    * 远程加载时显示的文字，支持自定义。如加上超链接
-   * @default ''
    */
   loadingText?: string | TNode;
   /**
@@ -129,6 +125,10 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
    * 是否显示下拉框
    */
   popupVisible?: boolean;
+  /**
+   * 是否显示下拉框，非受控属性
+   */
+  defaultPopupVisible?: boolean;
   /**
    * 组件前置图标
    */
@@ -203,11 +203,11 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
    */
   onBlur?: (context: { value: SelectValue; e: FocusEvent | KeyboardEvent }) => void;
   /**
-   * 选中值变化时触发，`context. trigger` 表示触发变化的来源
+   * 选中值变化时触发，`context.trigger` 表示触发变化的来源，`context.selectedOptions` 表示选中值的完整对象
    */
   onChange?: (
     value: SelectValue,
-    context: { trigger: SelectValueChangeTrigger; e?: MouseEvent | KeyboardEvent },
+    context: { selectedOptions: T[]; trigger: SelectValueChangeTrigger; e?: MouseEvent | KeyboardEvent },
   ) => void;
   /**
    * 点击清除按钮时触发
@@ -248,6 +248,11 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
 }
 
 export interface TdOptionProps {
+  /**
+   * 当前选项是否为全选，全选可以在顶部，也可以在底部。点击当前选项会选中禁用态除外的全部选项，即使是分组选择器也会选中全部选项
+   * @default false
+   */
+  checkAll?: boolean;
   /**
    * 用于定义复杂的选项内容
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/1503
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
需求背景：
期望实现类似 Checkbox 组件一样的全选功能，支持两种写法。
```html
<!-- 方式一 -->
<t-select v-model="value1" :options="options1" placeholder="请选择云解决方案" multiple />

<!-- 方式二  -->
<t-select v-model="value2" placeholder="请选择云产品" multiple>
  <t-option label="全选" :check-all="true" />
  <t-option v-for="item in options2" :key="item.value" :value="item.value" :label="item.label"></t-option>
</t-select>
```

```ts
const options1 = [
  { label: '全选', checkAll: true },
  { label: '架构云', value: '1' },
  { label: '大数据', value: '2' },
  { label: '区块链', value: '3' },
  { label: '物联网', value: '4', disabled: true },
  { label: '人工智能', value: '5' },
];
```

解决方案：
参考`checkbox-group`组件，计算全选、半选状态。


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Select): 支持基础功能「全选」([issue #1503](https://github.com/Tencent/tdesign-vue-next/issues/1503))
- feat(Select): `change` 事件回掉函数增加选中 `option` 参数


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供