### PR TITLE
fix(ImageViewer): closeBtn渲染异常

### DIFF
--- a/src/image-viewer/image-viewer.tsx
+++ b/src/image-viewer/image-viewer.tsx
@@ -191,6 +191,20 @@ export default defineComponent({
       );
     };
 
+    const renderCloseBtn = () => {
+      if (props.closeBtn === false) {
+        return;
+      }
+      return (
+        <div
+          class={[`${COMPONENT_NAME.value}__modal-icon`, `${COMPONENT_NAME.value}__modal-close-bt`]}
+          onClick={closeBtnAction}
+        >
+          {renderTNodeJSX('closeBtn', <CloseIcon size="24px" />)}
+        </div>
+      );
+    };
+
     return () => {
       if (props.mode === 'modeless') {
         return (
@@ -245,12 +259,7 @@ export default defineComponent({
                       {renderNavigationArrow('next')}
                     </>
                   )}
-                  <div
-                    class={[`${COMPONENT_NAME.value}__modal-icon`, `${COMPONENT_NAME.value}__modal-close-bt`]}
-                    onClick={closeBtnAction}
-                  >
-                    {renderTNodeJSX('closeBtn', <CloseIcon size="24px" />)}
-                  </div>
+                  {renderCloseBtn()}
                   <TImageViewerUtils
                     onZoomIn={onZoomIn}
                     onZoomOut={onZoomOut}


### PR DESCRIPTION
closed #2872

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2872 #2858 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

fix(ImageViewer): `closeBtn` 渲染异常([issue #2872](https://github.com/Tencent/tdesign-vue-next/issues/2872))([issue #2858](https://github.com/Tencent/tdesign-vue-next/issues/2858))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
