### PR TITLE
feat(menu): render `<a>` tag when href prop

### DIFF
--- a/src/menu/menu-item.tsx
+++ b/src/menu/menu-item.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, inject, onMounted, ref } from 'vue';
+import { defineComponent, computed, inject, onMounted, ref, toRefs } from 'vue';
 import props from './menu-item-props';
 import { TdMenuInterface, TdSubMenuInterface } from './const';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
@@ -11,6 +11,7 @@ export default defineComponent({
   props: { ...props },
   emits: ['click'],
   setup(props, ctx) {
+    const { href, target = '_self' } = toRefs(props);
     const classPrefix = usePrefixClass();
     const menu = inject<TdMenuInterface>('TdMenu');
     const itemRef = ref<HTMLElement>();
@@ -38,16 +39,17 @@ export default defineComponent({
       active,
       classes,
       itemRef,
+      href,
+      target,
     };
   },
   methods: {
-    handleClick() {
+    handleClick(e: MouseEvent) {
+      e.stopPropagation();
       if (this.disabled) return;
       this.menu.select(this.value);
       emitEvent(this, 'click');
-      if (this.href) {
-        window.open(this.href, this.target);
-      } else if (this.to) {
+      if (this.to) {
         const router = this.router || this.$router;
         const methods: string = this.replace ? 'replace' : 'push';
         router[methods](this.to).catch((err: Error) => {
@@ -68,7 +70,13 @@ export default defineComponent({
     return (
       <li ref="itemRef" class={this.classes} onClick={this.handleClick}>
         {renderTNodeJSX(this, 'icon')}
-        <span class={[`${this.classPrefix}-menu__content`]}>{renderContent(this, 'default', 'content')}</span>
+        {this.href ? (
+          <a href={this.href} target={this.target} className={`${this.classPrefix}-menu__item-link`}>
+            <span className={`${this.classPrefix}-menu__content`}>{renderContent(this, 'default', 'content')}</span>
+          </a>
+        ) : (
+          <span class={[`${this.classPrefix}-menu__content`]}>{renderContent(this, 'default', 'content')}</span>
+        )}
       </li>
     );
   },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/1671

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Menu): 如果存在链接参数，默认使用标签 `<a>` ([issue #1671](https://github.com/Tencent/tdesign-vue-next/issues/1671))

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
