### PR TITLE
feat(RadioGroup): options.value支持 boolean

### DIFF
--- a/src/radio/props.ts
+++ b/src/radio/props.ts
@@ -25,7 +25,7 @@ export default {
   default: {
     type: [String, Function] as PropType<TdRadioProps['default']>,
   },
-  /** 是否为禁用态 */
+  /** 是否为禁用态。如果存在父组件 RadioGroup，默认值由 RadioGroup.disabled 控制。Radio.disabled 优先级高于 RadioGroup.disabled */
   disabled: {
     type: Boolean,
     default: undefined,

--- a/src/radio/radio-group-props.ts
+++ b/src/radio/radio-group-props.ts
@@ -10,11 +10,8 @@ import { PropType } from 'vue';
 export default {
   /** 是否允许取消选中 */
   allowUncheck: Boolean,
-  /** 是否禁用全部子单选框 */
-  disabled: {
-    type: Boolean,
-    default: undefined,
-  },
+  /** 是否禁用全部子单选框。默认为 false。RadioGroup.disabled 优先级低于 Radio.disabled */
+  disabled: Boolean,
   /** HTML 元素原生属性 */
   name: {
     type: String,
@@ -36,11 +33,11 @@ export default {
   /** 选中的值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdRadioGroupProps['value']>,
-    default: undefined,
+    default: undefined as TdRadioGroupProps['value'],
   },
   modelValue: {
     type: [String, Number, Boolean] as PropType<TdRadioGroupProps['value']>,
-    default: undefined,
+    default: undefined as TdRadioGroupProps['value'],
   },
   /** 选中的值，非受控属性 */
   defaultValue: {

--- a/src/radio/radio.en-US.md
+++ b/src/radio/radio.en-US.md
@@ -12,7 +12,7 @@ default | String / Slot / Function | - | Typescript：`string \| TNode`。[see m
 disabled | Boolean | undefined | \- | N
 label | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 name | String | - | \- | N
-value | String / Number / Boolean | undefined | Typescript：`T` | N
+value | String / Number / Boolean | undefined | Typescript：`string \| number \| boolean` | N
 onChange | Function |  | Typescript：`(checked: boolean, context: { e: Event }) => void`<br/> | N
 onClick | Function |  | Typescript：`(context: { e: MouseEvent }) => void`<br/>trigger on click | N
 
@@ -28,12 +28,12 @@ click | `(context: { e: MouseEvent })` | trigger on click
 name | type | default | description | required
 -- | -- | -- | -- | --
 allowUncheck | Boolean | false | \- | N
-disabled | Boolean | undefined | \- | N
+disabled | Boolean | - | \- | N
 name | String | - | \- | N
-options | Array | - | Typescript：`Array<RadioOption>` `type RadioOption = string \| number \| RadioOptionObj` `interface RadioOptionObj { label?: string \| TNode; value?: string \| number; disabled?: boolean }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
+options | Array | - | Typescript：`Array<RadioOption>` `type RadioOption = string \| number \| RadioOptionObj` `interface RadioOptionObj { label?: string \| TNode; value?: string \| number \| boolean; disabled?: boolean }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
 size | String | medium | options：small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-value | String / Number / Boolean | - | `v-model` and `v-model:value` is supported。Typescript：`T` | N
-defaultValue | String / Number / Boolean | - | uncontrolled property。Typescript：`T` | N
+value | String / Number / Boolean | - | `v-model` and `v-model:value` is supported。Typescript：`T` `type RadioValue = string \| number \| boolean`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
+defaultValue | String / Number / Boolean | - | uncontrolled property。Typescript：`T` `type RadioValue = string \| number \| boolean`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
 variant | String | outline | options：outline/primary-filled/default-filled | N
 onChange | Function |  | Typescript：`(value: T, context: { e: Event }) => void`<br/> | N
 

--- a/src/radio/radio.md
+++ b/src/radio/radio.md
@@ -9,10 +9,10 @@ allowUncheck | Boolean | false | 是否允许取消选中 | N
 checked | Boolean | false | 是否选中。支持语法糖 `v-model` 或 `v-model:checked` | N
 defaultChecked | Boolean | false | 是否选中。非受控属性 | N
 default | String / Slot / Function | - | 单选按钮内容，同 label。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-disabled | Boolean | undefined | 是否为禁用态 | N
+disabled | Boolean | undefined | 是否为禁用态。如果存在父组件 RadioGroup，默认值由 RadioGroup.disabled 控制。Radio.disabled 优先级高于 RadioGroup.disabled | N
 label | String / Slot / Function | - | 主文案。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 name | String | - | HTML 元素原生属性 | N
-value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`T` | N
+value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`string \| number \| boolean` | N
 onChange | Function |  | TS 类型：`(checked: boolean, context: { e: Event }) => void`<br/>选中状态变化时触发 | N
 onClick | Function |  | TS 类型：`(context: { e: MouseEvent }) => void`<br/>点击时出发，一般用于外层阻止冒泡场景 | N
 
@@ -28,12 +28,12 @@ click | `(context: { e: MouseEvent })` | 点击时出发，一般用于外层阻
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 allowUncheck | Boolean | false | 是否允许取消选中 | N
-disabled | Boolean | undefined | 是否禁用全部子单选框 | N
+disabled | Boolean | - | 是否禁用全部子单选框。默认为 false。RadioGroup.disabled 优先级低于 Radio.disabled | N
 name | String | - | HTML 元素原生属性 | N
-options | Array | - | 单选组件按钮形式。RadioOption 数据类型为 string 或 number 时，表示 label 和 value 值相同。TS 类型：`Array<RadioOption>` `type RadioOption = string \| number \| RadioOptionObj` `interface RadioOptionObj { label?: string \| TNode; value?: string \| number; disabled?: boolean }`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
+options | Array | - | 单选组件按钮形式。RadioOption 数据类型为 string 或 number 时，表示 label 和 value 值相同。TS 类型：`Array<RadioOption>` `type RadioOption = string \| number \| RadioOptionObj` `interface RadioOptionObj { label?: string \| TNode; value?: string \| number \| boolean; disabled?: boolean }`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
 size | String | medium | 组件尺寸【讨论中】。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-value | String / Number / Boolean | - | 选中的值。支持语法糖 `v-model` 或 `v-model:value`。TS 类型：`T` | N
-defaultValue | String / Number / Boolean | - | 选中的值。非受控属性。TS 类型：`T` | N
+value | String / Number / Boolean | - | 选中的值。支持语法糖 `v-model` 或 `v-model:value`。TS 类型：`T` `type RadioValue = string \| number \| boolean`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
+defaultValue | String / Number / Boolean | - | 选中的值。非受控属性。TS 类型：`T` `type RadioValue = string \| number \| boolean`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/radio/type.ts) | N
 variant | String | outline | 单选组件按钮形式。可选项：outline/primary-filled/default-filled | N
 onChange | Function |  | TS 类型：`(value: T, context: { e: Event }) => void`<br/>选中值发生变化时触发 | N
 

--- a/src/radio/type.ts
+++ b/src/radio/type.ts
@@ -6,7 +6,7 @@
 
 import { TNode, SizeEnum } from '../common';
 
-export interface TdRadioProps<T = RadioValue> {
+export interface TdRadioProps {
   /**
    * 是否允许取消选中
    * @default false
@@ -32,7 +32,7 @@ export interface TdRadioProps<T = RadioValue> {
    */
   default?: string | TNode;
   /**
-   * 是否为禁用态
+   * 是否为禁用态。如果存在父组件 RadioGroup，默认值由 RadioGroup.disabled 控制。Radio.disabled 优先级高于 RadioGroup.disabled
    */
   disabled?: boolean;
   /**
@@ -47,7 +47,7 @@ export interface TdRadioProps<T = RadioValue> {
   /**
    * 单选按钮的值
    */
-  value?: T;
+  value?: string | number | boolean;
   /**
    * 选中状态变化时触发
    */
@@ -65,7 +65,7 @@ export interface TdRadioGroupProps<T = RadioValue> {
    */
   allowUncheck?: boolean;
   /**
-   * 是否禁用全部子单选框
+   * 是否禁用全部子单选框。默认为 false。RadioGroup.disabled 优先级低于 Radio.disabled
    */
   disabled?: boolean;
   /**
@@ -105,12 +105,12 @@ export interface TdRadioGroupProps<T = RadioValue> {
   onChange?: (value: T, context: { e: Event }) => void;
 }
 
-export type RadioValue = string | number | boolean;
-
 export type RadioOption = string | number | RadioOptionObj;
 
 export interface RadioOptionObj {
   label?: string | TNode;
-  value?: string | number;
+  value?: string | number | boolean;
   disabled?: boolean;
 }
+
+export type RadioValue = string | number | boolean;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
```
const options=[
  { value: true,  label: '启用' },
  { value: false, label: '停用' }
]

<t-radio-group name="status" :options="options" ></t-radio-group>
```
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(RadioGroup): `options.value` 支持 `boolean`

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
