### PR TITLE
fix(table): column resizable

### DIFF
--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -161,7 +161,9 @@ export default defineComponent({
             this.resizable || !canDragSort
               ? {
                   onMousedown: (e: MouseEvent) => {
-                    this.columnResizeParams?.onColumnMousedown?.(e, col, index);
+                    if (this.resizable) {
+                      this.columnResizeParams?.onColumnMousedown?.(e, col, index);
+                    }
                     if (!canDragSort) {
                       const timer = setTimeout(() => {
                         const thList = this.theadRef.querySelectorAll('th');
@@ -170,7 +172,9 @@ export default defineComponent({
                       }, 10);
                     }
                   },
-                  onMousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e, col),
+                  onMousemove: (e: MouseEvent) => {
+                    this.resizable && this.columnResizeParams?.onColumnMouseover?.(e, col);
+                  },
                 }
               : {};
           const content = isFunction(col.ellipsisTitle) ? col.ellipsisTitle(h, { col, colIndex: index }) : undefined;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 列宽调整功能，修复即使 `resizable=false` 时，也会显示拖拽调整列宽图标和辅助线问题，[issue#2699](https://github.com/Tencent/tdesign-vue-next/issues/2699)
- fix(Table): 列宽调整功能，修复在拖拽任意列宽使表格横向滚动条消失之后列宽无法正常调整的问题，即支持 `resize.minWidth`
- fix(Table): 列宽调整功能，修复开启多级表头时点击子表头后控制台报错的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
