### PR TITLE
fix(Tree): expand and checkable status conflict

### DIFF
--- a/src/tree-select/_example/base.vue
+++ b/src/tree-select/_example/base.vue
@@ -24,6 +24,7 @@ const options = [
   {
     label: '江苏省',
     value: 'jiangsu',
+    disabled: true,
     children: [
       {
         label: '南京市',

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -191,7 +191,9 @@ export default defineComponent({
       valueParam: Array<TreeNodeValue>,
       context: { node: TreeNodeModel<TreeOptionData>; e: MouseEvent },
     ) => {
-      setInnerVisible(false);
+      if (!props.multiple) {
+        setInnerVisible(false);
+      }
       // 多选模式屏蔽 Active 事件
       if (props.multiple) {
         return;
@@ -435,7 +437,7 @@ export default defineComponent({
             >
               <p
                 v-show={props.loading && !tDisabled.value}
-                class={`${classPrefix.value}-select-loading-tips ${classPrefix.value}-select__right-icon-polyfill`}
+                class={[`${classPrefix.value}-select-loading-tips`, `${classPrefix.value}-select__right-icon-polyfill`]}
               >
                 {renderDefaultTNode('loadingText', {
                   defaultNode: <div class={`${classPrefix.value}-select__empty`}>{globalConfig.value.loadingText}</div>,

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -50,12 +50,12 @@ export default function useTree(props: TdTreeProps) {
     const { expandOnClickNode } = props;
     const { mouseEvent, event, node } = state;
 
-    if (!node || props.disabled || node.disabled) {
+    if (!node) {
       return;
     }
 
     let shouldExpand = expandOnClickNode;
-    let shouldActive = true;
+    let shouldActive = !props.disabled && !node.disabled;
     ['trigger', 'ignore'].forEach((markName) => {
       const mark = getMark(markName, event.target as HTMLElement, event.currentTarget as HTMLElement);
       const markValue = mark?.value || '';

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -53,7 +53,6 @@ export default function useTree(props: TdTreeProps) {
     if (!node) {
       return;
     }
-
     let shouldExpand = expandOnClickNode;
     let shouldActive = !props.disabled && !node.disabled;
     ['trigger', 'ignore'].forEach((markName) => {
@@ -63,7 +62,7 @@ export default function useTree(props: TdTreeProps) {
         if (markName === 'trigger') {
           shouldExpand = true;
         } else if (markName === 'ignore') {
-          shouldExpand = false;
+          // shouldExpand = false;
         }
       }
       if (markValue.indexOf('active') >= 0) {
@@ -121,7 +120,15 @@ export default function useTree(props: TdTreeProps) {
         if (!nodeView) {
           // 初次仅渲染可显示的节点
           // 不存在节点视图，则创建该节点视图并插入到当前位置
-          nodeView = <TreeItem key={node.value} node={node} onChange={handleChange} onClick={handleClick} />;
+          nodeView = (
+            <TreeItem
+              key={node.value}
+              node={node}
+              onChange={handleChange}
+              onClick={handleClick}
+              expandOnClickNode={props.expandOnClickNode}
+            />
+          );
           cacheMap.set(node.value, nodeView);
         }
         return nodeView;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/issues/1738
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TreeSelect): 修复多选状态下点击选项直接关闭面板的问题
- fix(Tree): 修复`expandOnClickNode`与`checkable`冲突的问题
- fix(Tree): 修复`disabled`状态下无法展开子选项的错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
