### PR TITLE
fix(tree): 修复Tree active事件中actived值相反(#3110)

### DIFF
--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -88,6 +88,7 @@ export default function useTree(props: TdTreeProps) {
       const tnode = getNode(treeStore.value, node);
       const actived = node.setActived(!tnode.isActived());
       ctx.node.actived = actived.includes(ctx.node.value);
+      setInnerActived(actived, ctx);
     }
 
     props.onClick?.(ctx);

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -87,6 +87,11 @@ export default function useTree(props: TdTreeProps) {
     if (shouldActive) {
       const tnode = getNode(treeStore.value, node);
       const actived = node.setActived(!tnode.isActived());
+      if (actived.includes(ctx.node.value)) {
+        ctx.node.actived = true;
+      } else {
+        ctx.node.actived = false;
+      }
       setInnerActived(actived, ctx);
     }
 

--- a/src/tree/useTree.tsx
+++ b/src/tree/useTree.tsx
@@ -87,12 +87,7 @@ export default function useTree(props: TdTreeProps) {
     if (shouldActive) {
       const tnode = getNode(treeStore.value, node);
       const actived = node.setActived(!tnode.isActived());
-      if (actived.includes(ctx.node.value)) {
-        ctx.node.actived = true;
-      } else {
-        ctx.node.actived = false;
-      }
-      setInnerActived(actived, ctx);
+      ctx.node.actived = actived.includes(ctx.node.value);
     }
 
     props.onClick?.(ctx);


### PR DESCRIPTION
closed #3110

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#3110](https://github.com/Tencent/tdesign-vue-next/issues/3110)

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 目前actived的值与实际情况相反。
2. 解决方案：在传入ctx的时候做一遍判断，看当前节点是否在actived的数组中，然后调整ctx.node.actived的值。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 修复Tree Events - active 事件中，参数 context 中 actived 值和实际状态相反

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
