### PR TITLE
fix(ImageViewer): 使用全局配置

### DIFF
--- a/src/image-viewer/base/ImageItem.tsx
+++ b/src/image-viewer/base/ImageItem.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, PropType, ref, toRefs, watch } from 'vue';
 import { ImageErrorIcon } from 'tdesign-icons-vue-next';
-import { usePrefixClass } from '../../hooks/useConfig';
+import { usePrefixClass, useConfig } from '../../hooks/useConfig';
 import { useDrag } from '../hooks';
 import { useImagePreviewUrl } from '../../hooks/useImagePreviewUrl';
 
@@ -20,6 +20,8 @@ export default defineComponent({
     const error = ref(false);
     const loaded = ref(false);
     const { transform, mouseDownHandler } = useDrag({ translateX: 0, translateY: 0 });
+    const { globalConfig } = useConfig('imageViewer');
+    const errorText = globalConfig.value.errorText ?? '图片加载失败，可尝试重新加载';
 
     const imgStyle = computed(() => ({
       transform: `rotate(${props.rotate}deg) scale(${props.scale})`,
@@ -59,7 +61,7 @@ export default defineComponent({
               {/* 脱离文档流 */}
               <div class={`${classPrefix.value}-image-viewer__img-error-content`}>
                 <ImageErrorIcon size="4em" />
-                <div class={`${classPrefix.value}-image-viewer__img-error-text`}>图片加载失败，可尝试重新加载</div>
+                <div class={`${classPrefix.value}-image-viewer__img-error-text`}>{errorText}</div>
               </div>
             </div>
           )}

--- a/src/image-viewer/base/ImageViewerUtils.tsx
+++ b/src/image-viewer/base/ImageViewerUtils.tsx
@@ -2,7 +2,7 @@ import { computed, defineComponent, PropType } from 'vue';
 import { ImageIcon, ZoomInIcon, ZoomOutIcon, DownloadIcon, MirrorIcon, RotationIcon } from 'tdesign-icons-vue-next';
 import TImageViewerIcon from './ImageModalIcon';
 import TToolTip from '../../tooltip';
-import { usePrefixClass } from '../../hooks/useConfig';
+import { usePrefixClass, useConfig } from '../../hooks/useConfig';
 import { downloadFile } from '../utils';
 import { useImagePreviewUrl } from '../../hooks';
 import { ImageInfo } from '../type';
@@ -28,13 +28,14 @@ export default defineComponent({
     const imageUrl = computed(() => props.currentImage.mainImage);
 
     const { previewUrl } = useImagePreviewUrl(imageUrl);
+    const { globalConfig } = useConfig('imageViewer');
 
     return () => (
       <div class={`${classPrefix.value}-image-viewer__utils`}>
         <div class={`${classPrefix.value}-image-viewer__utils-content`}>
           <TToolTip
             overlayClassName={`${classPrefix.value}-image-viewer__utils--tip`}
-            content="镜像"
+            content={globalConfig.value.mirrorTipText ?? '镜像'}
             destroyOnClose
             placement="top"
             showArrow
@@ -44,7 +45,7 @@ export default defineComponent({
           </TToolTip>
           <TToolTip
             overlayClassName={`${classPrefix.value}-image-viewer__utils--tip`}
-            content="旋转"
+            content={globalConfig.value.rotateTipText ?? '旋转'}
             destroyOnClose
             placement="top"
             showArrow
@@ -61,7 +62,7 @@ export default defineComponent({
           <TImageViewerIcon icon={() => <ZoomInIcon size="medium" />} onClick={props.onZoomIn} />
           <TToolTip
             overlayClassName={`${classPrefix.value}-image-viewer__utils--tip`}
-            content="原始大小"
+            content={globalConfig.value.originalSizeTipText ?? '原始大小'}
             destroyOnClose
             placement="top"
             showArrow


### PR DESCRIPTION
closed #3171

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#3171
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ImageViewer): 修复图片浏览的全局配置无效([issue #3171](https://github.com/Tencent/tdesign-vue-next/issues/3171))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
