### PR TITLE
fix(Table): open ellipsis and virtual scroll console error

### DIFF
--- a/src/table/ellipsis.tsx
+++ b/src/table/ellipsis.tsx
@@ -67,6 +67,7 @@ export default defineComponent({
     };
 
     const onTriggerMouseleave = () => {
+      if (!root.value) return;
       isOverflow.value = isNodeOverflow(root.value);
     };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2796](https://github.com/Tencent/tdesign-vue-next/issues/2796)

### 💡 需求背景和解决方案

#### 1.具体问题
开启省略号ellipsis和虚拟滚动后，快速滚动控制台报读取null的属性异常

原因是：
开启debounce后，延迟80ms后节点不存在了，仍调用了isNodeOverflow方法

#### 2.处理方案
先判断一下节点是否存在，如果存在才继续执行后续函数逻辑

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): open ellipsis and virtual scroll console error ([issue #2796](https://github.com/Tencent/tdesign-vue-next/issues/2796))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
