### PR TITLE
fix(Guide): relative element position incorrect

### DIFF
--- a/src/guide/guide.tsx
+++ b/src/guide/guide.tsx
@@ -44,8 +44,6 @@ export default defineComponent({
     const referenceLayerRef = ref<HTMLElement>();
     // 当前高亮的元素
     const currentHighlightLayerElm = ref<HTMLElement>();
-    // 下一个高亮的元素
-    const nextHighlightLayerElm = ref<HTMLElement>();
     // dialog wrapper ref
     const dialogWrapperRef = ref<HTMLElement>();
     // dialog ref
@@ -66,8 +64,9 @@ export default defineComponent({
 
     // 设置高亮层的位置
     const setHighlightLayerPosition = (highlighLayer: HTMLElement) => {
-      let { top, left } = getRelativePosition(nextHighlightLayerElm.value, currentHighlightLayerElm.value);
-      let { width, height } = nextHighlightLayerElm.value.getBoundingClientRect();
+      // 这里预留了一个相对元素的功能，暂未使用，也是这里导致了 fix #2111
+      let { top, left } = getRelativePosition(currentHighlightLayerElm.value);
+      let { width, height } = currentHighlightLayerElm.value.getBoundingClientRect();
       const highlightPadding = getCurrentCrossProps('highlightPadding');
 
       if (isPopup.value) {
@@ -90,15 +89,12 @@ export default defineComponent({
     };
 
     const showPopupGuide = () => {
-      const currentElement = getTargetElm(currentStepInfo.value.element);
-      nextHighlightLayerElm.value = currentElement;
-
       nextTick(() => {
-        scrollToParentVisibleArea(nextHighlightLayerElm.value);
+        currentHighlightLayerElm.value = getTargetElm(currentStepInfo.value.element);
+        scrollToParentVisibleArea(currentHighlightLayerElm.value);
         setHighlightLayerPosition(highlightLayerRef.value);
         setHighlightLayerPosition(referenceLayerRef.value);
-        scrollToElm(nextHighlightLayerElm.value);
-        currentHighlightLayerElm.value = currentElement;
+        scrollToElm(currentHighlightLayerElm.value);
       });
     };
 
@@ -108,12 +104,10 @@ export default defineComponent({
 
     const showDialogGuide = () => {
       nextTick(() => {
-        const currentElement = dialogTooltipRef.value;
-        nextHighlightLayerElm.value = currentElement;
-        scrollToParentVisibleArea(nextHighlightLayerElm.value);
+        currentHighlightLayerElm.value = dialogTooltipRef.value;
+        scrollToParentVisibleArea(currentHighlightLayerElm.value);
         setHighlightLayerPosition(highlightLayerRef.value);
-        scrollToElm(nextHighlightLayerElm.value);
-        currentHighlightLayerElm.value = currentElement;
+        scrollToElm(currentHighlightLayerElm.value);
       });
     };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

fix: #2111 

### 💡 需求背景和解决方案

之前的设计存在一个 bug，当相对元素的 `position` 为 `relative` 且非 `body` 时，会基于相对元素获取引导框的位置，这里其实是有问题的，相对元素不应该是前一个引导框，而应该是用户设置的（一般不会设置，默认为 `document.body`），针对此进行了修复

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Guide): relative element position incorrect

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
