### PR TITLE
fix: 修复 input number 内容为空时，值为 undefined 的问题，应当为 null

### DIFF
--- a/src/input-number/useInputNumber.tsx
+++ b/src/input-number/useInputNumber.tsx
@@ -88,13 +88,13 @@ export default function useInputNumber(props: TdInputNumberProps) {
         }
         const fixedNumber = Number(largeNumberToFixed(inputValue, decimalPlaces, largeNumber));
         if (decimalPlaces !== undefined && ![undefined, null].includes(val) && Number(fixedNumber) !== Number(tValue)) {
-          setTValue(fixedNumber, { type: 'props', e: undefined });
+          setTValue(fixedNumber, { type: 'props', e: null });
         }
       }
       if (largeNumber) {
         userInput.value = getUserInput(inputValue);
         if (decimalPlaces !== undefined && largeNumberToFixed(inputValue, decimalPlaces, largeNumber) !== val) {
-          setTValue(userInput.value, { type: 'props', e: undefined });
+          setTValue(userInput.value, { type: 'props', e: null });
         }
       }
     },
@@ -158,7 +158,8 @@ export default function useInputNumber(props: TdInputNumberProps) {
   const onInnerInputChange: TdInputProps['onChange'] = (inputValue, { e }) => {
     // 千分位处理
     const val = formatThousandths(inputValue);
-    if (!canInputNumber(val, props.largeNumber)) return;
+
+    if (!canInputNumber(val, props.largeNumber)) return null;
 
     userInput.value = val;
 
@@ -168,14 +169,14 @@ export default function useInputNumber(props: TdInputNumberProps) {
     }
 
     if (canSetValue(String(val), Number(tValue.value))) {
-      const newVal = val === '' ? undefined : Number(val);
+      const newVal = val === '' ? null : Number(val);
       setTValue(newVal, { type: 'input', e });
     }
   };
 
   const handleBlur = (value: string, ctx: { e: FocusEvent }) => {
     const { largeNumber, max, min, decimalPlaces } = props;
-    if (!props.allowInputOverLimit && tValue.value !== undefined) {
+    if (!props.allowInputOverLimit && tValue.value !== null) {
       const r = getMaxOrMinValidateResult({ value: tValue.value, largeNumber, max, min });
       if (r === 'below-minimum') {
         setTValue(min, { type: 'blur', e: ctx.e });
@@ -191,6 +192,7 @@ export default function useInputNumber(props: TdInputNumberProps) {
       largeNumber,
     });
     userInput.value = getUserInput(newValue);
+
     if (newValue !== tValue.value) {
       setTValue(newValue, { type: 'blur', e: ctx.e });
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #2900 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(InputNumber): 修复 `input-number` 内容为空时，值为 `undefined` 的问题，应当为 `null` ([issue #2900](https://github.com/Tencent/tdesign-vue-next/issues/2900))

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
