### PR TITLE
fix(popup): 修复触发元素隐藏时，popper仍显示到页面左上角的问题

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -253,8 +253,18 @@ export default defineComponent({
     function updatePopper() {
       if (!popperEl.value || !visible.value) return;
       if (popper) {
-        popper.state.elements.reference = triggerEl.value;
-        popper.update();
+        const rect = triggerEl.value.getBoundingClientRect();
+        let parent = triggerEl.value;
+        while (parent && parent !== document.body) {
+          parent = parent.parentElement;
+        }
+        const isHidden = parent !== document.body || (rect.width === 0 && rect.height === 0);
+        if (!isHidden) {
+          popper.state.elements.reference = triggerEl.value;
+          popper.update();
+        } else {
+          setVisible(false, { trigger: getTriggerType({ type: 'mouseenter' } as Event) });
+        }
         return;
       }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2697](https://github.com/Tencent/tdesign-vue-next/issues/2697)

### 💡 需求背景和解决方案

#### 1. 要解决的具体问题
触发元素隐藏时，popper仍显示到页面左上角
##### 可能出现隐藏的情况：
- 触发元素或其上级元素通过block none隐藏了
- 触发元素或其上级元素从document.body中移除

#### 2. 处理方案
- 通过getBoundingClientRect判断触发元素的宽高是否为0了
- 是否还在document.body中
- 如果宽高为0或者不在document.body中，则做隐藏处理

### 📝 更新日志

- fix(Popup): 修复触发元素隐藏时，`popper` 仍显示到页面左上角的问题([#2697](https://github.com/Tencent/tdesign-vue-next/issues/2697))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
