### PR TITLE
fix(table): 远程分页使用非受控用法时，切换超过defaultPageSize的页面大小数据展示不全

### DIFF
--- a/src/table/_example/pagination-ajax.vue
+++ b/src/table/_example/pagination-ajax.vue
@@ -71,6 +71,7 @@ const data = ref([]);
 const isLoading = ref(false);
 const selectedRowKeys = ref([]);
 
+// 分页受控用法，需将current和pageSize写回pagination
 const pagination = reactive({
   current: 1,
   pageSize: 10,
@@ -80,6 +81,12 @@ const pagination = reactive({
     console.log('pagination.onChange', pageInfo);
   },
 });
+// 分页非受控用法（示例有效勿删），仅需传入defaultCurrent和defaultPageSize
+// const pagination = reactive({
+//   defaultCurrent: 1,
+//   defaultPageSize: 10,
+//   total: 0,
+// });
 
 const fetchData = async (paginationInfo) => {
   try {
@@ -106,16 +113,24 @@ const rehandleChange = (changeParams, triggerAndData) => {
 // BaseTable 中只有 page-change 事件，没有 change 事件
 const onPageChange = async (pageInfo) => {
   console.log('page-change', pageInfo);
+  // 分页受控用法
   pagination.current = pageInfo.current;
   pagination.pageSize = pageInfo.pageSize;
+  // 分页非受控用法无需更新pagination，每次切换分页都会触发该方法，pageInfo.pageSize为新的单页大小值
   await fetchData(pageInfo);
 };
 
 onMounted(async () => {
+  // 关联受控用法
   await fetchData({
-    current: pagination.current || pagination.defaultCurrent,
-    pageSize: pagination.pageSize || pagination.defaultPageSize,
+    current: pagination.current,
+    pageSize: pagination.pageSize,
   });
+  // 关联非受控用法
+  // await fetchData({
+  //   current: pagination.defaultCurrent,
+  //   pageSize: pagination.defaultPageSize,
+  // });
 });
 
 const onSelectChange = (value, params) => {

--- a/src/table/hooks/usePagination.tsx
+++ b/src/table/hooks/usePagination.tsx
@@ -43,7 +43,10 @@ export default function usePagination(props: TdBaseTableProps, context: SetupCon
     [data],
     () => {
       if (!pagination.value || !pagination.value.defaultCurrent) return;
-      updateDataSourceAndPaginate(pagination.value.defaultCurrent, pagination.value.defaultPageSize);
+      updateDataSourceAndPaginate(
+        innerPagination.value.current ?? pagination.value.defaultCurrent,
+        innerPagination.value.pageSize ?? pagination.value.defaultPageSize,
+      );
     },
     { immediate: true },
   );


### PR DESCRIPTION
closed #3172

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/3172

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 远程分页使用非受控用法时，切换超过 `defaultPageSize` 的页面大小数据展示不全

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
