### PR TITLE
fix(menu): mouse hover first in submenu will make next submenu disappear

### DIFF
--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -179,6 +179,11 @@ export default defineComponent({
       }),
     );
 
+    watch(popupWrapperRef, () => {
+      // 第一次触发nextTick会取空值，导致subPopupRef拿不到对应的DOM
+      passSubPopupRefToParent(popupWrapperRef.value);
+    });
+
     onMounted(() => {
       menu?.vMenu?.add({ value: props.value, parent: submenu?.value, vnode: ctx.slots.default });
       const instance = getCurrentInstance();


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [√] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2588 

### 💡 需求背景和解决方案

### 📝 更新日志
fix(menu):
第一次鼠标触发事件的时候，组件才会开始渲染，然后触发handleMouseEnter，接着在setTimeout中在nextTick阶段将ref传递出来给subPopupRef。
但是实际上却没有改动，导致handleMouseLeavePopup方法中的target === subPopupRef.value判断为假（此时subPopupRef.value是undefined）所以直接导致追踪到根子菜单触发消失，然后整个popup菜单树消失。
第二次触发hover的时候才能真正拿到subPopupRef，于是符合target === subPopupRef.value条件，正常触发消失流程。
目前用watch来监视popupWrapperRef能够在更新值之后及时通过passSubPopupRefToParent传递给subPopupRef，handleMouseLeavePopup能够正常拿到subPopupRef即可

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
