### PR TITLE
fix(input): fix conflict between suffix icon and empty icon

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -164,12 +164,18 @@ export default defineComponent({
           );
         } else {
           suffixIcon = (
-            <CloseCircleFilledIcon
-              ref={inputHandle.clearIconRef}
-              class={`${COMPONENT_NAME.value}__suffix-clear`}
-              onClick={inputHandle.emitClear}
-              onMousedown={inputHandle.onClearIconMousedown}
-            />
+            <span class={[`${COMPONENT_NAME.value}__suffix`, `${COMPONENT_NAME.value}__suffix-icon`]}>
+              <span style={{ marginRight: suffixIcon ? '5px' : '' }}>{suffixIcon}</span>
+              <CloseCircleFilledIcon
+                ref={inputHandle.clearIconRef}
+                class={[
+                  `${COMPONENT_NAME.value}__suffix-clear`,
+                  { [`${COMPONENT_NAME.value}__clear`]: showClear.value },
+                ]}
+                onClick={inputHandle.emitClear}
+                onMousedown={inputHandle.onClearIconMousedown}
+              />
+            </span>
           );
         }
       }
@@ -240,17 +246,7 @@ export default defineComponent({
                 {passwordIcon}
               </span>
             ) : null}
-            {suffixIcon ? (
-              <span
-                class={[
-                  `${COMPONENT_NAME.value}__suffix`,
-                  `${COMPONENT_NAME.value}__suffix-icon`,
-                  { [`${COMPONENT_NAME.value}__clear`]: showClear.value },
-                ]}
-              >
-                {suffixIcon}
-              </span>
-            ) : null}
+            {suffixIcon ? <span>{suffixIcon}</span> : null}
           </div>
           {tips && <div class={tipsClasses}>{tips}</div>}
         </div>


### PR DESCRIPTION
closed #3331

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/issues/3331
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修复输入框后缀图标和清空图标的冲突
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(input): 修复输入框后缀图标和清空图标的冲突

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
