### PR TITLE
fix(table): 当禁用resizable时，表格默认使用用户定义的列宽

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -320,13 +320,14 @@ export default defineComponent({
     }
     const defaultColWidth = this.tableLayout === 'fixed' && this.isWidthOverflow ? '100px' : undefined;
 
-    const renderColGroup = () => (
+    const renderColGroup = (isAffixHeader = true) => (
       <colgroup>
         {columns.map((col) => {
           const style: Styles = {
             width:
-              formatCSSUnit((columnResizable ? this.thWidthList[col.colKey] : undefined) || col.width) ||
-              defaultColWidth,
+              formatCSSUnit(
+                (isAffixHeader || columnResizable ? this.thWidthList[col.colKey] : undefined) || col.width,
+              ) || defaultColWidth,
           };
           if (col.minWidth) {
             style.minWidth = formatCSSUnit(col.minWidth);
@@ -420,7 +421,7 @@ export default defineComponent({
         class={['scrollbar', { [this.tableBaseClass.affixedHeaderElm]: this.headerAffixedTop || this.isVirtual }]}
       >
         <table class={this.tableElmClasses} style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}>
-          {renderColGroup()}
+          {renderColGroup(true)}
           <THead v-slots={this.$slots} {...headProps} />
         </table>
       </div>
@@ -458,7 +459,7 @@ export default defineComponent({
         >
           <table class={this.tableElmClasses} style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}>
             {/* 此处和 Vue2 不同，Vue3 里面必须每一处单独写 <colgroup> */}
-            {renderColGroup()}
+            {renderColGroup(true)}
             <TFoot
               rowKey={this.rowKey}
               v-slots={this.$slots}
@@ -518,7 +519,7 @@ export default defineComponent({
         {this.isVirtual && <div class={this.virtualScrollClasses.cursor} style={virtualStyle} />}
 
         <table ref="tableElmRef" class={this.tableElmClasses} style={this.tableElementStyles}>
-          {renderColGroup()}
+          {renderColGroup(false)}
           {this.showHeader && (
             <THead v-slots={this.$slots} {...{ ...headProps, thWidthList: columnResizable ? this.thWidthList : {} }} />
           )}

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -324,7 +324,9 @@ export default defineComponent({
       <colgroup>
         {columns.map((col) => {
           const style: Styles = {
-            width: formatCSSUnit(this.thWidthList[col.colKey] || col.width) || defaultColWidth,
+            width:
+              formatCSSUnit((columnResizable ? this.thWidthList[col.colKey] : undefined) || col.width) ||
+              defaultColWidth,
           };
           if (col.minWidth) {
             style.minWidth = formatCSSUnit(col.minWidth);
@@ -517,7 +519,9 @@ export default defineComponent({
 
         <table ref="tableElmRef" class={this.tableElmClasses} style={this.tableElementStyles}>
           {renderColGroup()}
-          {this.showHeader && <THead v-slots={this.$slots} {...headProps} />}
+          {this.showHeader && (
+            <THead v-slots={this.$slots} {...{ ...headProps, thWidthList: columnResizable ? this.thWidthList : {} }} />
+          )}
           <TBody v-slots={this.$slots} {...tableBodyProps} />
           <TFoot
             v-slots={this.$slots}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/1934

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 增加判断，在resizable为false时，表格本体忽略thWidthList的传值

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 当禁用resizable时，表格默认使用用户定义的列宽

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
