### PR TITLE
fix(BreadcrumbItem): target equals Invalid when '_blank'

### DIFF
--- a/src/breadcrumb/breadcrumb-item.tsx
+++ b/src/breadcrumb/breadcrumb-item.tsx
@@ -63,17 +63,24 @@ export default defineComponent({
       <ChevronRightIcon {...{ color: 'rgba(0,0,0,.3)' }} />
     );
     const { proxy } = getCurrentInstance();
-    const bindEvent = (e: MouseEvent) => {
-      if (!props.disabled) {
-        e.preventDefault();
-        if (props.href) {
-          window.location.href = props.href;
-        }
-        const router = props.router || proxy.$router;
-        if (props.to && router) {
-          props.replace ? router.replace(props.to) : router.push(props.to);
-        }
+
+    const handleClick = () => {
+      if (props.href) {
+        window.location.href = props.href;
       }
+      const router = props.router || proxy.$router;
+      if (props.to && router) {
+        props.replace ? router.replace(props.to) : router.push(props.to);
+      }
+    };
+    const bindEvent = (e: MouseEvent) => {
+      if (!props.disabled)
+        if (props.target === '_blank') {
+          props.href ? window.open(props.href) : window.open(props.to as string);
+        } else {
+          e.preventDefault();
+          handleClick();
+        }
     };
 
     return () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[#3634](https://github.com/Tencent/tdesign-vue-next/issues/3634)

### 💡 需求背景和解决方案
与a标签target属性的_blank选项表现一致

### 📝 更新日志
- fix(BreadcrumbItem): 修复breadcrumb-item组件target属性为'_blank'时没有在新标签页打开

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
