### PR TITLE
fix(radio-group): 如果父元素width设置为100%, 滑动块样式不会自动重新计算位置和偏移

### DIFF
--- a/src/radio/group.tsx
+++ b/src/radio/group.tsx
@@ -15,6 +15,8 @@ import {
 import isString from 'lodash/isString';
 import isNumber from 'lodash/isNumber';
 import isNil from 'lodash/isNil';
+import throttle from 'lodash/throttle';
+
 import props from './radio-group-props';
 import { RadioOptionObj, RadioOption } from './type';
 import Radio from './radio';
@@ -26,6 +28,7 @@ import useKeyboard from './useKeyboard';
 import isFunction from 'lodash/isFunction';
 import { useMutationObserver } from '../watermark/hooks';
 import type { UseMutationObserverReturn } from '../watermark/hooks';
+import useResizeObserver from '../hooks/useResizeObserver';
 
 export default defineComponent({
   name: 'TRadioGroup',
@@ -82,8 +85,16 @@ export default defineComponent({
       await nextTick();
       calcBarStyle();
     });
+
     onMounted(() => {
       calcBarStyle();
+      useResizeObserver(
+        radioGroupRef,
+        throttle(async () => {
+          await nextTick();
+          calcBarStyle();
+        }, 300),
+      );
 
       const checkedRadioLabel: HTMLElement = radioGroupRef.value.querySelector(
         `${checkedClassName.value} .${radioBtnName.value}__label`,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

暂时未提issue

### 💡 需求背景和解决方案

如果父元素width设置为100%, 滑动块样式不会自动重新计算位置和偏移, 导致容易出现这样的情况.
![image](https://github.com/Tencent/tdesign-vue-next/assets/32406368/b016c0fc-89ac-4ceb-80c3-8fc6905ab9e4)

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog
- fix(RadioGroup): 修复父元素 `width` 设置为 `100%`, 滑动块样式不会自动重新计算位置和偏移

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
