### PR TITLE
fix: 修复popup 类型问题

### DIFF
--- a/src/popconfirm/popconfirm.tsx
+++ b/src/popconfirm/popconfirm.tsx
@@ -8,7 +8,7 @@ import { useConfig, usePrefixClass } from '../hooks/useConfig';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
 import Popup, { PopupProps, PopupVisibleChangeContext } from '../popup/index';
 import props from './props';
-import { PopconfirmVisibleChangeContext } from './type';
+import { PopconfirmVisibleChangeContext, TdPopconfirmProps } from './type';
 import { useAction } from '../dialog/hooks';
 import { useContent, useTNodeJSX, useTNodeDefault } from '../hooks/tnode';
 import useVModel from '../hooks/useVModel';
@@ -17,7 +17,11 @@ export default defineComponent({
   name: 'TPopconfirm',
   props,
 
-  setup(props) {
+  setup(
+    props: TdPopconfirmProps & {
+      modelValue: boolean;
+    },
+  ) {
     const { globalConfig } = useConfig('popconfirm');
     const COMPONENT_NAME = usePrefixClass('popconfirm');
     const { InfoCircleFilledIcon, ErrorCircleFilledIcon } = useGlobalIcon({

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -174,7 +174,6 @@ export default defineComponent({
     function emitVisible(visible: boolean, context: PopupVisibleChangeContext) {
       if (props.disabled || visible === innerVisible.value) return;
       if (!visible && visibleState.value > 1) return;
-      if (visible && mouseInRange.value) return;
       setInnerVisible(visible, context);
     }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Popconfirm): 修复 `confirmBtn` 等属性存在类型错误 ([issue #1642](https://github.com/Tencent/tdesign-vue-next/issues/1642))
- fix(Dropdown): 修复 `hover` 有时候不能触发打开下拉菜单 ([issue #1642](https://github.com/Tencent/tdesign-vue-next/issues/1648))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
