### PR TITLE
feat(table): support expand tree node onRowClick

### DIFF
--- a/src/table/_example/tree-select.vue
+++ b/src/table/_example/tree-select.vue
@@ -28,10 +28,12 @@
       :tree="{
         childrenKey: 'childrenList',
         checkStrictly: checkStrictly === 'true' ? true : false,
+        expandTreeNodeOnClick: true,
       }"
       :selected-row-keys="selectedRowKeys"
       @expand-change="onExpandChange"
       @select-change="rehandleSelectChange"
+      @row-click="onRowClick"
     />
   </div>
 </template>
@@ -152,5 +154,9 @@ const getTreeExpandedRow = () => {
   console.log('全部行信息：', treeExpandedRowState);
 
   MessagePlugin.success('获取成功，请打开控制台查看');
+};
+
+const onRowClick = (data) => {
+  console.log(data);
 };
 </script>

--- a/src/table/enhanced-table.tsx
+++ b/src/table/enhanced-table.tsx
@@ -3,7 +3,7 @@ import baseTableProps from './base-table-props';
 import primaryTableProps from './primary-table-props';
 import enhancedTableProps from './enhanced-table-props';
 import PrimaryTable from './primary-table';
-import { TdEnhancedTableProps, PrimaryTableCol, TableRowData, DragSortContext } from './type';
+import { TdEnhancedTableProps, PrimaryTableCol, TableRowData, DragSortContext, TdPrimaryTableProps } from './type';
 import useTreeData from './hooks/useTreeData';
 import useTreeSelect from './hooks/useTreeSelect';
 
@@ -58,6 +58,19 @@ export default defineComponent({
       props.onDragSort?.(params);
     };
 
+    const onEnhancedTableRowClick: TdPrimaryTableProps['onRowClick'] = (p) => {
+      if (props.tree?.expandTreeNodeOnClick) {
+        treeInstanceFunctions.toggleExpandData(
+          {
+            row: p.row,
+            rowIndex: p.index,
+          },
+          'row-click',
+        );
+      }
+      props.onRowClick?.(p);
+    };
+
     context.expose({
       store: store.value,
       dataSource: dataSource.value,
@@ -78,8 +91,9 @@ export default defineComponent({
 
     return () => {
       const { vnode } = getCurrentInstance();
-      const enhancedProps = {
+      const enhancedProps: TdPrimaryTableProps = {
         ...vnode.props,
+        rowKey: props.rowKey || 'id',
         data: dataSource.value,
         columns: tColumns.value,
         // 半选状态节点
@@ -89,7 +103,10 @@ export default defineComponent({
         onSelectChange: onInnerSelectChange,
         onDragSort: onDragSortChange,
       };
-      // ref 顺序很重要，如果移动到 v-slots 前面，会让 EnhancedTable 所有实例方法失效，勿动
+      if (props.tree?.expandTreeNodeOnClick) {
+        enhancedProps.onRowClick = onEnhancedTableRowClick;
+      }
+      // @ts-ignore ref 顺序很重要，如果移动到 v-slots 前面，会让 EnhancedTable 所有实例方法失效，勿动
       return <PrimaryTable v-slots={context.slots} {...enhancedProps} ref={primaryTableRef} />;
     };
   },

--- a/src/table/hooks/useTreeData.tsx
+++ b/src/table/hooks/useTreeData.tsx
@@ -120,7 +120,7 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
    * 组件实例方法，展开或收起某一行
    * @param p 行数据
    */
-  function toggleExpandData(p: { row: TableRowData; rowIndex: number }, trigger?: 'expand-fold-icon') {
+  function toggleExpandData(p: { row: TableRowData; rowIndex: number }, trigger?: 'expand-fold-icon' | 'row-click') {
     dataSource.value = [...store.value.toggleExpandData(p, dataSource.value, rowDataKeys.value)];
     const rowValue = get(p.row, rowDataKeys.value.rowKey);
     const rowState = store.value?.treeDataMap?.get(rowValue);
@@ -163,7 +163,13 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
         return (
           <div class={[tableTreeClasses.col, classes]} style={colStyle}>
             {!!(childrenNodes.length || childrenNodes === true) && (
-              <span class={tableTreeClasses.icon} onClick={() => toggleExpandData(p, 'expand-fold-icon')}>
+              <span
+                class={tableTreeClasses.icon}
+                onClick={(e: MouseEvent) => {
+                  toggleExpandData(p, 'expand-fold-icon');
+                  e.stopPropagation();
+                }}
+              >
                 {iconNode}
               </span>
             )}

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -871,6 +871,10 @@ export interface TableTreeConfig {
    */
   defaultExpandAll?: boolean;
   /**
+   * 是否在点击行时展开树形结构节点
+   */
+  expandTreeNodeOnClick?: boolean;
+  /**
    * 树结点缩进距离，单位：px
    * @default 24
    */
@@ -1078,7 +1082,7 @@ export interface TableTreeExpandChangeContext<T> {
   row: T;
   rowIndex: number;
   rowState: TableRowState<T>;
-  trigger?: 'expand-fold-icon';
+  trigger?: 'expand-fold-icon' | 'row-click';
 }
 
 export type TableRowValue = string | number;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 树形结构，支持点击行展开树节点，[tdesign-vue#1847](https://github.com/Tencent/tdesign-vue/issues/1847)
- feat(Table): 树形结构，点击树节点展开图标时，不触发 `onRowClick` 行点击事件，[issue#1847](https://github.com/Tencent/tdesign-vue/issues/1847)
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
