### PR TITLE
feat(table): 多级表头下,动态列配置支持指定父级列以展示其下的所有子列

### DIFF
--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -215,13 +215,17 @@ export default defineComponent({
     };
 
     // 1. 影响列数量的因素有：自定义列配置、展开/收起行、多级表头；2. 影响表头内容的因素有：排序图标、筛选图标
-    const getColumns = (columns: PrimaryTableCol<TableRowData>[]) => {
+    const getColumns = (columns: PrimaryTableCol<TableRowData>[], parentDisplay = false) => {
       const arr: PrimaryTableCol<TableRowData>[] = [];
       for (let i = 0, len = columns.length; i < len; i++) {
         let item = { ...columns[i] };
         // 自定义列显示控制
         const isDisplayColumn = item.children?.length || tDisplayColumns.value?.includes(item.colKey);
-        if (!isDisplayColumn && (props.columnController || props.displayColumns || props.defaultDisplayColumns))
+        if (
+          !isDisplayColumn &&
+          (props.columnController || props.displayColumns || props.defaultDisplayColumns) &&
+          !parentDisplay
+        )
           continue;
         item = formatToRowSelectColumn(item);
         const { sort } = props;
@@ -290,7 +294,7 @@ export default defineComponent({
           };
         }
         if (item.children?.length) {
-          item.children = getColumns(item.children);
+          item.children = getColumns(item.children, parentDisplay || tDisplayColumns.value?.includes(item.colKey));
         }
         // 多级表头和自定义列配置特殊逻辑：要么子节点不存在，要么子节点长度大于 1，方便做自定义列配置
         if (!item.children || item.children?.length) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在多级表头的场景下，使用动态的列配置的时候，只能去配置到叶子节点的列名去展示相应的列，没办法通过配置一个父级的表头列，来指定之下的所有子列显示，批量地配置显示和隐藏不方便。

在判断列是否展示的时候，如果一个拥有 children 的列被配置在 displayColumns 中，透传它的显示属性，以下所有的子列都进行展示。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 多级表头下，动态列配置支持指定父级列以展示其下的所有子列

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
