### PR TITLE
fix(table): getSortIcon is not a function in webpack5 Vue3

### DIFF
--- a/src/table/sorter-button.tsx
+++ b/src/table/sorter-button.tsx
@@ -1,6 +1,5 @@
 import { computed, defineComponent, PropType } from 'vue';
 import { ChevronDownIcon as TdChevronDownIcon } from 'tdesign-icons-vue-next';
-
 import useClassName from './hooks/useClassName';
 import { SortType } from './type';
 import Tooltip, { TooltipProps } from '../tooltip';
@@ -44,35 +43,30 @@ export default defineComponent({
       context.emit('sort-icon-click', e, { descending: direction === 'desc' });
     };
 
-    return {
-      t,
-      globalConfig,
-      ChevronDownIcon,
-      tableSortClasses,
-      negativeRotate180,
-      allowSortTypes,
-      onSortIconClick,
-      renderTNode,
-    };
-  },
-
-  methods: {
-    getSortIcon(direction: string, activeClass: string) {
-      const { ChevronDownIcon } = this;
-      const defaultIcon = this.t(this.globalConfig.sortIcon) || <ChevronDownIcon />;
-      const icon = this.renderTNode('sortIcon', defaultIcon);
+    const getSortIcon = (direction: string, activeClass: string) => {
+      const defaultIcon = t(globalConfig.value.sortIcon) || <ChevronDownIcon />;
+      const icon = renderTNode('sortIcon', defaultIcon);
       const sortClassName = [
         activeClass,
-        this.tableSortClasses.sortIcon,
-        this.tableSortClasses.iconDirection[direction],
-        { [this.negativeRotate180]: direction === 'asc' },
+        tableSortClasses.sortIcon,
+        tableSortClasses.iconDirection[direction],
+        { [negativeRotate180]: direction === 'asc' },
       ];
       return (
-        <span class={sortClassName} onClick={(e) => this.onSortIconClick(e, direction)}>
+        <span class={sortClassName} onClick={(e) => onSortIconClick(e, direction)}>
           {icon}
         </span>
       );
-    },
+    };
+
+    return {
+      t,
+      globalConfig,
+      tableSortClasses,
+      negativeRotate180,
+      allowSortTypes,
+      getSortIcon,
+    };
   },
 
   render() {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): `getSortIcon is not a function` in Webpack5 & Vue3, [issue#2538](https://github.com/Tencent/tdesign-vue-next/issues/2538)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
