### PR TITLE
fix(table): fix table 'resizable' API failure

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -40,7 +40,7 @@ export default defineComponent({
      */
     renderExpandedRow: Function as PropType<BaseTableProps['renderExpandedRow']>,
     onLeafColumnsChange: Function as PropType<BaseTableProps['onLeafColumnsChange']>,
-    thDraggable: Boolean,
+    thDraggable: [Boolean, undefined],
   },
 
   setup(props: BaseTableProps, context: SetupContext) {

--- a/src/table/interface.ts
+++ b/src/table/interface.ts
@@ -21,7 +21,7 @@ export interface BaseTableProps extends TdBaseTableProps {
   /**
    * 表头是否可拖拽。非公开属性，请勿在业务中使用
    */
-  thDraggable?: boolean;
+  thDraggable?: boolean | undefined;
 }
 
 export type PrimaryTableProps = TdPrimaryTableProps;

--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -335,7 +335,7 @@ export default defineComponent({
         bottomContent,
         firstFullRow,
         lastFullRow,
-        thDraggable: props.dragSort === 'col',
+        thDraggable: props.dragSort ? props.dragSort === 'col' : undefined,
         onPageChange: onInnerPageChange,
         renderExpandedRow: showExpandedRow.value ? renderExpandedRow : undefined,
       };

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -158,7 +158,7 @@ export default defineComponent({
           const styles = { ...(thStyles.style || {}), width };
           const innerTh = renderTitle(this.slots, col, index);
           const resizeColumnListener =
-            this.resizable || !canDragSort
+            this.resizable || (!canDragSort && this.thDraggable !== undefined)
               ? {
                   onMousedown: (e: MouseEvent) => {
                     this.columnResizeParams?.onColumnMousedown?.(e, col, index);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2699]
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 当前 resizable 单独设置无效 需要结合 dragSort使用
2. 内部 thDraggable 属性 增加 undefined 类型
### 📝 更新日志


<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复table resizable API失效 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
