### PR TITLE
fix(message): messagePlugin extraApi return wrong Message instance

### DIFF
--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -39,7 +39,7 @@ export const MessageList = defineComponent({
     const add = (msg: MessageOptions): number => {
       const mg = { ...msg, key: getUniqueId() };
       list.value.push(mg);
-      return list.value.length - 1;
+      return mg.key;
     };
 
     const remove = (index: number) => {

--- a/src/message/plugin.tsx
+++ b/src/message/plugin.tsx
@@ -66,6 +66,7 @@ const MessageFunction = (props: MessageOptions): Promise<MessageInstance> => {
     instanceMap.set(attachDom, {});
   }
   const p = instanceMap.get(attachDom)[placement];
+  let mgKey: number;
   if (!p) {
     const wrapper = document.createElement('div');
 
@@ -74,18 +75,18 @@ const MessageFunction = (props: MessageOptions): Promise<MessageInstance> => {
       placement: options.placement,
     }).mount(wrapper);
 
-    instance.add(options);
+    mgKey = instance.add(options);
     instanceMap.get(attachDom)[placement] = instance;
     attachDom.appendChild(wrapper);
   } else {
-    p.add(options);
+    mgKey = p.add(options);
   }
   // 返回最新消息的 Element
   return new Promise((resolve) => {
     const ins = instanceMap.get(attachDom)[placement];
     nextTick(() => {
       const msg: Array<MessageInstance> = ins.messageList;
-      resolve(msg[msg.length - 1]);
+      resolve(msg?.find((mg) => mg.$?.vnode?.key === mgKey));
     });
   });
 };
@@ -122,7 +123,7 @@ const extraApi: ExtraApi = {
   question: (params, duration) => showThemeMessage('question', params, duration),
   loading: (params, duration) => showThemeMessage('loading', params, duration),
   close: (promise) => {
-    promise.then((instance) => instance.close());
+    promise.then((instance) => instance?.close());
   },
   closeAll: () => {
     if (instanceMap instanceof Map) {

--- a/src/message/type.ts
+++ b/src/message/type.ts
@@ -4,6 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
+import { ComponentPublicInstance } from 'vue';
 import { TNode, AttachNode } from '../common';
 
 export interface TdMessageProps {
@@ -88,7 +89,7 @@ export type MessagePlacementList =
   | 'bottom-left'
   | 'bottom-right';
 
-export interface MessageInstance {
+export interface MessageInstance extends ComponentPublicInstance {
   close: () => void;
 }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
MessagePlugin.close方法在同时显示多个TMessage的时候会导致调用错对应TMessage Instance的close方法，导致关闭了错误的TMessage

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
https://stackblitz.com/edit/dq51jw-y8h43c?file=package.json,src%2Fdemo.vue
复现代码：
```javascript
new Promise((resolve) => {
  const uploading1 = MessagePlugin.loading(`loading 1`, 0);
  setTimeout(() => {
    MessagePlugin.close(uploading1);
    MessagePlugin.success('success 1', 0);
    resolve(true);
  }, 1000);
});
new Promise((resolve) => {
  const uploading2 = MessagePlugin.loading(`loading 2`, 0);
  setTimeout(() => {
    MessagePlugin.close(uploading2);
    MessagePlugin.success('success 2', 0);
    resolve(true);
  }, 5000);
});
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(message): 修复同时显示多个Message时，会导致调用错误的关闭方法导致关闭错误的Message的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
