### PR TITLE
fix(input-number): change decimal value on blur when end of 0

### DIFF
--- a/src/input-number/useInputNumber.tsx
+++ b/src/input-number/useInputNumber.tsx
@@ -151,7 +151,7 @@ export default function useInputNumber(props: TdInputNumberProps) {
     }
     // specialCode 新增或删除这些字符时不触发 change 事件
     const isDelete = (e as InputEvent).inputType === 'deleteContentBackward';
-    const inputSpecialCode = specialCode.includes(val.slice(-1)) || /\.0+$/.test(val);
+    const inputSpecialCode = specialCode.includes(val.slice(-1)) || /\.\d*0+$/.test(val); // 输入特殊字符不改变当前值
     const deleteSpecialCode = isDelete && specialCode.includes(String(userInput.value).slice(-1));
     if ((!isNaN(Number(val)) && !inputSpecialCode) || deleteSpecialCode) {
       const newVal = val === '' ? undefined : Number(val);
@@ -180,7 +180,7 @@ export default function useInputNumber(props: TdInputNumberProps) {
       decimalPlaces,
       largeNumber,
     });
-    if (newValue !== value && String(newValue) !== value) {
+    if ((newValue !== value && String(newValue) !== value) || Number(newValue) !== Number(tValue.value)) {
       setTValue(newValue, { type: 'blur', e: ctx.e });
     }
     props.onBlur?.(newValue, ctx);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://codesandbox.io/s/tdesign-vue-demo-forked-m372sx?file=/src/demo.vue
如 当输入1.01后失焦，再输入1.00，会被重置会1.01
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(InputNumber): 修复小数位操作以 `0` 结尾时部分边界场景异常的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
