### PR TITLE
fix(Input): auto width in display: none

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -43,7 +43,7 @@ export default defineComponent({
     },
   },
 
-  setup(props, { slots, expose }) {
+  setup(props, { expose }) {
     const { globalConfig } = useConfig('input');
     const { BrowseIcon, BrowseOffIcon, CloseCircleFilledIcon } = useGlobalIcon({
       BrowseIcon: TdBrowseIcon,
@@ -61,7 +61,6 @@ export default defineComponent({
       isHover,
       tStatus,
       inputRef,
-      inputPreRef,
       renderType,
       showClear,
       focused,
@@ -70,7 +69,9 @@ export default defineComponent({
       limitNumber,
       ...inputHandle
     } = useInput(props, expose);
-    useInputWidth(props, inputPreRef, inputRef, innerValue);
+
+    const { inputPreRef } = useInputWidth(props, inputRef, innerValue);
+
     const inputEventHandler = useInputEventHandler(props, isHover, innerValue);
 
     const tPlaceholder = computed(() => props.placeholder ?? globalConfig.value.placeholder);

--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -146,7 +146,15 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
   watch(
     innerValue,
     (v) => {
-      inputValue.value = v;
+      const { format } = props;
+      if (format) {
+        const r = format(innerValue.value);
+        if (inputValue.value !== r) {
+          inputValue.value = r;
+        }
+      } else {
+        inputValue.value = v;
+      }
     },
     { immediate: true },
   );

--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -1,4 +1,4 @@
-import { ref, computed, watch, nextTick, toRefs, inject } from 'vue';
+import { ref, onMounted, computed, watch, nextTick, toRefs, inject, onBeforeMount } from 'vue';
 import { InputValue, TdInputProps } from './type';
 import { FormItemInjectionKey } from '../form/const';
 import useVModel from '../hooks/useVModel';
@@ -23,7 +23,6 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
   const focused = ref(false);
   const renderType = ref(props.type);
   const inputRef = ref<HTMLInputElement>(null);
-  const inputPreRef = ref(null);
 
   const limitParams = computed(() => ({
     value: innerValue.value === undefined ? undefined : String(innerValue.value),
@@ -193,6 +192,5 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
     emitClear,
     onClearIconMousedown,
     innerValue,
-    inputPreRef,
   };
 }

--- a/src/pagination/usePaginationClasses.ts
+++ b/src/pagination/usePaginationClasses.ts
@@ -1,4 +1,5 @@
 import { computed, Ref } from 'vue';
+import { getIEVersion } from '../_common/js/utils/helper';
 import { useCommonClassName } from '../hooks/useConfig';
 import { TdPaginationProps } from './type';
 
@@ -20,6 +21,7 @@ export default function usePaginationClasses(
     SIZE.value[props.size],
     {
       [STATUS.value.disabled]: props.disabled,
+      [`${name.value}-ie`]: getIEVersion() < 11,
     },
   ]);
 

--- a/src/table/tr.tsx
+++ b/src/table/tr.tsx
@@ -24,6 +24,7 @@ import baseTableProps from './base-table-props';
 import useLazyLoad from './hooks/useLazyLoad';
 import { RowAndColFixedPosition } from './interface';
 import { getCellKey, SkipSpansValue } from './hooks/useRowspanAndColspan';
+import { TooltipProps } from '../tooltip';
 
 export interface RenderTdExtra {
   rowAndColFixedPosition: RowAndColFixedPosition;
@@ -237,7 +238,7 @@ export default defineComponent({
   methods: {
     renderEllipsisCell(cellParams: BaseTableCellParams<TableRowData>, params: RenderEllipsisCellParams) {
       const { cellNode } = params;
-      const { col } = cellParams;
+      const { col, colIndex } = cellParams;
       let content = isFunction(col.ellipsis) ? col.ellipsis(h, cellParams) : undefined;
       if (typeof col.ellipsis === 'object' && isFunction(col.ellipsis.content)) {
         content = col.ellipsis.content(h, cellParams);
@@ -247,9 +248,11 @@ export default defineComponent({
         tooltipProps = 'props' in col.ellipsis ? col.ellipsis.props : col.ellipsis || undefined;
       }
       const tableElement = this.tableElm as HTMLDivElement;
+      let placement: TooltipProps['placement'] = colIndex === 0 ? 'top-left' : 'top';
+      placement = colIndex === this.columns.length - 1 ? 'top-right' : placement;
       return (
         <TEllipsis
-          placement={'top'}
+          placement={placement}
           attach={tableElement ? () => tableElement : undefined}
           tooltipContent={content && (() => content)}
           tooltipProps={tooltipProps}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 默认值 `format` 失效问题，[issue#1964](https://github.com/Tencent/tdesign-vue-next/issues/1964)
- fix(Input): 修复在输入框进行预渲染处于 `display: none` 状态时，宽度计算不正确问题，[tdesign-vue#1678](https://github.com/Tencent/tdesign-vue/issues/1678)
- feat(Table): 优化超出省略场景，浮层默认出现位置 `placement`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
