### PR TITLE
fix: menu popup style

### DIFF
--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -226,7 +226,7 @@ export default defineComponent({
       if (!this.isNested && this.isHead) {
         placement = 'bottom-left';
       }
-      const overlayInnerStyle = this.isNested && this.isHead ? { marginLeft: '0px' } : { [`margin-top': `]: '12px' };
+      const overlayInnerStyle = this.isNested && this.isHead ? { marginLeft: '0px' } : { marginTop: '12px' };
 
       const popupWrapper = (
         <div
@@ -248,7 +248,7 @@ export default defineComponent({
       const realPopup = (
         <Popup
           overlayInnerClassName={[...this.popupClass]}
-          overlayClassName={`${this.classPrefix}-menu--${this.theme}`}
+          overlayClassName={[`${this.classPrefix}-menu--${this.theme}`, this.isHead && `${this.classPrefix}-is-head`]}
           visible={this.popupVisible}
           placement={placement as PopupPlacement}
           overlayInnerStyle={overlayInnerStyle}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

common: https://github.com/Tencent/tdesign-common/pull/1366

线上样式：
顶部导航菜单位置有误
<img width="954" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/7600149/b2493456-0def-4dad-b937-c9a3bccae473">

dark 主题下弹窗菜单缺少边框：
<img width="646" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/7600149/2866cafb-28a7-41fd-87ed-18605c21a65a">

与设计稿不符：
https://www.figma.com/community/file/1053279236128724321/TDesign-for-web
<img width="1091" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/7600149/c646be44-5a07-46db-aa45-5ad2d828808d">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): 修复顶部导航菜单位置有误的问题
- fix(Menu): 修复 `theme = dark` 模式下弹窗菜单缺少边框样式的问题 https://github.com/Tencent/tdesign-common/pull/1366

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
