### PR TITLE
fix(color-picker): gradient mode support empty string

### DIFF
--- a/src/color-picker/color-picker.en-US.md
+++ b/src/color-picker/color-picker.en-US.md
@@ -15,12 +15,12 @@ format | String | RGB | options：RGB/RGBA/HSL/HSLA/HSB/HSV/HSVA/HEX/CMYK/CSS | 
 inputProps | Object | - | Typescript：`InputProps`，[Input API Documents](./input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
 multiple | Boolean | false | \- | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
-recentColors | Array | [] | used color recently。`v-model:recentColors` is supported。Typescript：`boolean \| Array<string>` | N
-defaultRecentColors | Array | [] | used color recently。uncontrolled property。Typescript：`boolean \| Array<string>` | N
+recentColors | Array | [] | used color recently。`v-model:recentColors` is supported。Typescript：`boolean \| Array<string> \| null` | N
+defaultRecentColors | Array | [] | used color recently。uncontrolled property。Typescript：`boolean \| Array<string> \| null` | N
 selectInputProps | Object | - | Typescript：`SelectInputProps`，[SelectInput API Documents](./select-input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
 showPrimaryColorPreview | Boolean | true | \- | N
 size | String | medium | options：small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-swatchColors | Array | - | swatch colors。Typescript：`Array<string>` | N
+swatchColors | Array | - | swatch colors。Typescript：`Array<string> \| null` | N
 value | String | - | color value。`v-model` and `v-model:value` is supported | N
 defaultValue | String | - | color value。uncontrolled property | N
 onChange | Function |  | Typescript：`(value: string, context: { color: ColorObject; trigger: ColorPickerChangeTrigger }) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts)。<br/>`type ColorPickerChangeTrigger = 'palette-saturation-brightness' \| 'palette-saturation' \| 'palette-brightness' \| 'palette-hue-bar' \| 'palette-alpha-bar' \| 'input' \| 'preset' \| 'recent' `<br/> | N

--- a/src/color-picker/color-picker.md
+++ b/src/color-picker/color-picker.md
@@ -15,12 +15,12 @@ format | String | RGB | 格式化色值。`enableAlpha` 为真时，`RGBA/HSLA/H
 inputProps | Object | - | 透传 Input 输入框组件全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
 multiple | Boolean | false | 【开发中】是否允许选中多个颜色 | N
 popupProps | Object | - | 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
-recentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。支持语法糖 `v-model:recentColors`。TS 类型：`boolean \| Array<string>` | N
-defaultRecentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。非受控属性。TS 类型：`boolean \| Array<string>` | N
+recentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。支持语法糖 `v-model:recentColors`。TS 类型：`boolean \| Array<string> \| null` | N
+defaultRecentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。非受控属性。TS 类型：`boolean \| Array<string> \| null` | N
 selectInputProps | Object | - | 透传 SelectInputProps 筛选器输入框组件全部属性。TS 类型：`SelectInputProps`，[SelectInput API Documents](./select-input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts) | N
 showPrimaryColorPreview | Boolean | true | 是否展示颜色选择条右侧的颜色预览区域 | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-swatchColors | Array | - | 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色。TS 类型：`Array<string>` | N
+swatchColors | Array | - | 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色。TS 类型：`Array<string> \| null` | N
 value | String | - | 色值。支持语法糖 `v-model` 或 `v-model:value` | N
 defaultValue | String | - | 色值。非受控属性 | N
 onChange | Function |  | TS 类型：`(value: string, context: { color: ColorObject; trigger: ColorPickerChangeTrigger }) => void`<br/>选中的色值发生变化时触发，第一个参数 `value` 表示新色值，`context.color` 表示当前调色板控制器的色值，`context.trigger` 表示触发颜色变化的来源。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/color-picker/type.ts)。<br/>`type ColorPickerChangeTrigger = 'palette-saturation-brightness' \| 'palette-saturation' \| 'palette-brightness' \| 'palette-hue-bar' \| 'palette-alpha-bar' \| 'input' \| 'preset' \| 'recent' `<br/> | N

--- a/src/color-picker/panel/format/index.tsx
+++ b/src/color-picker/panel/format/index.tsx
@@ -7,6 +7,7 @@ import { Color } from '../../utils';
 import { Select as TSelect, Option as TOption } from '../../../select';
 import FormatInputs from './inputs';
 import { useBaseClassName } from '../../hooks';
+import type { TdSelectInputProps } from '../../../select-input/type';
 
 export default defineComponent({
   name: 'FormatPanel',
@@ -71,6 +72,7 @@ export default defineComponent({
             {...selectInputProps}
             popupProps={{
               overlayClassName: `${baseClassName}__select-options`,
+              ...(selectInputProps as TdSelectInputProps).popupProps,
             }}
             v-model={this.formatModel}
             onChange={handleModeChange}

--- a/src/color-picker/panel/index.tsx
+++ b/src/color-picker/panel/index.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, toRefs, watch } from 'vue';
+import { defineComponent, ref, toRefs, watch, computed } from 'vue';
 import { useCommonClassName, useConfig } from '../../hooks/useConfig';
 import props from '../props';
 import {
@@ -37,9 +37,15 @@ export default defineComponent({
     const statusClassNames = STATUS.value;
     const { value: inputValue, modelValue, recentColors } = toRefs(props);
     const [innerValue, setInnerValue] = useVModel(inputValue, modelValue, props.defaultValue, props.onChange);
-    const color = ref<Color>(new Color(innerValue.value || DEFAULT_COLOR));
-    const updateColor = () => color.value.update(innerValue.value || DEFAULT_COLOR);
-    const mode = ref<TdColorModes>(color.value.isGradient ? 'linear-gradient' : 'monochrome');
+
+    const defaultEmptyColor = computed(() => (isGradient.value ? DEFAULT_LINEAR_GRADIENT : DEFAULT_COLOR));
+
+    const mode = ref<TdColorModes>(props.colorModes?.length === 1 ? props.colorModes[0] : 'monochrome');
+    const isGradient = computed(() => mode.value === 'linear-gradient');
+
+    const color = ref<Color>(new Color(innerValue.value || defaultEmptyColor.value));
+    const updateColor = () => color.value.update(innerValue.value || defaultEmptyColor.value);
+
     const formatModel = ref<TdColorPickerProps['format']>(color.value.isGradient ? 'CSS' : 'RGB');
 
     const [recentlyUsedColors, setRecentlyUsedColors] = useDefaultValue(
@@ -48,12 +54,6 @@ export default defineComponent({
       props.onRecentColorsChange,
       'recentColors',
     );
-
-    if (props.colorModes.length === 1) {
-      // eslint-disable-next-line vue/no-setup-props-destructure
-      const m = props.colorModes[0];
-      mode.value = m;
-    }
 
     const formatValue = () => {
       // 渐变模式下直接输出css样式
@@ -256,6 +256,7 @@ export default defineComponent({
       mode,
       formatModel,
       recentlyUsedColors,
+      isGradient,
       addRecentlyUsedColor,
       handleModeChange,
       handleSatAndValueChange,
@@ -269,8 +270,16 @@ export default defineComponent({
     };
   },
   render() {
-    const { t, baseClassName, statusClassNames, globalConfig, recentColors, swatchColors, showPrimaryColorPreview } =
-      this;
+    const {
+      t,
+      baseClassName,
+      statusClassNames,
+      globalConfig,
+      recentColors,
+      swatchColors,
+      showPrimaryColorPreview,
+      isGradient,
+    } = this;
     const baseProps = {
       color: this.color,
       disabled: this.disabled,
@@ -313,8 +322,6 @@ export default defineComponent({
         </>
       );
     };
-
-    const isGradient = this.mode === 'linear-gradient';
 
     return (
       <div class={[`${baseClassName}__panel`, this.disabled ? statusClassNames.disabled : false]}>

--- a/src/color-picker/type.ts
+++ b/src/color-picker/type.ts
@@ -61,12 +61,12 @@ export interface TdColorPickerProps {
    * 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”
    * @default []
    */
-  recentColors?: boolean | Array<string>;
+  recentColors?: boolean | Array<string> | null;
   /**
    * 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”，非受控属性
    * @default []
    */
-  defaultRecentColors?: boolean | Array<string>;
+  defaultRecentColors?: boolean | Array<string> | null;
   /**
    * 透传 SelectInputProps 筛选器输入框组件全部属性
    */
@@ -84,7 +84,7 @@ export interface TdColorPickerProps {
   /**
    * 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色
    */
-  swatchColors?: Array<string>;
+  swatchColors?: Array<string> | null;
   /**
    * 色值
    * @default ''


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/2904
- https://github.com/Tencent/tdesign-vue-next/issues/2903
- https://github.com/Tencent/tdesign-vue/issues/2498
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ColorPicker): 初始化为渐变模式时 支持空字符串作为初始值
- fix(ColorPicker): 修复 `recentColors` 等字段的类型问题
- fix(ColorPicker): 修复内部下拉选项未透传 `popupProps` 的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
