### PR TITLE
[Input][Pagination][Select][Table] fix auto width computed error

### DIFF
--- a/src/dialog/_example/base.vue
+++ b/src/dialog/_example/base.vue
@@ -4,7 +4,7 @@
     <t-dialog
       v-model:visible="visible"
       header="对话框标题"
-      attach="body"
+      width="40%"
       :confirm-on-enter="true"
       :on-cancel="onCancel"
       :on-esc-keydown="onEscKeydown"
@@ -13,9 +13,13 @@
       :on-close="close"
       :on-confirm="onConfirmAnother"
     >
-      <div>
+      <t-space direction="vertical" style="width: 100%">
+        <div>
+          <p>这是弹框内容</p>
+          <p>This is Dialog Content</p>
+        </div>
         <t-pagination v-model="current" v-model:pageSize="pageSize" :total="30" />
-      </div>
+      </t-space>
     </t-dialog>
   </t-space>
 </template>

--- a/src/dialog/_example/base.vue
+++ b/src/dialog/_example/base.vue
@@ -4,7 +4,6 @@
     <t-dialog
       v-model:visible="visible"
       header="对话框标题"
-      body="对话框内容"
       attach="body"
       :confirm-on-enter="true"
       :on-cancel="onCancel"
@@ -13,13 +12,19 @@
       :on-overlay-click="onOverlayClick"
       :on-close="close"
       :on-confirm="onConfirmAnother"
-    />
+    >
+      <div>
+        <t-pagination v-model="current" v-model:pageSize="pageSize" :total="30" />
+      </div>
+    </t-dialog>
   </t-space>
 </template>
 <script setup>
 import { ref } from 'vue';
 
 const visible = ref(false);
+const current = ref(1);
+const pageSize = ref(10);
 const onClick = (context) => {
   console.log('点击了确认按钮，弹出弹窗', context);
   visible.value = true;

--- a/src/dialog/plugin.tsx
+++ b/src/dialog/plugin.tsx
@@ -115,9 +115,9 @@ const extraApi: ExtraApi = {
   alert,
 };
 
-export type DialogPluginType = Plugin & ExtraApi & DialogAlertMethod;
+export type DialogPluginType = Plugin & ExtraApi & DialogMethod;
 
-export const DialogPlugin: DialogPluginType = createDialog as DialogPluginType;
+export const DialogPlugin = createDialog as DialogPluginType;
 
 DialogPlugin.install = (app: App): void => {
   app.config.globalProperties.$dialog = createDialog;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复默认不显示，满足某种条件后才显示的场景下，自动宽度计算错误问题，[issue#3266](https://github.com/Tencent/tdesign-vue-next/issues/3266)，[issue#3092](https://github.com/Tencent/tdesign-vue-next/issues/3092)
- fix(Table): 修复 Dialog 弹框中打开表格，表格中分页组件信息出现超出省略问题，[issue#3266](https://github.com/Tencent/tdesign-vue-next/issues/3266)，[issue#3092](https://github.com/Tencent/tdesign-vue-next/issues/3092)
- fix(Pagination): 修复 Dialog 弹框中打开表格，分页组件信息出现超出省略问题，[issue#3266](https://github.com/Tencent/tdesign-vue-next/issues/3266)，[issue#3092](https://github.com/Tencent/tdesign-vue-next/issues/3092)
- fix(Dialog): 修复 Dialog 弹框中打开表格，分页组件信息出现超出省略问题，[issue#3266](https://github.com/Tencent/tdesign-vue-next/issues/3266)，[issue#3092](https://github.com/Tencent/tdesign-vue-next/issues/3092)
- fix(Dialog): 类型问题，修复 DialogPlugin({ cancenBtn: '取消' }) 提醒类型缺失问题， [issues#2635](https://github.com/Tencent/tdesign-vue-next/issues/2635)

<img width="532" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/11605702/2d92cdaf-25c4-4d0d-b285-1cdfa4d7ffc8">


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
