### PR TITLE
fix(table): fix edit.on.onChange is invalidate

### DIFF
--- a/src/table/_example/editable-cell.vue
+++ b/src/table/_example/editable-cell.vue
@@ -117,6 +117,11 @@ const columns = computed(() => [
         clearable: true,
         options: STATUS_OPTIONS,
       },
+      on: (editContext) => ({
+        onChange: (params) => {
+          console.log('status changed', editContext, params);
+        },
+      }),
       // 除了点击非自身元素退出编辑态之外，还有哪些事件退出编辑态
       abortEditOnEvent: ['onChange'],
       // 编辑完成，退出编辑态后触发

--- a/src/table/editable-cell.tsx
+++ b/src/table/editable-cell.tsx
@@ -82,6 +82,9 @@ export default defineComponent({
     const errorList = ref<AllValidateResult[]>();
 
     const { Edit1Icon } = useGlobalIcon({ Edit1Icon: TdEdit1Icon });
+    const editOnListeners = computed(() => {
+      return col.value.edit?.on?.({ ...cellParams.value, editedRow: currentRow.value });
+    });
 
     const cellParams = computed(() => ({
       rowIndex: props.rowIndex,
@@ -234,6 +237,7 @@ export default defineComponent({
       };
       props.onChange?.(params);
       props.onRuleChange?.(params);
+      editOnListeners.value?.onChange?.(params);
       const isCellEditable = props.editable === undefined;
       if (isCellEditable && isAbortEditOnChange.value) {
         const outsideAbortEvent = col.value.edit?.onEdited;
@@ -349,6 +353,8 @@ export default defineComponent({
         return null;
       }
       const errorMessage = errorList.value?.[0]?.message;
+      const tmpEditOnListeners = { ...editOnListeners.value };
+      delete tmpEditOnListeners.onChange;
       return (
         <div
           class={props.tableBaseClass.cellEditWrap}
@@ -362,7 +368,7 @@ export default defineComponent({
             tips={errorMessage}
             {...componentProps.value}
             {...listeners.value}
-            {...col.value.edit?.on?.({ ...cellParams.value, editedRow: currentRow.value })}
+            {...tmpEditOnListeners}
             value={editValue.value}
             onChange={onEditChange}
           />


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复 `column.edit.on.onChange` 无效报错问题，[issue#2362](https://github.com/Tencent/tdesign-vue-next/issues/)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
