### PR TITLE
fix(Upload): request-method 类型不兼容

### DIFF
--- a/src/upload/type.ts
+++ b/src/upload/type.ts
@@ -128,7 +128,9 @@ export interface TdUploadProps<T extends UploadFile = UploadFile> {
   /**
    * 自定义上传方法。返回值 `status` 表示上传成功或失败，`error` 或 `response.error` 表示上传失败的原因，`response` 表示请求上传成功后的返回数据，`response.url` 表示上传成功后的图片地址。示例一：`{ status: 'fail', error: '上传失败', response }`。示例二：`{ status: 'success', response: { url: 'https://tdesign.gtimg.com/site/avatar.jpg' } }`
    */
-  requestMethod?: (files: UploadFile | UploadFile[]) => Promise<RequestMethodResponse>;
+  requestMethod?: (
+    files: UploadFile,
+  ) => Promise<RequestMethodResponse> | ((files: UploadFile[]) => Promise<RequestMethodResponse>);
   /**
    * 是否显示上传进度
    * @default true


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2176 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
我测试了一下，应该是 类型作为`PropType`的泛型参数后导致的 (具体原因我还在看)
既然我们无法使用参数的联合类型，我们大可以使整个函数变为联合函数类型，毕竟参数可选值是两个

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Upload): request-method 类型不兼容

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
