### PR TITLE
fix: 修复DatePicker的prefixIcon未传递时仍透传了prefixIcon函数导致产生非预期渲染

### DIFF
--- a/src/date-picker/hooks/useSingle.tsx
+++ b/src/date-picker/hooks/useSingle.tsx
@@ -46,7 +46,7 @@ export default function useSingle(props: TdDatePickerProps) {
     ...props.inputProps,
     size: props.size,
     ref: inputRef,
-    prefixIcon: () => renderTNodeJSX('prefixIcon'),
+    prefixIcon: props.prefixIcon && (() => renderTNodeJSX('prefixIcon')),
     readonly: !props.allowInput,
     placeholder: props.placeholder || globalConfig.value.placeholder[props.mode],
     suffixIcon: () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

### 💡 需求背景和解决方案

业务开发中遇到的问题，使用Space组件 设置align="center"后高度被prefixIcon撑高。
![image](https://user-images.githubusercontent.com/52393227/229478349-e32cdd55-d126-4c5c-a6a0-b5b1aab961eb.png)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): prefixIcon未传递时仍透传了prefixIcon函数导致产生非预期渲染。

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
