### PR TITLE
fix(table): 在提供列配置选项时,默认只提供叶子列作为配置选项,作为最细粒度配置的方式

### DIFF
--- a/src/table/hooks/useColumnController.tsx
+++ b/src/table/hooks/useColumnController.tsx
@@ -115,11 +115,13 @@ export default function useColumnController(props: TdPrimaryTableProps, context:
     if (columnController.value?.groupColumns?.length) return [];
     for (let i = 0, len = columns.length; i < len; i++) {
       const item = columns[i];
-      if (item.colKey) {
-        arr.push(getOneColumnItem(item, i));
-      }
       if (item.children?.length) {
         getCheckboxOptions(item.children, arr);
+      } else {
+        // 只把叶子列提供出去进行配置
+        if (item.colKey) {
+          arr.push(getOneColumnItem(item, i));
+        }
       }
     }
     return arr;

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -20,6 +20,7 @@ import { getScrollbarWidthWithCSS } from '../../_common/js/utils/getScrollbarWid
 import { on, off } from '../../utils/dom';
 import { FixedColumnInfo, TableRowFixedClasses, RowAndColFixedPosition, TableColFixedClasses } from '../interface';
 import { getIEVersion } from '../../_common/js/utils/helper';
+import pick from 'lodash/pick';
 
 // 固定列相关类名处理
 export function getColumnFixedStyles(
@@ -503,7 +504,8 @@ export default function useFixed(
       reduceKeys.forEach((key) => {
         reduceWidth += thWidthList[key];
       });
-      const oldTotalWidth = Object.values(thWidthList).reduce((r = 0, n) => r + n);
+      const rootThWidthList = pick(thWidthList, preColKeys);
+      const oldTotalWidth = Object.values(rootThWidthList).reduce((r = 0, n) => r + n);
       setTableElmWidth(oldTotalWidth - reduceWidth);
     }
   });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
在提供列配置选项时,默认只提供叶子列作为配置选项,作为最细粒度配置的方式

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 在提供列配置选项时,默认只提供叶子列作为配置选项,作为最细粒度配置的方式
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
