### PR TITLE
fix(image-viewer): download img with params the file ext is lost

### DIFF
--- a/src/image-viewer/utils.ts
+++ b/src/image-viewer/utils.ts
@@ -5,7 +5,7 @@ import { TdImageViewerProps, ImageInfo } from './type';
 
 export const downloadFile = function (imgSrc: string) {
   const image = new Image();
-  const name = imgSrc?.split?.('/').pop() || Math.random().toString(32).slice(2);
+  const name = imgSrc?.split?.('?')?.[0]?.split?.('#')?.[0]?.split?.('/').pop() || Math.random().toString(32).slice(2);
 
   image.setAttribute('crossOrigin', 'anonymous');
 

--- a/src/image-viewer/utils.ts
+++ b/src/image-viewer/utils.ts
@@ -5,6 +5,9 @@ import { TdImageViewerProps, ImageInfo } from './type';
 
 export const downloadFile = function (imgSrc: string) {
   const image = new Image();
+  // fix #2935
+  // 当链接携带了参数时，需处理掉参数再取图片名称，否则扩展名会与参数链接导致原扩展名失效
+  // 例如：img.png?sign=xxx 不处理参数会被转成 img.png_sign=xxx
   const name = imgSrc?.split?.('?')?.[0]?.split?.('#')?.[0]?.split?.('/').pop() || Math.random().toString(32).slice(2);
 
   image.setAttribute('crossOrigin', 'anonymous');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#2395](https://github.com/Tencent/tdesign-vue-next/issues/2935)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1、问题
链接带参数时（?或#），扩展名失效

2、处理方案
做?和#的字符串分割，取无参数的部分再进行/分割，拿到最后的原文件名，再进行下载
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 修复图片链接带有参数时，下载时文件扩展名丢失 ([issue #2935](https://github.com/Tencent/tdesign-vue-next/issues/2935))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
