### PR TITLE
fix(statistic): fix with missing default precision in animation

### DIFF
--- a/src/statistic/statistic.tsx
+++ b/src/statistic/statistic.tsx
@@ -31,6 +31,9 @@ export default defineComponent({
     };
     const numberValue = computed(() => (isNumber(props.value) ? props.value : 0));
     const innerValue = ref(props.animation?.valueFrom ?? props.value);
+    const innerDecimalPlaces = computed(
+      () => props.decimalPlaces ?? numberValue.value.toString().split('.')[1]?.length ?? 0,
+    );
 
     const tween = ref<Tween>();
     const { value } = toRefs(props);
@@ -46,7 +49,7 @@ export default defineComponent({
           },
           duration: props.animation.duration,
           onUpdate: (keys) => {
-            innerValue.value = keys.value;
+            innerValue.value = Number(keys.value.toFixed(innerDecimalPlaces.value));
           },
           onFinish: () => {
             innerValue.value = to;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[(2931) [https://github.com/Tencent/tdesign-vue/issues/2931]](https://github.com/Tencent/tdesign-vue/issues/2931)

未设置 `decimalPlaces` 小数保留位数时，`tween` 更新数值时精度很高导致数字动画变化时很长。

### 💡 需求背景和解决方案

1. 根据用户传入的 `value` 得到默认小数点位数，动画进行时保持这个小数点位数更新。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

-  fix(Statistic): 修复动画缺失默认位数问题([issue #2931](https://github.com/Tencent/tdesign-vue/issues/2931))

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
