### PR TITLE
fix(table): 修正动态列变化时,表头的宽度和高度更新问题

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -521,7 +521,7 @@ export default defineComponent({
     // 添加这一层，是为了隐藏表头的横向滚动条。如果以后不需要照顾 IE 10 以下的项目，则可直接移除这一层
     // 彼时，可更为使用 CSS 样式中的 .hideScrollbar()
     const affixHeaderWithWrap = (
-      <div class={this.tableBaseClass.affixedHeaderWrap} style={affixHeaderWrapHeightStyle}>
+      <div class={this.tableBaseClass.affixedHeaderWrap} style={affixHeaderWrapHeightStyle.value}>
         {affixedHeader}
       </div>
     );

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -477,15 +477,22 @@ export default defineComponent({
     // IE 浏览器需要遮挡 header 吸顶滚动条，要减去 getBoundingClientRect.height 的滚动条高度 4 像素
     const IEHeaderWrap = getIEVersion() <= 11 ? 4 : 0;
     const barWidth = this.isWidthOverflow ? this.scrollbarWidth : 0;
-    const affixHeaderHeight = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap;
-    const affixHeaderWrapHeight = affixHeaderHeight - barWidth;
+    const affixHeaderHeight = ref((this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap);
+    // 等待表头渲染完成后再更新高度，有可能列变动带来多级表头的高度变化，错误高度会导致滚动条显示
+    const timer = setTimeout(() => {
+      affixHeaderHeight.value = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap;
+      clearTimeout(timer);
+    }, 0);
+    const affixHeaderWrapHeight = computed(() => affixHeaderHeight.value - barWidth);
     // 两类场景：1. 虚拟滚动，永久显示表头，直到表头消失在可视区域； 2. 表头吸顶，根据滚动情况判断是否显示吸顶表头
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
-    const affixHeaderWrapHeightStyle = {
-      width: `${this.tableWidth}px`,
-      height: `${affixHeaderWrapHeight}px`,
-      opacity: headerOpacity,
-    };
+    const affixHeaderWrapHeightStyle = computed(() => {
+      return {
+        width: `${this.tableWidth}px`,
+        height: `${affixHeaderWrapHeight.value}px`,
+        opacity: headerOpacity,
+      };
+    });
     // 多级表头左边线缺失
     const affixedLeftBorder = this.bordered ? 1 : 0;
     const affixedHeader = Boolean(

--- a/src/table/hooks/useColumnController.tsx
+++ b/src/table/hooks/useColumnController.tsx
@@ -115,11 +115,13 @@ export default function useColumnController(props: TdPrimaryTableProps, context:
     if (columnController.value?.groupColumns?.length) return [];
     for (let i = 0, len = columns.length; i < len; i++) {
       const item = columns[i];
-      if (item.colKey) {
-        arr.push(getOneColumnItem(item, i));
-      }
       if (item.children?.length) {
         getCheckboxOptions(item.children, arr);
+      } else {
+        // 只把叶子列提供出去进行配置
+        if (item.colKey) {
+          arr.push(getOneColumnItem(item, i));
+        }
       }
     }
     return arr;

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -20,6 +20,7 @@ import { getScrollbarWidthWithCSS } from '../../_common/js/utils/getScrollbarWid
 import { on, off } from '../../utils/dom';
 import { FixedColumnInfo, TableRowFixedClasses, RowAndColFixedPosition, TableColFixedClasses } from '../interface';
 import { getIEVersion } from '../../_common/js/utils/helper';
+import pick from 'lodash/pick';
 
 // 固定列相关类名处理
 export function getColumnFixedStyles(
@@ -503,7 +504,8 @@ export default function useFixed(
       reduceKeys.forEach((key) => {
         reduceWidth += thWidthList[key];
       });
-      const oldTotalWidth = Object.values(thWidthList).reduce((r = 0, n) => r + n);
+      const rootThWidthList = pick(thWidthList, preColKeys);
+      const oldTotalWidth = Object.values(rootThWidthList).reduce((r = 0, n) => r + n);
       setTableElmWidth(oldTotalWidth - reduceWidth);
     }
   });

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -506,7 +506,10 @@ export default function useFixed(
       });
       const rootThWidthList = pick(thWidthList, preColKeys);
       const oldTotalWidth = Object.values(rootThWidthList).reduce((r = 0, n) => r + n);
-      setTableElmWidth(oldTotalWidth - reduceWidth);
+      // 保留原有可能编辑过的列宽度，但是当剩余列过小时，表头小于内容宽，需要缩放回内容宽度
+      const contentWidth = tableElmRef.value.getBoundingClientRect().width;
+      const widthToReserve = oldTotalWidth - reduceWidth;
+      setTableElmWidth(Math.max(contentWidth, widthToReserve));
     }
   });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
修正动态列变化时,表头的宽度和高度更新问

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修正动态列变化时，表头过小或表头高度更新错误导致意外的滚动条出现的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
