### PR TITLE
fix(hooks): vm redundant paramters

### DIFF
--- a/src/hooks/useDefaultValue.ts
+++ b/src/hooks/useDefaultValue.ts
@@ -20,7 +20,7 @@ export default function useDefaultValue<T, P extends (...args: any) => void>(
     return [
       value,
       (newValue, ...args) => {
-        vProps[`onUpdate:${propsName}`] && emit(`update:${propsName}`, newValue, ...args);
+        emit(`update:${propsName}`, newValue);
         onChange?.(newValue, ...args);
       },
     ];

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -23,7 +23,7 @@ export default function useVModel<T, P extends (...args: any) => void>(
     return [
       modelValue,
       (newValue, ...args) => {
-        vProps['onUpdate:modelValue'] && emit('update:modelValue', newValue, ...args);
+        emit('update:modelValue', newValue);
         onChange?.(newValue, ...args);
       },
     ];
@@ -33,7 +33,7 @@ export default function useVModel<T, P extends (...args: any) => void>(
     return [
       value,
       (newValue, ...args) => {
-        vProps[`onUpdate:${propName}`] && emit(`update:${propName}`, newValue, ...args);
+        emit(`update:${propName}`, newValue);
         onChange?.(newValue, ...args);
       },
     ];


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

input 组件使用v-model.trim会将内容清空Bug： https://github.com/Tencent/tdesign-vue-next/issues/1699

### 💡 需求背景和解决方案

解决背景见 issue

### 📝 更新日志

- fix(Hooks):  修复使用 `v-model.trim` 会将内容清空的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
