### PR TITLE
fix(menu): 初始化时维护menu数据

### DIFF
--- a/src/menu/head-menu.tsx
+++ b/src/menu/head-menu.tsx
@@ -1,4 +1,17 @@
-import { defineComponent, computed, provide, ref, reactive, watch, onMounted, watchEffect, toRefs, h } from 'vue';
+import {
+  defineComponent,
+  computed,
+  provide,
+  ref,
+  reactive,
+  watch,
+  onMounted,
+  watchEffect,
+  toRefs,
+  h,
+  VNode,
+  Component,
+} from 'vue';
 import { EllipsisIcon } from 'tdesign-icons-vue-next';
 import log from '../_common/js/log/log';
 import props from './head-menu-props';
@@ -187,6 +200,23 @@ export default defineComponent({
       }
       return slot;
     };
+
+    const initVMenu = (slots: VNode[], parentValue?: string) => {
+      slots.forEach((node) => {
+        const nodeValue = node.props?.value;
+        if ((node.type as Component)?.name === 'TSubmenu' || (node.type as Component)?.name === 'TMenuItem') {
+          vMenu.add({ value: nodeValue, parent: parentValue, vnode: (node.children as any).default });
+        }
+        if (typeof (node.children as any)?.default === 'function') {
+          initVMenu((node.children as any).default(), nodeValue);
+          return;
+        }
+        if (Array.isArray(node.children)) {
+          initVMenu(node.children as VNode[], nodeValue);
+        }
+      });
+    };
+    initVMenu(ctx.slots.default?.() || ctx.slots.content?.() || []);
 
     return () => {
       const logo = props.logo?.(h) || ctx.slots.logo?.();


### PR DESCRIPTION
closed #1810

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#1810
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): 修复多层收纳导航 `head-menu` 默认未激活([issue 1810](https://github.com/Tencent/tdesign-vue-next/issues/1810))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
