### PR TITLE
fix: 通过正则匹配space,误判断删除键(backspace)是空格键(space)

### DIFF
--- a/src/checkbox/hooks/useKeyboardEvent.ts
+++ b/src/checkbox/hooks/useKeyboardEvent.ts
@@ -1,8 +1,8 @@
-export const CHECKED_CODE_REG = /(enter|space)/i;
+export const CHECKED_CODE = ['Enter', 'Space'];
 
 export function useKeyboardEvent(handleChange: (e: Event) => void) {
   const keyboardEventListener = (e: KeyboardEvent) => {
-    const isCheckedCode = CHECKED_CODE_REG.test(e.key) || CHECKED_CODE_REG.test(e.code);
+    const isCheckedCode = CHECKED_CODE.includes(e.key) || CHECKED_CODE.includes(e.code);
     if (isCheckedCode) {
       e.preventDefault();
       const { disabled } = (e.currentTarget as HTMLElement).querySelector('input');

--- a/src/radio/useKeyboard.ts
+++ b/src/radio/useKeyboard.ts
@@ -1,7 +1,7 @@
 import { onBeforeMount, onMounted, Ref } from 'vue';
 import { off, on } from '../utils/dom';
 import isString from 'lodash/isString';
-import { CHECKED_CODE_REG } from '../checkbox/hooks/useKeyboardEvent';
+import { CHECKED_CODE } from '../checkbox/hooks/useKeyboardEvent';
 
 /** 键盘操作 */
 export default function useKeyboard(
@@ -9,7 +9,7 @@ export default function useKeyboard(
   setInnerValue: (value: any, context: { e: Event }) => void,
 ) {
   const checkRadioInGroup = (e: KeyboardEvent) => {
-    const isCheckedCode = CHECKED_CODE_REG.test(e.key) || CHECKED_CODE_REG.test(e.code);
+    const isCheckedCode = CHECKED_CODE.includes(e.key) || CHECKED_CODE.includes(e.code);
     if (isCheckedCode) {
       e.preventDefault();
       const inputNode = (e.target as HTMLElement).querySelector('input');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/issues/3598

空格space, 删除backspace ,正则判断space，触发删除键误判断是空格
### 💡 需求背景和解决方案 

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Radio): `useKeyboard` 通过正则匹配space,误判断删除键(backspace)是空格键(space)
- fix(Checkout): `useKeyboardEvent ` 通过正则匹配space,误判断删除键(backspace)是空格键(space)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
