### PR TITLE
fix: popconfirm describe text color

### DIFF
--- a/src/popconfirm/_example/describe.vue
+++ b/src/popconfirm/_example/describe.vue
@@ -25,5 +25,6 @@
 .describe {
   margin-top: 8px;
   font-size: 12px;
+  color: var(--td-text-color-secondary);
 }
 </style>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[#251](https://github.com/Tencent/tdesign/issues/251)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
带有描述文案的demo气泡框里描述字体的颜色不对
<img width="395" alt="image" src="https://user-images.githubusercontent.com/49859520/201526022-b6baf750-1f61-4a6d-aa5f-855bea9c0540.png">

解决方案：
只改了demo里describe.vue中的类describe，加了颜色设置，修改后：
<img width="326" alt="image" src="https://user-images.githubusercontent.com/49859520/201526070-834ddfc8-bc0f-4ac6-92cf-6b863397d4cb.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(PopConfirm): 修复官网 `demo` 气泡框描述文案字体颜色 ([#251](https://github.com/Tencent/tdesign/issues/251))

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
