### PR TITLE
fix(popup): call close method will get error

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -221,7 +221,7 @@ export default defineComponent({
 
     expose({
       update: updatePopper,
-      close: hide,
+      close: () => hide(),
       getOverlay() {
         return overlayEl.value;
       },
@@ -294,7 +294,7 @@ export default defineComponent({
       }, delay.value.show);
     }
 
-    function hide(ev: Event) {
+    function hide(ev?: Event) {
       clearAllTimeout();
       hideTimeout = setTimeout(() => {
         setVisible(false, { trigger: getTriggerType(ev) });
@@ -306,8 +306,8 @@ export default defineComponent({
       clearTimeout(hideTimeout);
     }
 
-    function getTriggerType(ev: Event) {
-      switch (ev.type) {
+    function getTriggerType(ev?: Event) {
+      switch (ev?.type) {
         case 'mouseenter':
         case 'mouseleave':
           return 'trigger-element-hover';
@@ -322,6 +322,8 @@ export default defineComponent({
           return 'keydown-esc';
         case 'mousedown':
           return 'document';
+        default:
+          return 'trigger-element-close';
       }
     }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2835 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

暴露出的`close`方法由用户调用时大概率是不会传`event`事件的。因此在暴露`close`方法时不传参数，让`switch`走`default`判断，这里的`triggerType`可能需要决定一下叫啥名字。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): 修复调用popup组件暴露的`close()`时报错([issue #2835](https://github.com/Tencent/tdesign-vue-next/issues/2835))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
