### PR TITLE
fix(tree): fix tree-node render error when value is 0

### DIFF
--- a/src/tree/hooks/useTreeNodes.tsx
+++ b/src/tree/hooks/useTreeNodes.tsx
@@ -28,7 +28,7 @@ export default function useTreeNodes(state: TypeTreeState) {
         hasVisibleNode = true;
         cacheMap.set(node.value, node.value);
       }
-      if (cacheMap.get(node.value)) {
+      if (cacheMap.has(node.value)) {
         // 创建的节点是缓存的节点
         list.push(node);
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#3474 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

原因为当`node`的`value`为`0`时，使用`map.get()`后得到的值为`0`，导致`if`的判断不正确。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tree): 修复当 `node` 的 `value` 为 `0` 时不会渲染([issue #3474](https://github.com/Tencent/tdesign-vue-next/issues/3474))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
