### PR TITLE
docs(icon): 修复 manifest 统一入口导出 esm 模块，文档为及时更新的问题

### DIFF
--- a/src/icon/_example/icon-select.vue
+++ b/src/icon/_example/icon-select.vue
@@ -15,7 +15,7 @@
 </template>
 <script setup>
 import { ref } from 'vue';
-import { manifest } from 'tdesign-icons-vue-next/lib/manifest';
+import { manifest } from 'tdesign-icons-vue-next';
 // 获取全部图标的列表
 const options = ref(manifest);
 const value = ref('add');

--- a/src/icon/icon.md
+++ b/src/icon/icon.md
@@ -54,7 +54,7 @@
 
 #### 如何获取全部图标的名称列表？
 
-可以通过`import { manifest } from 'tdesign-icons-vue-next/lib/manifest'` 获取全部图标的名称列表。
+可以通过`import { manifest } from 'tdesign-icons-vue-next'` 获取全部图标的名称列表。
 
 ### t-icon、iconfont和icon使用时都会发起网络请求，我的项目是无网络场景，如何使用？
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

在用户群，有使用者反馈导入所有图标提示报错，经过排查发现因为 vite 的原生 module 加载方式不支持 cjs。现在改用入口导出的 esm 内容。

![image](https://user-images.githubusercontent.com/60692794/232662550-b9560279-4a54-457e-a8f7-934d82693022.png)

![image](https://user-images.githubusercontent.com/60692794/232662497-e6d37622-8f71-4d2e-bd74-7e60e785083a.png)

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- docs(icon): 修复 manifest 统一入口导出 esm 模块，文档为及时更新的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
