### PR TITLE
fix: type compile omit union type

### DIFF
--- a/src/breadcrumb/breadcrumb.en-US.md
+++ b/src/breadcrumb/breadcrumb.en-US.md
@@ -23,4 +23,4 @@ maxWidth | String | undefined | \- | N
 replace | Boolean | false | \- | N
 router | Object | - | Typescript：`any` | N
 target | String | _self | options：_blank/_self/_parent/_top | N
-to | String / Object | - | Typescript：`Route` `interface Route { path?: string; name?: string; hash?: string; query?: RouteData; params?: RouteData }` `type RouteData = { [key: string]: string \| string[] }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/breadcrumb/type.ts) | N
+to | String / Object | - | Typescript：`string \| Route` `interface Route { path?: string; name?: string; hash?: string; query?: RouteData; params?: RouteData }` `type RouteData = { [key: string]: string \| string[] }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/breadcrumb/type.ts) | N

--- a/src/breadcrumb/breadcrumb.md
+++ b/src/breadcrumb/breadcrumb.md
@@ -29,4 +29,4 @@ maxWidth | String | undefined | 最大宽度，超出后会以省略号形式呈
 replace | Boolean | false | 路由跳转是否采用覆盖的方式（覆盖后将没有浏览器历史记录） | N
 router | Object | - | 路由对象。如果项目存在 Router，则默认使用 Router。TS 类型：`any` | N
 target | String | _self | 链接或路由跳转方式。可选项：_blank/_self/_parent/_top | N
-to | String / Object | - | 路由跳转目标，当且仅当 Router 存在时，该 API 有效。TS 类型：`Route` `interface Route { path?: string; name?: string; hash?: string; query?: RouteData; params?: RouteData }` `type RouteData = { [key: string]: string \| string[] }`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/breadcrumb/type.ts) | N
+to | String / Object | - | 路由跳转目标，当且仅当 Router 存在时，该 API 有效。TS 类型：`string \| Route` `interface Route { path?: string; name?: string; hash?: string; query?: RouteData; params?: RouteData }` `type RouteData = { [key: string]: string \| string[] }`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/breadcrumb/type.ts) | N

--- a/src/breadcrumb/type.ts
+++ b/src/breadcrumb/type.ts
@@ -69,7 +69,7 @@ export interface TdBreadcrumbItemProps {
   /**
    * 路由跳转目标，当且仅当 Router 存在时，该 API 有效
    */
-  to?: Route;
+  to?: string | Route;
 }
 
 export interface Route {

--- a/src/calendar/props.ts
+++ b/src/calendar/props.ts
@@ -19,7 +19,7 @@ export default {
   /** 右上角控制器配置。支持全局配置。值为 false 则表示不显示控制器，值为 true 则显示控制器默认配置，值类型为 CalendarController 则显示为自定义控制器配置 */
   controllerConfig: {
     type: [Boolean, Object] as PropType<TdCalendarProps['controllerConfig']>,
-    default: undefined,
+    default: undefined as TdCalendarProps['controllerConfig'],
   },
   /** 小于 10 的日期，是否使用 '0' 填充。支持全局配置。默认表现为 `01` `02`，值为 false 表现为 `1` `2` `9` */
   fillWithZero: {

--- a/src/cascader/props.ts
+++ b/src/cascader/props.ts
@@ -139,11 +139,11 @@ export default {
   /** 选中项的值 */
   value: {
     type: [String, Number, Array] as PropType<TdCascaderProps['value']>,
-    default: undefined,
+    default: undefined as TdCascaderProps['value'],
   },
   modelValue: {
     type: [String, Number, Array] as PropType<TdCascaderProps['value']>,
-    default: undefined,
+    default: undefined as TdCascaderProps['value'],
   },
   /** 选中项的值，非受控属性 */
   defaultValue: {

--- a/src/checkbox/checkbox-group-props.ts
+++ b/src/checkbox/checkbox-group-props.ts
@@ -28,11 +28,11 @@ export default {
   /** 选中值 */
   value: {
     type: Array as PropType<TdCheckboxGroupProps['value']>,
-    default: undefined,
+    default: undefined as TdCheckboxGroupProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdCheckboxGroupProps['value']>,
-    default: undefined,
+    default: undefined as TdCheckboxGroupProps['value'],
   },
   /** 选中值，非受控属性 */
   defaultValue: {

--- a/src/collapse/props.ts
+++ b/src/collapse/props.ts
@@ -38,11 +38,11 @@ export default {
   /** 展开的面板集合 */
   value: {
     type: Array as PropType<TdCollapseProps['value']>,
-    default: undefined,
+    default: undefined as TdCollapseProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdCollapseProps['value']>,
-    default: undefined,
+    default: undefined as TdCollapseProps['value'],
   },
   /** 展开的面板集合，非受控属性 */
   defaultValue: {

--- a/src/color-picker/props.ts
+++ b/src/color-picker/props.ts
@@ -46,7 +46,7 @@ export default {
   /** 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色” */
   recentColors: {
     type: Array as PropType<TdColorPickerProps['recentColors']>,
-    default: undefined,
+    default: undefined as TdColorPickerProps['recentColors'],
   },
   /** 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”，非受控属性 */
   defaultRecentColors: {

--- a/src/date-picker/props.ts
+++ b/src/date-picker/props.ts
@@ -49,7 +49,7 @@ export default {
   /** 占位符 */
   placeholder: {
     type: [String, Array] as PropType<TdDatePickerProps['placeholder']>,
-    default: undefined,
+    default: undefined as TdDatePickerProps['placeholder'],
   },
   /** 透传给 popup 组件的参数 */
   popupProps: {
@@ -95,16 +95,16 @@ export default {
   /** 选中值 */
   value: {
     type: [String, Number, Array, Date] as PropType<TdDatePickerProps['value']>,
-    default: undefined,
+    default: undefined as TdDatePickerProps['value'],
   },
   modelValue: {
     type: [String, Number, Array, Date] as PropType<TdDatePickerProps['value']>,
-    default: undefined,
+    default: undefined as TdDatePickerProps['value'],
   },
   /** 选中值，非受控属性 */
   defaultValue: {
     type: [String, Number, Array, Date] as PropType<TdDatePickerProps['defaultValue']>,
-    default: '',
+    default: '' as TdDatePickerProps['defaultValue'],
   },
   /** 用于格式化日期的值，仅支持部分格式，时间戳、日期等。⚠️ `YYYYMMDD` 这种格式不支持，请勿使用，如果希望支持可以给 `dayjs` 提个 PR。注意和 `format` 的区别，`format` 仅用于处理日期在页面中呈现的格式 */
   valueType: {

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -16,7 +16,7 @@ import {
   ErrorCircleFilledIcon as TdErrorCircleFilledIcon,
 } from 'tdesign-icons-vue-next';
 
-import { DialogCloseContext, TdDialogProps } from './type';
+import { DialogCloseContext } from './type';
 import props from './props';
 import TransferDom from '../utils/transfer-dom';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
@@ -26,6 +26,8 @@ import { useTNodeJSX, useContent } from '../hooks/tnode';
 import useDestroyOnClose from '../hooks/useDestroyOnClose';
 import { stack } from './stack';
 import { getScrollbarWidth } from '../utils/dom';
+
+import type { TdDialogProps } from './type';
 
 function GetCSSValue(v: string | number) {
   return Number.isNaN(Number(v)) ? v : `${Number(v)}px`;
@@ -106,7 +108,7 @@ export default defineComponent({
   props,
 
   emits: ['update:visible'],
-  setup(props: TdDialogProps, context) {
+  setup(props, context) {
     const COMPONENT_NAME = usePrefixClass('dialog');
     const classPrefix = usePrefixClass();
     const renderContent = useContent();
@@ -318,13 +320,13 @@ export default defineComponent({
       const defaultFooter = (
         <div>
           {getCancelBtn({
-            cancelBtn: props.cancelBtn,
+            cancelBtn: props.cancelBtn as TdDialogProps['cancelBtn'],
             globalCancel: globalConfig.value.cancel,
             className: `${COMPONENT_NAME.value}__cancel`,
           })}
           {getConfirmBtn({
             theme: props.theme,
-            confirmBtn: props.confirmBtn,
+            confirmBtn: props.confirmBtn as TdDialogProps['confirmBtn'],
             globalConfirm: globalConfig.value.confirm,
             globalConfirmBtnTheme: globalConfig.value.confirmBtnTheme,
             className: `${COMPONENT_NAME.value}__confirm`,

--- a/src/dialog/hooks.tsx
+++ b/src/dialog/hooks.tsx
@@ -5,14 +5,13 @@ import omit from 'lodash/omit';
 import { useTNodeJSX } from '../hooks/tnode';
 import TButton, { ButtonProps } from '../button';
 import { PopconfirmConfig, DialogConfig, DrawerConfig } from '../config-provider';
-import { ClassName, TNode } from '../common';
-
-export type MixinsFooterButton = string | ButtonProps | TNode | null;
+import type { ClassName } from '../common';
+import type { TdDialogProps } from './type';
 
 export interface MixinsConfirmBtn {
   theme?: MixinsThemeType;
   className?: ClassName;
-  confirmBtn: MixinsFooterButton;
+  confirmBtn: TdDialogProps['confirmBtn'];
   globalConfirm: PopconfirmConfig['confirm'] | DrawerConfig['confirm'] | DialogConfig['confirm'];
   globalConfirmBtnTheme?: PopconfirmConfig['confirmBtnTheme'] | DialogConfig['confirmBtnTheme'];
   size?: ButtonProps['size'];
@@ -20,7 +19,7 @@ export interface MixinsConfirmBtn {
 
 export interface MixinsCancelBtn {
   className?: ClassName;
-  cancelBtn: MixinsFooterButton;
+  cancelBtn: TdDialogProps['cancelBtn'];
   globalCancel: PopconfirmConfig['cancel'] | DrawerConfig['cancel'] | DialogConfig['cancel'];
   size?: ButtonProps['size'];
 }

--- a/src/dialog/props.ts
+++ b/src/dialog/props.ts
@@ -21,7 +21,7 @@ export default {
   /** 取消按钮，可自定义。值为 null 则不显示取消按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制取消事件 */
   cancelBtn: {
     type: [String, Object, Function] as PropType<TdDialogProps['cancelBtn']>,
-    default: '',
+    default: '' as TdDialogProps['cancelBtn'],
   },
   /** 关闭按钮，可以自定义。值为 true 显示默认关闭按钮，值为 false 不显示关闭按钮。值类型为 string 则直接显示值，如：“关闭”。值类型为 TNode，则表示呈现自定义按钮示例 */
   closeBtn: {
@@ -41,7 +41,7 @@ export default {
   /** 确认按钮。值为 null 则不显示确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制确认事件 */
   confirmBtn: {
     type: [String, Object, Function] as PropType<TdDialogProps['confirmBtn']>,
-    default: '',
+    default: '' as TdDialogProps['confirmBtn'],
   },
   /** 是否在按下回车键时，触发确认事件 */
   confirmOnEnter: Boolean,

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -10,6 +10,7 @@ import TransferDom from '../utils/transfer-dom';
 import { useAction } from '../dialog/hooks';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import { useDrag } from './hooks';
+import type { TdDrawerProps } from './type';
 
 let key = 1;
 
@@ -30,7 +31,7 @@ export default defineComponent({
     const renderTNodeJSX = useTNodeJSX();
     const renderContent = useContent();
     const COMPONENT_NAME = usePrefixClass('drawer');
-    const { draggedSizeValue, enableDrag, draggableLineStyles } = useDrag(props);
+    const { draggedSizeValue, enableDrag, draggableLineStyles } = useDrag(props as TdDrawerProps);
 
     const confirmBtnAction = (e: MouseEvent) => {
       props.onConfirm?.({ e });
@@ -132,13 +133,13 @@ export default defineComponent({
     const getDefaultFooter = () => {
       // this.getConfirmBtn is a function of useAction
       const confirmBtn = getConfirmBtn({
-        confirmBtn: props.confirmBtn,
+        confirmBtn: props.confirmBtn as TdDrawerProps['confirmBtn'],
         globalConfirm: globalConfig.value.confirm,
         className: `${COMPONENT_NAME.value}__confirm`,
       });
       // this.getCancelBtn is a function of useAction
       const cancelBtn = getCancelBtn({
-        cancelBtn: props.cancelBtn,
+        cancelBtn: props.cancelBtn as TdDrawerProps['cancelBtn'],
         globalCancel: globalConfig.value.cancel,
         className: `${COMPONENT_NAME.value}__cancel`,
       });

--- a/src/drawer/hooks.ts
+++ b/src/drawer/hooks.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue';
 import { Styles } from '../common';
-import { TdDrawerProps } from './type';
+import type { TdDrawerProps } from './type';
 
 export const useDrag = (props: TdDrawerProps) => {
   // 以下为拖拽改变抽屉大小相关 可以抽成hooks

--- a/src/drawer/props.ts
+++ b/src/drawer/props.ts
@@ -20,7 +20,7 @@ export default {
   /** 取消按钮，可自定义。值为 null 则不显示取消按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制取消事件 */
   cancelBtn: {
     type: [String, Object, Function] as PropType<TdDrawerProps['cancelBtn']>,
-    default: '',
+    default: '' as TdDrawerProps['cancelBtn'],
   },
   /** 关闭按钮，可以自定义。值为 true 显示默认关闭按钮，值为 false 不显示关闭按钮。值类型为 string 则直接显示值，如：“关闭”。值类型为 TNode，则表示呈现自定义按钮示例 */
   closeBtn: {
@@ -39,7 +39,7 @@ export default {
   /** 确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制确认事件 */
   confirmBtn: {
     type: [String, Object, Function] as PropType<TdDrawerProps['confirmBtn']>,
-    default: '',
+    default: '' as TdDrawerProps['confirmBtn'],
   },
   /** 抽屉内容，同 body */
   default: {

--- a/src/input-number/props.ts
+++ b/src/input-number/props.ts
@@ -103,11 +103,11 @@ export default {
   /** 数字输入框的值。当值为 '' 时，输入框显示为空 */
   value: {
     type: [String, Number] as PropType<TdInputNumberProps['value']>,
-    default: undefined,
+    default: undefined as TdInputNumberProps['value'],
   },
   modelValue: {
     type: [String, Number] as PropType<TdInputNumberProps['value']>,
-    default: undefined,
+    default: undefined as TdInputNumberProps['value'],
   },
   /** 数字输入框的值。当值为 '' 时，输入框显示为空，非受控属性 */
   defaultValue: {

--- a/src/input/props.ts
+++ b/src/input/props.ts
@@ -114,16 +114,16 @@ export default {
   /** 输入框的值 */
   value: {
     type: [String, Number] as PropType<TdInputProps['value']>,
-    default: undefined,
+    default: undefined as TdInputProps['value'],
   },
   modelValue: {
     type: [String, Number] as PropType<TdInputProps['value']>,
-    default: undefined,
+    default: undefined as TdInputProps['value'],
   },
   /** 输入框的值，非受控属性 */
   defaultValue: {
     type: [String, Number] as PropType<TdInputProps['defaultValue']>,
-    default: '',
+    default: '' as TdInputProps['defaultValue'],
   },
   /** 失去焦点时触发 */
   onBlur: Function as PropType<TdInputProps['onBlur']>,

--- a/src/menu/head-menu-props.ts
+++ b/src/menu/head-menu-props.ts
@@ -47,11 +47,11 @@ export default {
   /** 激活菜单项 */
   value: {
     type: [String, Number] as PropType<TdHeadMenuProps['value']>,
-    default: undefined,
+    default: undefined as TdHeadMenuProps['value'],
   },
   modelValue: {
     type: [String, Number] as PropType<TdHeadMenuProps['value']>,
-    default: undefined,
+    default: undefined as TdHeadMenuProps['value'],
   },
   /** 激活菜单项，非受控属性 */
   defaultValue: {

--- a/src/menu/props.ts
+++ b/src/menu/props.ts
@@ -51,11 +51,11 @@ export default {
   /** 激活菜单项 */
   value: {
     type: [String, Number] as PropType<TdMenuProps['value']>,
-    default: undefined,
+    default: undefined as TdMenuProps['value'],
   },
   modelValue: {
     type: [String, Number] as PropType<TdMenuProps['value']>,
-    default: undefined,
+    default: undefined as TdMenuProps['value'],
   },
   /** 激活菜单项，非受控属性 */
   defaultValue: {

--- a/src/popconfirm/popconfirm.tsx
+++ b/src/popconfirm/popconfirm.tsx
@@ -8,20 +8,17 @@ import { useConfig, usePrefixClass } from '../hooks/useConfig';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
 import Popup, { PopupProps, PopupVisibleChangeContext } from '../popup/index';
 import props from './props';
-import { PopconfirmVisibleChangeContext, TdPopconfirmProps } from './type';
-import { useAction } from '../dialog/hooks';
 import { useContent, useTNodeJSX, useTNodeDefault } from '../hooks/tnode';
 import useVModel from '../hooks/useVModel';
+import { useAction } from '../dialog/hooks';
 
+import type { PopconfirmVisibleChangeContext } from './type';
+import type { TdDialogProps } from '../dialog/type';
 export default defineComponent({
   name: 'TPopconfirm',
   props,
 
-  setup(
-    props: TdPopconfirmProps & {
-      modelValue: boolean;
-    },
-  ) {
+  setup(props) {
     const { globalConfig } = useConfig('popconfirm');
     const COMPONENT_NAME = usePrefixClass('popconfirm');
     const { InfoCircleFilledIcon, ErrorCircleFilledIcon } = useGlobalIcon({
@@ -65,7 +62,7 @@ export default defineComponent({
     const renderTNodeDefault = useTNodeDefault();
     const renderContent = () => {
       const cancelBtn = getCancelBtn({
-        cancelBtn: props.cancelBtn,
+        cancelBtn: props.cancelBtn as TdDialogProps['cancelBtn'],
         globalCancel: globalConfig.value.cancel,
         className: `${COMPONENT_NAME.value}__cancel`,
         size: 'small',
@@ -73,7 +70,7 @@ export default defineComponent({
 
       const confirmBtn = getConfirmBtn({
         theme: props.theme,
-        confirmBtn: props.confirmBtn,
+        confirmBtn: props.confirmBtn as TdDialogProps['confirmBtn'],
         globalConfirm: globalConfig.value.confirm,
         globalConfirmBtnTheme: globalConfig.value.confirmBtnTheme,
         className: `${COMPONENT_NAME.value}__confirm`,

--- a/src/popconfirm/props.ts
+++ b/src/popconfirm/props.ts
@@ -11,12 +11,12 @@ export default {
   /** 取消按钮，可自定义。值为 null 则不显示取消按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制取消事件 */
   cancelBtn: {
     type: [String, Object, Function] as PropType<TdPopconfirmProps['cancelBtn']>,
-    default: '',
+    default: '' as TdPopconfirmProps['cancelBtn'],
   },
   /** 确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制确认事件 */
   confirmBtn: {
     type: [String, Object, Function] as PropType<TdPopconfirmProps['confirmBtn']>,
-    default: '',
+    default: '' as TdPopconfirmProps['confirmBtn'],
   },
   /** 确认框内容 */
   content: {

--- a/src/progress/props.ts
+++ b/src/progress/props.ts
@@ -12,7 +12,7 @@ export default {
   /** 进度条颜色。示例：'#ED7B2F' 或 'orange' 或 `['#f00', '#0ff', '#f0f']` 或 `{ '0%': '#f00', '100%': '#0ff' }` 或  `{ from: '#000', to: '#000' }` 等 */
   color: {
     type: [String, Object, Array] as PropType<TdProgressProps['color']>,
-    default: '',
+    default: '' as TdProgressProps['color'],
   },
   /** 进度百分比，可自定义 */
   label: {

--- a/src/radio/props.ts
+++ b/src/radio/props.ts
@@ -42,7 +42,7 @@ export default {
   /** 单选按钮的值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdRadioProps['value']>,
-    default: undefined,
+    default: undefined as TdRadioProps['value'],
   },
   /** 选中状态变化时触发 */
   onChange: Function as PropType<TdRadioProps['onChange']>,

--- a/src/range-input/range-input-popup-props.ts
+++ b/src/range-input/range-input-popup-props.ts
@@ -15,7 +15,7 @@ export default {
   /** 输入框的值 */
   inputValue: {
     type: Array as PropType<TdRangeInputPopupProps['inputValue']>,
-    default: undefined,
+    default: undefined as TdRangeInputPopupProps['inputValue'],
   },
   /** 输入框的值，非受控属性 */
   defaultInputValue: {

--- a/src/rate/props.ts
+++ b/src/rate/props.ts
@@ -13,7 +13,7 @@ export default {
   /** 评分图标的颜色，样式中默认为 #ED7B2F。一个值表示设置选中高亮的五角星颜色，示例：[选中颜色]。数组则表示分别设置 选中高亮的五角星颜色 和 未选中暗灰的五角星颜色，[选中颜色，未选中颜色]。示例：['#ED7B2F', '#E3E6EB'] */
   color: {
     type: [String, Array] as PropType<TdRateProps['color']>,
-    default: '#ED7B2F',
+    default: '#ED7B2F' as TdRateProps['color'],
   },
   /** 评分的数量 */
   count: {

--- a/src/select/props.ts
+++ b/src/select/props.ts
@@ -154,11 +154,11 @@ export default {
   /** 选中值 */
   value: {
     type: [String, Number, Object, Array] as PropType<TdSelectProps['value']>,
-    default: undefined,
+    default: undefined as TdSelectProps['value'],
   },
   modelValue: {
     type: [String, Number, Object, Array] as PropType<TdSelectProps['value']>,
-    default: undefined,
+    default: undefined as TdSelectProps['value'],
   },
   /** 选中值，非受控属性 */
   defaultValue: {

--- a/src/select/type.ts
+++ b/src/select/type.ts
@@ -12,7 +12,7 @@ import { TagInputProps } from '../tag-input';
 import { TagProps } from '../tag';
 import { SelectInputValueChangeContext } from '../select-input';
 import { PopupVisibleChangeContext } from '../popup';
-import { TNode, SizeEnum, TScroll } from '../common';
+import { PlainObject, TNode, SizeEnum, TScroll } from '../common';
 
 export interface TdSelectProps<T extends SelectOption = SelectOption> {
   /**
@@ -307,7 +307,7 @@ export interface SelectRemoveContext<T> {
   e: MouseEvent | KeyboardEvent;
 }
 
-export type SelectOption = TdOptionProps | SelectOptionGroup;
+export type SelectOption = TdOptionProps | SelectOptionGroup | PlainObject;
 
 export interface SelectOptionGroup extends TdOptionGroupProps {
   group: string;

--- a/src/slider/props.ts
+++ b/src/slider/props.ts
@@ -14,7 +14,7 @@ export default {
   /** 用于控制数字输入框组件，值为 false 表示不显示数字输入框；值为 true 表示呈现默认数字输入框；值类型为 Object 表示透传属性到数字输入框组件 */
   inputNumberProps: {
     type: [Boolean, Object] as PropType<TdSliderProps['inputNumberProps']>,
-    default: false,
+    default: false as TdSliderProps['inputNumberProps'],
   },
   /** 滑块当前值文本。不传则默认显示当前数值，值为 `${value}%` 则表示组件会根据占位符渲染文案 */
   label: {
@@ -57,7 +57,7 @@ export default {
   },
   modelValue: {
     type: [Number, Array] as PropType<TdSliderProps['value']>,
-    default: undefined,
+    default: undefined as TdSliderProps['value'],
   },
   /** 透传提示组件属性 */
   tooltipProps: {
@@ -66,7 +66,7 @@ export default {
   /** 滑块值 */
   value: {
     type: [Number, Array] as PropType<TdSliderProps['value']>,
-    default: undefined,
+    default: undefined as TdSliderProps['value'],
   },
   /** 滑块值，非受控属性 */
   defaultValue: {

--- a/src/slider/type.ts
+++ b/src/slider/type.ts
@@ -19,7 +19,7 @@ export interface TdSliderProps {
    * 用于控制数字输入框组件，值为 false 表示不显示数字输入框；值为 true 表示呈现默认数字输入框；值类型为 Object 表示透传属性到数字输入框组件
    * @default false
    */
-  inputNumberProps?: InputNumberProps;
+  inputNumberProps?: false | InputNumberProps;
   /**
    * 滑块当前值文本。不传则默认显示当前数值，值为 `${value}%` 则表示组件会根据占位符渲染文案
    * @default false

--- a/src/switch/props.ts
+++ b/src/switch/props.ts
@@ -33,17 +33,17 @@ export default {
   /** v-model 开关值 */
   modelValue: {
     type: [String, Number, Boolean] as PropType<TdSwitchProps['value']>,
-    default: undefined,
+    default: undefined as TdSwitchProps['value'],
   },
   /** 开关值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdSwitchProps['value']>,
-    default: undefined,
+    default: undefined as TdSwitchProps['value'],
   },
   /** 开关值，非受控属性 */
   defaultValue: {
     type: [String, Number, Boolean] as PropType<TdSwitchProps['defaultValue']>,
-    default: false,
+    default: false as TdSwitchProps['defaultValue'],
   },
   /** 数据发生变化时触发 */
   onChange: Function as PropType<TdSwitchProps['onChange']>,

--- a/src/table/base-table-props.ts
+++ b/src/table/base-table-props.ts
@@ -64,7 +64,7 @@ export default {
   /** 表尾吸底。使用此向功能，需要非常注意表格是相对于哪一个父元素进行滚动。值为 `true`，则表示相对于整个窗口吸底。如果表格滚动的父元素不是整个窗口，请通过 `footerAffixedBottom.container` 调整固钉的吸顶范围。基于 Affix 组件开发，透传全部 Affix 组件属性 */
   footerAffixedBottom: {
     type: [Boolean, Object] as PropType<TdBaseTableProps['footerAffixedBottom']>,
-    default: false,
+    default: false as TdBaseTableProps['footerAffixedBottom'],
   },
   /** 表尾总结行 */
   footerSummary: {
@@ -77,7 +77,7 @@ export default {
   /** 表头吸顶。使用该功能，需要非常注意表格是相对于哪一个父元素进行滚动。值为 `true`，表示相对于整个窗口吸顶。如果表格滚动的父元素不是整个窗口，请通过 `headerAffixedTop.container` 调整吸顶的位置。基于 Affix 组件开发，透传全部 Affix 组件属性。 */
   headerAffixedTop: {
     type: [Boolean, Object] as PropType<TdBaseTableProps['headerAffixedTop']>,
-    default: false,
+    default: false as TdBaseTableProps['headerAffixedTop'],
   },
   /** 表格高度，超出后会出现滚动条。示例：100,  '30%',  '300'。值为数字类型，会自动加上单位 px。如果不是绝对固定表格高度，建议使用 `maxHeight` */
   height: {

--- a/src/table/primary-table-props.ts
+++ b/src/table/primary-table-props.ts
@@ -92,7 +92,7 @@ export default {
   /** 过滤数据的值 */
   filterValue: {
     type: Object as PropType<TdPrimaryTableProps['filterValue']>,
-    default: undefined,
+    default: undefined as TdPrimaryTableProps['filterValue'],
   },
   /** 过滤数据的值，非受控属性 */
   defaultFilterValue: {
@@ -128,7 +128,7 @@ export default {
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序 */
   sort: {
     type: [Object, Array] as PropType<TdPrimaryTableProps['sort']>,
-    default: undefined,
+    default: undefined as TdPrimaryTableProps['sort'],
   },
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序，非受控属性 */
   defaultSort: {

--- a/src/tag-input/props.ts
+++ b/src/tag-input/props.ts
@@ -103,11 +103,11 @@ export default {
   /** 值 */
   value: {
     type: Array as PropType<TdTagInputProps['value']>,
-    default: undefined,
+    default: undefined as TdTagInputProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdTagInputProps['value']>,
-    default: undefined,
+    default: undefined as TdTagInputProps['value'],
   },
   /** 值，非受控属性 */
   defaultValue: {

--- a/src/textarea/props.ts
+++ b/src/textarea/props.ts
@@ -13,7 +13,7 @@ export default {
   /** 高度自动撑开。 autosize = true 表示组件高度自动撑开，同时，依旧允许手动拖高度。如果设置了 autosize.maxRows 或者 autosize.minRows 则不允许手动调整高度 */
   autosize: {
     type: [Boolean, Object] as PropType<TdTextareaProps['autosize']>,
-    default: false,
+    default: false as TdTextareaProps['autosize'],
   },
   /** 是否禁用文本框 */
   disabled: Boolean,

--- a/src/time-picker/time-range-picker-props.ts
+++ b/src/time-picker/time-range-picker-props.ts
@@ -77,11 +77,11 @@ export default {
   /** 选中值 */
   value: {
     type: Array as PropType<TdTimeRangePickerProps['value']>,
-    default: undefined,
+    default: undefined as TdTimeRangePickerProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdTimeRangePickerProps['value']>,
-    default: undefined,
+    default: undefined as TdTimeRangePickerProps['value'],
   },
   /** 选中值，非受控属性 */
   defaultValue: {

--- a/src/transfer/props.ts
+++ b/src/transfer/props.ts
@@ -16,7 +16,7 @@ export default {
   /** 数据列表选中项 */
   checked: {
     type: Array as PropType<TdTransferProps['checked']>,
-    default: undefined,
+    default: undefined as TdTransferProps['checked'],
   },
   /** 数据列表选中项，非受控属性 */
   defaultChecked: {
@@ -92,12 +92,12 @@ export default {
   /** 目标数据列表数据 */
   value: {
     type: Array as PropType<TdTransferProps['value']>,
-    default: undefined,
+    default: undefined as TdTransferProps['value'],
   },
   /** v-model*/
   modelValue: {
     type: Array as PropType<TdTransferProps['value']>,
-    default: undefined,
+    default: undefined as TdTransferProps['value'],
   },
   /** 目标数据列表数据，非受控属性 */
   defaultValue: {

--- a/src/tree-select/props.ts
+++ b/src/tree-select/props.ts
@@ -112,11 +112,11 @@ export default {
   /** 选中值 */
   value: {
     type: [String, Number, Object, Array] as PropType<TdTreeSelectProps['value']>,
-    default: undefined,
+    default: undefined as TdTreeSelectProps['value'],
   },
   modelValue: {
     type: [String, Number, Object, Array] as PropType<TdTreeSelectProps['value']>,
-    default: undefined,
+    default: undefined as TdTreeSelectProps['value'],
   },
   /** 选中值，非受控属性 */
   defaultValue: {

--- a/src/tree/props.ts
+++ b/src/tree/props.ts
@@ -122,11 +122,11 @@ export default {
   /** 选中值（组件为可选状态时） */
   value: {
     type: Array as PropType<TdTreeProps['value']>,
-    default: undefined,
+    default: undefined as TdTreeProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdTreeProps['value']>,
-    default: undefined,
+    default: undefined as TdTreeProps['value'],
   },
   /** 选中值（组件为可选状态时），非受控属性 */
   defaultValue: {

--- a/src/upload/props.ts
+++ b/src/upload/props.ts
@@ -63,7 +63,7 @@ export default {
   /** 已上传文件列表，同 `value` */
   files: {
     type: Array as PropType<TdUploadProps['files']>,
-    default: undefined,
+    default: undefined as TdUploadProps['files'],
   },
   /** 已上传文件列表，同 `value`，非受控属性 */
   defaultFiles: {
@@ -171,11 +171,11 @@ export default {
   /** 已上传文件列表，同 `files` */
   value: {
     type: Array as PropType<TdUploadProps['value']>,
-    default: undefined,
+    default: undefined as TdUploadProps['value'],
   },
   modelValue: {
     type: Array as PropType<TdUploadProps['value']>,
-    default: undefined,
+    default: undefined as TdUploadProps['value'],
   },
   /** 已上传文件列表，同 `files`，非受控属性 */
   defaultValue: {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/2338
- https://github.com/Tencent/tdesign-vue-next/issues/2263
- https://github.com/Tencent/tdesign-vue-next/issues/2264
- https://github.com/Tencent/tdesign-vue-next/issues/2265
- https://github.com/Tencent/tdesign-vue-next/issues/2168

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

defineComponent定义了props的默认值之后 在输出类型文件时会再联合默认值的类型 在存在复杂类型的情况下 输出的类型存在一定的错误，如只保留默认值的类型，故对默认值进行cast处理，保证最终输出的产物类型文件保留所有定义的类型。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复`cancelBtn`、`confirmBtn`的类型问题
- fix(Calendar): 修复`controllerConfig`的产物类型问题
- fix(Table): 修复`headerAffixedTop`、`footerAffixedBottom`、`filterValue`的类型错误
- fix(Form): 修复表单类组件value语法糖可能存在的类型问题
- fix(Drawer): 修复`cancelBtn`、`confirmBtn`的类型问题
- fix(Popconfirm): 修复`cancelBtn`、`confirmBtn`的类型问题
- fix(Slider): 修复`InputNumberProps`的类型问题
- fix(Textarea): 修复`autosize`的类型问题
- fix(Select): 修复`options`的类型问题
- fix(BreadCrumb): 修复BreadCrumbItem的`to`的类型问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
