### PR TITLE
fix(upload): fix thumbnails don't show

### DIFF
--- a/src/upload/themes/dragger-file.tsx
+++ b/src/upload/themes/dragger-file.tsx
@@ -69,12 +69,10 @@ export default defineComponent({
       const url = file?.url || file?.response?.url;
       return (
         <div class={`${uploadPrefix}__dragger-img-wrap`}>
-          {url && (
-            <ImageViewer
-              images={[url]}
-              trigger={(h, { open }: any) => <Image src={url || file.raw} onClick={open} error="" />}
-            ></ImageViewer>
-          )}
+          <ImageViewer
+            images={[url]}
+            trigger={(h, { open }: any) => <Image src={url || file.raw} onClick={open} error="" />}
+          ></ImageViewer>
         </div>
       );
     };

--- a/src/upload/themes/image-card.tsx
+++ b/src/upload/themes/image-card.tsx
@@ -69,7 +69,7 @@ export default defineComponent({
           <div class={`${classPrefix.value}-upload__card-mask`}>
             <span class={`${classPrefix.value}-upload__card-mask-item`} onClick={(e) => e.stopPropagation()}>
               <ImageViewer
-                images={displayFiles.value.map((t: UploadFile) => t.url)}
+                images={displayFiles.value.map((t: UploadFile) => t.url || t.raw)}
                 defaultIndex={index}
                 trigger={(h, { open }) => {
                   return (
@@ -144,7 +144,7 @@ export default defineComponent({
                 <li class={cardItemClasses} key={index}>
                   {file.status === 'progress' && renderProgressFile(file, loadCard)}
                   {file.status === 'fail' && renderFailFile(file, index, loadCard)}
-                  {!['progress', 'fail'].includes(file.status) && file.url && renderMainContent(file, index)}
+                  {!['progress', 'fail'].includes(file.status) && renderMainContent(file, index)}
                   {fileName &&
                     (file.url ? (
                       <Link href={file.url} class={fileNameClassName} target="_blank" hover="color" size="small">


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

close: #3273

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
根据PR https://github.com/Tencent/tdesign-vue-next/pull/3136 的修改

<img width="1309" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/41513919/6ada6c98-878d-43ab-b743-e2d2fb189e4a">

之后非自动上传的图片求`file.url`的逻辑放到了`image`组件, 所以我们渲染图片时不再需要 url 存在，根据 PR3136，应该传`file.raw`属性给`image`，由`image`组件求 url 然后渲染。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 修复非自动上传时图片缩略图不显示

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
