### PR TITLE
fix(guide): update when popup ref position change

### DIFF
--- a/src/guide/guide.tsx
+++ b/src/guide/guide.tsx
@@ -42,6 +42,8 @@ export default defineComponent({
     const dialogWrapperRef = ref<HTMLElement>();
     // dialog ref
     const dialogTooltipRef = ref<HTMLElement>();
+    // ! popup ref 不确定这里的类型是否完全正确
+    const popupTooltipRef = ref<InstanceType<typeof Popup>>();
     // 是否开始展示
     const actived = ref<boolean>(false);
     // 步骤总数
@@ -90,6 +92,9 @@ export default defineComponent({
         setHighlightLayerPosition(highlightLayerRef.value);
         setHighlightLayerPosition(referenceLayerRef.value);
         scrollToElm(currentHighlightLayerElm.value);
+        // fix: https://github.com/Tencent/tdesign-vue-next/issues/2536
+        // 这里其实是一个临时解决方案，最合理的是 popup 内部处理
+        popupTooltipRef.value?.update();
       });
     };
 
@@ -390,6 +395,7 @@ export default defineComponent({
         ];
         return (
           <Popup
+            ref={popupTooltipRef}
             visible={true}
             show-arrow={!content}
             zIndex={zIndex.value}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
#2536 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

高亮区域位置更新后调用popup update 以达到更新的目的

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Guide):  解决 `guide popup` 提示在重叠情形下不更新 ([issue #2536 ](https://github.com/Tencent/tdesign-vue-next/issues/2536))

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
