### PR TITLE
fix(table): 修复取消表尾吸底时requestAnimationFrame在Unmounted之后仍执行了一次导致的异常问题

### DIFF
--- a/src/affix/affix.tsx
+++ b/src/affix/affix.tsx
@@ -24,10 +24,12 @@ export default defineComponent({
 
     const scrollContainer = ref<ScrollContainerElement>();
     const affixStyle = ref<Record<string, any>>();
+    let rAFId = 0;
 
     const handleScroll = () => {
       if (!ticking.value) {
-        window.requestAnimationFrame(() => {
+        rAFId = window.requestAnimationFrame(() => {
+          rAFId = 0;
           const {
             top: wrapToTop,
             width: wrapWidth,
@@ -104,6 +106,9 @@ export default defineComponent({
       if (!scrollContainer.value || !binded.value) return;
       off(scrollContainer.value, 'scroll', handleScroll);
       off(window, 'resize', handleScroll);
+      if (rAFId) {
+        window.cancelAnimationFrame(rAFId);
+      }
       binded.value = false;
     };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2744](https://github.com/Tencent/tdesign-vue-next/issues/2744)

### 💡 需求背景和解决方案

#### 1. 要解决的具体问题:
requestAnimationFrame在Unmounted之后仍执行了一次 导致异常报错

#### 2.处理方案
获取requestAnimationFrame的返回 ID，在BeforeUnmount进行cancelAnimationFrame调用取消后续的requestAnimationFrame的执行

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复取消表尾吸底时requestAnimationFrame在Unmounted之后仍执行了一次导致的异常问题([issue #2744](https://github.com/Tencent/tdesign-vue-next/issues/2744))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
