### PR TITLE
fix(input): 修复添加clearable属性并输入内容,hover时宽度变化

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -142,27 +142,33 @@ export default defineComponent({
         }
       }
 
-      if (showClear.value) {
-        // 如果类型为 password 则使用 passwordIcon 显示 clear
-        if (props.type === 'password') {
-          passwordIcon = (
-            <CloseCircleFilledIcon
-              ref={inputHandle.clearIconRef}
-              class={`${COMPONENT_NAME.value}__suffix-clear`}
-              onClick={inputHandle.emitClear}
-              onMousedown={inputHandle.onClearIconMousedown}
-            />
-          );
-        } else {
-          suffixIcon = (
-            <CloseCircleFilledIcon
-              ref={inputHandle.clearIconRef}
-              class={`${COMPONENT_NAME.value}__suffix-clear`}
-              onClick={inputHandle.emitClear}
-              onMousedown={inputHandle.onClearIconMousedown}
-            />
-          );
-        }
+      // 如果类型为 password 则使用 passwordIcon 显示 clear
+      if (props.type === 'password') {
+        passwordIcon = (
+          <CloseCircleFilledIcon
+            ref={inputHandle.clearIconRef}
+            class={[
+              `${COMPONENT_NAME.value}__suffix-clear`,
+              // showClear为false时，添加hidden样式
+              { [`${COMPONENT_NAME.value}__suffix-clear-hidden`]: !showClear.value },
+            ]}
+            onClick={inputHandle.emitClear}
+            onMousedown={inputHandle.onClearIconMousedown}
+          />
+        );
+      } else {
+        suffixIcon = (
+          <CloseCircleFilledIcon
+            ref={inputHandle.clearIconRef}
+            class={[
+              `${COMPONENT_NAME.value}__suffix-clear`,
+              // showClear为false时，添加hidden样式
+              { [`${COMPONENT_NAME.value}__suffix-clear-hidden`]: !showClear.value },
+            ]}
+            onClick={inputHandle.emitClear}
+            onMousedown={inputHandle.onClearIconMousedown}
+          />
+        );
       }
 
       const classes = [
@@ -230,7 +236,7 @@ export default defineComponent({
                 class={[
                   `${COMPONENT_NAME.value}__suffix`,
                   `${COMPONENT_NAME.value}__suffix-icon`,
-                  { [`${COMPONENT_NAME.value}__clear`]: showClear.value },
+                  `${COMPONENT_NAME.value}__clear`,
                 ]}
               >
                 {suffixIcon}

--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -37,10 +37,7 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
   const { limitNumber, getValueByLimitNumber, tStatus } = useLengthLimit(limitParams);
 
   const showClear = computed(() => {
-    return (
-      ((innerValue.value && !disabled.value && props.clearable && !props.readonly) || props.showClearIconOnEmpty) &&
-      isHover.value
-    );
+    return (innerValue.value && !disabled.value && props.clearable && !props.readonly) || props.showClearIconOnEmpty;
   });
 
   const focus = () => inputRef.value?.focus();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#3001](https://github.com/Tencent/tdesign-vue-next/issues/3001)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复前：
hover时会使得clear图标显示，宽度突然增加
![ioeu4-bm845](https://github.com/Tencent/tdesign-common/assets/134275252/68272de0-451a-4095-927c-02361a475600)



修复后：
当添加clearable属性时，会将clear图标进行占位不显示。
当有输入内容时展示图标（去除Hover时才展示图标的逻辑）。
![o9s4w-rf4uj](https://github.com/Tencent/tdesign-common/assets/134275252/3b169364-9138-4e26-b4c5-6293ae258a28)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(input): input 输入框添加clearable属性并输入内容，hover时宽度进行变化

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供