### PR TITLE
fix(calendar): custom range select wrong

### DIFF
--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -76,6 +76,22 @@ export default defineComponent({
       }
       return disabled;
     }
+    // 当存在日期范围限制时，改变年份后应将月份调整为合法月份
+    function adjustMonth(): void {
+      if (rangeFromTo.value?.from && rangeFromTo.value?.to) {
+        const beginYear = dayjs(rangeFromTo.value.from).year();
+        const endYear = dayjs(rangeFromTo.value.to).year();
+        const beginMon = parseInt(dayjs(rangeFromTo.value.from).format('M'), 10);
+        if (checkMonthAndYearSelectedDisabled(state.curSelectedYear, state.curSelectedMonth)) {
+          state.curSelectedMonth =
+            state.curSelectedYear === beginYear
+              ? beginMon
+              : state.curSelectedYear === endYear
+              ? 1
+              : state.curSelectedMonth;
+        }
+      }
+    }
     watch(
       () => {
         return {
@@ -106,11 +122,10 @@ export default defineComponent({
         }
 
         for (let i = begin; i <= end; i++) {
-          const disabled = checkMonthAndYearSelectedDisabled(i, state.curSelectedMonth);
           re.push({
             value: i,
             label: t(globalConfig.value.yearSelection, { year: i }),
-            disabled,
+            disabled: false,
           });
         }
         return re;
@@ -122,6 +137,7 @@ export default defineComponent({
         return controller.checkControllerDisabled('year', 'selectProps');
       }),
       monthSelectOptionList: computed<YearMonthOption[]>(() => {
+        adjustMonth();
         const re: YearMonthOption[] = [];
         for (let i = FIRST_MONTH_OF_YEAR; i <= LAST_MONTH_OF_YEAR; i++) {
           const disabled = checkMonthAndYearSelectedDisabled(state.curSelectedYear, i);

--- a/src/calendar/hook/useState.ts
+++ b/src/calendar/hook/useState.ts
@@ -24,6 +24,7 @@ export function useState(props: TdCalendarProps) {
 
   function toToday() {
     const curDate = createDefaultCurDate();
+    state.curDate = curDate;
     state.curSelectedYear = curDate.year();
     state.curSelectedMonth = parseInt(curDate.format('M'), 10);
   }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/3035
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

After fix：
![Jul333-03-2023 15-39-39333](https://github.com/Tencent/tdesign-vue-next/assets/41513919/c564c353-6f5d-467d-87ca-724aefda2865)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Calendar): 修复返回`今天/本月`，自定义日期的实际选择范围与定义不符([issue #3035](https://github.com/Tencent/tdesign-vue-next/issues/3035))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
