### PR TITLE
fix(range-input): prefix and suffix content reactive render

### DIFF
--- a/src/range-input/range-input.tsx
+++ b/src/range-input/range-input.tsx
@@ -45,12 +45,6 @@ export default defineComponent({
         ((props.clearable && props.value?.length && !disabled.value) || props.showClearIconOnEmpty) && isHover.value,
     );
 
-    const labelContent = renderTNodeJSX('label');
-    const prefixIconContent = renderTNodeJSX('prefixIcon');
-    const suffixContent = renderTNodeJSX('suffix');
-    const suffixIconContent = renderTNodeJSX('suffixIcon');
-    const tips = renderTNodeJSX('tips');
-
     const inputRefs = {
       firstInputRef: ref(),
       secondInputRef: ref(),
@@ -102,115 +96,122 @@ export default defineComponent({
       },
     });
 
-    return () => (
-      <div
-        class={[
-          COMPONENT_NAME.value,
-          {
-            [SIZE.value[props.size]]: props.size !== 'medium',
-            [STATUS.value.disabled]: disabled.value,
-            [STATUS.value.focused]: focused.value,
-            [STATUS.value.success]: props.status === 'success',
-            [STATUS.value.warning]: props.status === 'warning',
-            [STATUS.value.error]: props.status === 'error',
-            [`${COMPONENT_NAME.value}--prefix`]: prefixIconContent || labelContent,
-            [`${COMPONENT_NAME.value}--suffix`]: suffixContent || suffixIconContent,
-          },
-        ]}
-        onMouseenter={handleMouseEnter}
-        onMouseleave={handleMouseLeave}
-      >
-        <div class={`${COMPONENT_NAME.value}__inner`}>
-          {prefixIconContent && <div class={`${COMPONENT_NAME.value}__prefix`}>{prefixIconContent}</div>}
-          {labelContent ? <div class={`${COMPONENT_NAME.value}__prefix`}>{labelContent}</div> : null}
-          <Input
-            ref={inputRefs.firstInputRef}
-            class={`${COMPONENT_NAME.value}__inner-left`}
-            inputClass={{
-              [`${classPrefix.value}-is-focused`]: props.activeIndex === 0,
-            }}
-            placeholder={placeholder.value[0]}
-            disabled={disabled.value}
-            readonly={props.readonly}
-            format={format.value[0]}
-            value={innerValue.value?.[0]}
-            onClick={({ e }: { e: MouseEvent }) => props.onClick?.({ e, position: 'first' })}
-            onClear={() => setInnerValue([], { position: 'first', trigger: 'input' })}
-            onEnter={(val, { e }) =>
-              handleEnter([val, innerValue.value?.[1]], { e, position: 'first' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onFocus={(val, { e }) =>
-              handleFocus([val, innerValue.value?.[1]], { e, position: 'first' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onBlur={(val, { e }) =>
-              handleBlur([val, innerValue.value?.[1]], { e, position: 'first' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onChange={(val, { e }) =>
-              setInnerValue([val, innerValue.value?.[1]], { e, position: 'first', trigger: 'input' })
-            }
-            {...inputProps.value[0]}
-          />
+    return () => {
+      const labelContent = renderTNodeJSX('label');
+      const prefixIconContent = renderTNodeJSX('prefixIcon');
+      const suffixContent = renderTNodeJSX('suffix');
+      const suffixIconContent = renderTNodeJSX('suffixIcon');
+      const tips = renderTNodeJSX('tips');
+      return (
+        <div
+          class={[
+            COMPONENT_NAME.value,
+            {
+              [SIZE.value[props.size]]: props.size !== 'medium',
+              [STATUS.value.disabled]: disabled.value,
+              [STATUS.value.focused]: focused.value,
+              [STATUS.value.success]: props.status === 'success',
+              [STATUS.value.warning]: props.status === 'warning',
+              [STATUS.value.error]: props.status === 'error',
+              [`${COMPONENT_NAME.value}--prefix`]: prefixIconContent || labelContent,
+              [`${COMPONENT_NAME.value}--suffix`]: suffixContent || suffixIconContent,
+            },
+          ]}
+          onMouseenter={handleMouseEnter}
+          onMouseleave={handleMouseLeave}
+        >
+          <div class={`${COMPONENT_NAME.value}__inner`}>
+            {prefixIconContent && <div class={`${COMPONENT_NAME.value}__prefix`}>{prefixIconContent}</div>}
+            {labelContent ? <div class={`${COMPONENT_NAME.value}__prefix`}>{labelContent}</div> : null}
+            <Input
+              ref={inputRefs.firstInputRef}
+              class={`${COMPONENT_NAME.value}__inner-left`}
+              inputClass={{
+                [`${classPrefix.value}-is-focused`]: props.activeIndex === 0,
+              }}
+              placeholder={placeholder.value[0]}
+              disabled={disabled.value}
+              readonly={props.readonly}
+              format={format.value[0]}
+              value={innerValue.value?.[0]}
+              onClick={({ e }: { e: MouseEvent }) => props.onClick?.({ e, position: 'first' })}
+              onClear={() => setInnerValue([], { position: 'first', trigger: 'input' })}
+              onEnter={(val, { e }) =>
+                handleEnter([val, innerValue.value?.[1]], { e, position: 'first' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onFocus={(val, { e }) =>
+                handleFocus([val, innerValue.value?.[1]], { e, position: 'first' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onBlur={(val, { e }) =>
+                handleBlur([val, innerValue.value?.[1]], { e, position: 'first' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onChange={(val, { e }) =>
+                setInnerValue([val, innerValue.value?.[1]], { e, position: 'first', trigger: 'input' })
+              }
+              {...inputProps.value[0]}
+            />
 
-          <div class={`${COMPONENT_NAME.value}__inner-separator`}>{props.separator}</div>
+            <div class={`${COMPONENT_NAME.value}__inner-separator`}>{props.separator}</div>
 
-          <Input
-            ref={inputRefs.secondInputRef}
-            class={`${COMPONENT_NAME.value}__inner-right`}
-            inputClass={{
-              [`${classPrefix.value}-is-focused`]: props.activeIndex === 1,
-            }}
-            placeholder={placeholder.value[1]}
-            disabled={disabled.value}
-            readonly={props.readonly}
-            format={format.value[1]}
-            value={innerValue.value?.[1]}
-            onClick={({ e }: { e: MouseEvent }) => props.onClick?.({ e, position: 'second' })}
-            onClear={() => setInnerValue([], { position: 'second', trigger: 'input' })}
-            onEnter={(val, { e }) =>
-              handleEnter([innerValue.value?.[0], val], { e, position: 'second' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onFocus={(val, { e }) =>
-              handleFocus([innerValue.value?.[0], val], { e, position: 'second' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onBlur={(val, { e }) =>
-              handleBlur([innerValue.value?.[0], val], { e, position: 'second' } as {
-                e: any;
-                position: RangeInputPosition;
-              })
-            }
-            onChange={(val, { e }) =>
-              setInnerValue([innerValue.value?.[0], val], { e, position: 'second', trigger: 'input' })
-            }
-            {...inputProps.value[1]}
-          />
-          {suffixContent ? <div class={`${COMPONENT_NAME.value}__suffix`}>{suffixContent}</div> : null}
-          {suffixIconContent && (
-            <span class={`${COMPONENT_NAME.value}__suffix ${COMPONENT_NAME.value}__suffix-icon`}>
-              {isShowClearIcon.value ? (
-                <CloseCircleFilledIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={handleClear} />
-              ) : (
-                suffixIconContent
-              )}
-            </span>
-          )}
+            <Input
+              ref={inputRefs.secondInputRef}
+              class={`${COMPONENT_NAME.value}__inner-right`}
+              inputClass={{
+                [`${classPrefix.value}-is-focused`]: props.activeIndex === 1,
+              }}
+              placeholder={placeholder.value[1]}
+              disabled={disabled.value}
+              readonly={props.readonly}
+              format={format.value[1]}
+              value={innerValue.value?.[1]}
+              onClick={({ e }: { e: MouseEvent }) => props.onClick?.({ e, position: 'second' })}
+              onClear={() => setInnerValue([], { position: 'second', trigger: 'input' })}
+              onEnter={(val, { e }) =>
+                handleEnter([innerValue.value?.[0], val], { e, position: 'second' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onFocus={(val, { e }) =>
+                handleFocus([innerValue.value?.[0], val], { e, position: 'second' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onBlur={(val, { e }) =>
+                handleBlur([innerValue.value?.[0], val], { e, position: 'second' } as {
+                  e: any;
+                  position: RangeInputPosition;
+                })
+              }
+              onChange={(val, { e }) =>
+                setInnerValue([innerValue.value?.[0], val], { e, position: 'second', trigger: 'input' })
+              }
+              {...inputProps.value[1]}
+            />
+            {suffixContent ? <div class={`${COMPONENT_NAME.value}__suffix`}>{suffixContent}</div> : null}
+            {suffixIconContent && (
+              <span class={`${COMPONENT_NAME.value}__suffix ${COMPONENT_NAME.value}__suffix-icon`}>
+                {isShowClearIcon.value ? (
+                  <CloseCircleFilledIcon class={`${COMPONENT_NAME.value}__suffix-clear`} onClick={handleClear} />
+                ) : (
+                  suffixIconContent
+                )}
+              </span>
+            )}
+          </div>
+          {tips && <div class={`${COMPONENT_NAME.value}__tips`}>{tips}</div>}
         </div>
-        {tips && <div class={`${COMPONENT_NAME.value}__tips`}>{tips}</div>}
-      </div>
-    );
+      );
+    };
   },
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
<img width="623" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/26377630/9111cb43-2755-49d0-ad14-16b5e239a43b">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DateRangePicker): 修复`suffix` `prefix` 无法响应数据变化渲染的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
