### PR TITLE
fix(dropdown): 修复下拉菜单配置template的content或prefixIcon插槽时未进行渲染的问题

### DIFF
--- a/src/dropdown/hooks/useDropdownOptions.ts
+++ b/src/dropdown/hooks/useDropdownOptions.ts
@@ -42,7 +42,7 @@ export const getOptionsFromChildren = (menuNode: VNode | VNode[]): DropdownOptio
         );
 
         // 将item.props的属性名都转成驼峰，再进行传递
-        const itemProps = Object.keys(item.props).reduce((props, propName) => {
+        const itemProps = Object.keys(item.props || {}).reduce((props, propName) => {
           props[camelCase(propName)] = item.props[propName];
           return props;
         }, {});

--- a/src/dropdown/hooks/useDropdownOptions.ts
+++ b/src/dropdown/hooks/useDropdownOptions.ts
@@ -1,6 +1,7 @@
 import { computed, ComputedRef, VNode, getCurrentInstance, Slots } from 'vue';
 import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
+import camelCase from 'lodash/camelCase';
 
 import { useChildComponentSlots } from '../../hooks/slot';
 import type { DropdownOption, TdDropdownProps } from '../type';
@@ -26,6 +27,8 @@ export const getOptionsFromChildren = (menuNode: VNode | VNode[]): DropdownOptio
     }, []);
     return menuNode
       .map((item) => {
+        const slotContent = (item.children as any)?.content?.();
+        const slotPrefixIcon = (item.children as any)?.prefixIcon?.() || (item.children as any)?.['prefix-icon']?.();
         const groupChildren = (item.children as any)?.default?.();
 
         // 当前节点的渲染内容
@@ -38,9 +41,16 @@ export const getOptionsFromChildren = (menuNode: VNode | VNode[]): DropdownOptio
             !isString(v.children) && ['TDropdownMenu', 'TDropdownItem'].includes((v.type as { name: string })?.name),
         );
 
+        // 将item.props的属性名都转成驼峰，再进行传递
+        const itemProps = Object.keys(item.props).reduce((props, propName) => {
+          props[camelCase(propName)] = item.props[propName];
+          return props;
+        }, {});
+
         return {
-          content: contentCtx || groupChildren,
-          ...item.props,
+          content: slotContent || contentCtx || groupChildren,
+          ...itemProps,
+          ...(slotPrefixIcon ? { prefixIcon: () => slotPrefixIcon } : {}),
           children: childrenCtx?.length > 0 ? getOptionsFromChildren(childrenCtx) : null,
         };
       })


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[2688](https://github.com/Tencent/tdesign-vue-next/issues/2688)

### 💡 需求背景和解决方案

#### 一. 要解决的具体问题：
1.template配置的content和prefixIcon插槽未进行渲染
2.传递子元素属性时，未做驼峰转换，子元素读取属性时又是通过驼峰属性名读取

#### 二. 处理方案：
1.已有的处理方案：
- dropdown是通过解析所有子元素然后生成options的数据，再传递给dropdown-menu的，处理过程未读取template
- 传递子元素属性时，未做属性驼峰转换

2.解决方案：
- 增加template的content和prefixIcon的插槽读取，优先template
- 传递子元素属性时，做属性名的驼峰转换处理

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dropdown): 修复下拉菜单配置 `template` 的 `content` 或 `prefixIcon` 插槽时未进行渲染的问题([issues #2688](https://github.com/Tencent/tdesign-vue-next/issues/2688))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
