### PR TITLE
fix(Input): 修复input clearable在没固定宽度下 hove时会变宽问题

### DIFF
--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -36,10 +36,7 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
   const { limitNumber, getValueByLimitNumber, tStatus } = useLengthLimit(limitParams);
 
   const showClear = computed(() => {
-    return (
-      ((innerValue.value && !disabled.value && props.clearable && !props.readonly) || props.showClearIconOnEmpty) &&
-      isHover.value
-    );
+    return (innerValue.value && !disabled.value && props.clearable && !props.readonly) || props.showClearIconOnEmpty;
   });
 
   const focus = () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#3591、#3129
在不固定长的情况下 清除按钮在hove时渲染会导致input宽撑开影响用户体验

### 💡 需求背景和解决方案

<!--
1. 解决hove时不会宽度突变问题
2. 在clearable情况下需要清楚按钮提前占位只是不显示 dom还是真实在。
3. 重现链接在这https://codesandbox.io/s/clearable-input-forked-cjrgs8?file=/src/Demo.vue。
-->

### 📝 更新日志

<!--
在二次封装查询表单时会出现这种宽度突变问题很影响体验。
![image](https://github.com/Tencent/tdesign-vue-next/assets/77528443/77121b91-4c26-48c1-85f7-0fd10e655f16)
![image](https://github.com/Tencent/tdesign-vue-next/assets/77528443/24dd176d-e4da-454f-908c-f213caf7fac0)

-->

- fix(Input): 修复input clearable在没固定宽度下 hove时会变宽问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
