### PR TITLE
fix(DateRangePicker): 修复valueType的validator校验错误

### DIFF
--- a/src/date-picker/date-range-picker-props.ts
+++ b/src/date-picker/date-range-picker-props.ts
@@ -136,15 +136,15 @@ export default {
     validator(val: TdDateRangePickerProps['valueType']): boolean {
       if (!val) return true;
       return [
-        'time-stamp' ||
-          'Date' ||
-          'YYYY' ||
-          'YYYY-MM' ||
-          'YYYY-MM-DD' ||
-          'YYYY-MM-DD HH' ||
-          'YYYY-MM-DD HH:mm' ||
-          'YYYY-MM-DD HH:mm:ss' ||
-          'YYYY-MM-DD HH:mm:ss:SSS',
+        'time-stamp',
+        'Date',
+        'YYYY',
+        'YYYY-MM',
+        'YYYY-MM-DD',
+        'YYYY-MM-DD HH',
+        'YYYY-MM-DD HH:mm',
+        'YYYY-MM-DD HH:mm:ss',
+        'YYYY-MM-DD HH:mm:ss:SSS',
       ].includes(val);
     },
   },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2755](https://github.com/Tencent/tdesign-vue-next/issues/2755)

### 💡 需求背景和解决方案

#### 1.问题：
校验器使用 || 并值，只会得到第一个值

#### 2.处理方案：
把( || ) 改成( , )号，确保数组是类型的所有值

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DateRangePicker): 修复valueType的validator校验错误([issue #2755](https://github.com/Tencent/tdesign-vue-next/issues/2755))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
