### PR TITLE
fix(Menu): click twice to re-expand submenus

### DIFF
--- a/src/menu/menu.tsx
+++ b/src/menu/menu.tsx
@@ -95,6 +95,16 @@ export default defineComponent({
         vMenu.expandValues = new Set(value);
       },
     );
+    watch(
+      () => props.collapsed,
+      (newValue, oldValue) => {
+        if (!newValue && oldValue) {
+          // 如果重新打开菜单，就将原本已经展开的子菜单重新展开
+          setExpand([...vMenu.expandValues]);
+        }
+      },
+    );
+
     const updateActiveValues = (value: MenuValue) => {
       activeValues.value = vMenu.select(value);
     };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [√] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2557 

### 💡 需求背景和解决方案

- fix(Menu): 因为normal和popup的展开方式均使用同一个expandValues存储，在鼠标移出popup模式的子菜单之后，就会直接用setExpand的方法设置空的数组。因此重新展开后，normal模式的子菜单就是空的。
- 但是同时也发现了子菜单的bug，已经发起了新的issue #2588 

### 📝 更新日志

- fix(Menu): 修复重新展开后，`normal` 模式的子菜单就是空的。([issue #2557](https://github.com/Tencent/tdesign-vue-next/issues/2557))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
