### PR TITLE
fix: 🐛 优化表格移动端横向滑动问题

### DIFF
--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -180,15 +180,19 @@ export default function useAffix(props: TdBaseTableProps) {
   const removeHorizontalScrollElementEnterListeners = () => {
     if (affixHeaderRef.value) {
       off(affixHeaderRef.value, 'mouseenter', onHeaderMouseEnter);
+      off(affixHeaderRef.value, 'touchstart', onHeaderMouseEnter);
     }
     if (affixFooterRef.value) {
       off(affixFooterRef.value, 'mouseenter', onFootMouseEnter);
+      off(affixFooterRef.value, 'touchstart', onFootMouseEnter);
     }
     if (tableContentRef.value) {
       off(tableContentRef.value, 'mouseenter', onTableContentMouseEnter);
+      off(tableContentRef.value, 'touchstart', onTableContentMouseEnter);
     }
     if (horizontalScrollbarRef.value) {
       off(horizontalScrollbarRef.value, 'mouseenter', onScrollbarMouseEnter);
+      off(horizontalScrollbarRef.value, 'touchstart', onScrollbarMouseEnter);
     }
   };
 

--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -120,76 +120,75 @@ export default function useAffix(props: TdBaseTableProps) {
     onHorizontalScroll(tableContentRef.value);
   };
 
-  const onFootMouseEnter = () => {
-    on(affixFooterRef.value, 'scroll', onFootScroll);
-  };
-
-  const onFootMouseLeave = () => {
-    off(affixFooterRef.value, 'scroll', onFootScroll);
-  };
-
-  const onHeaderMouseEnter = () => {
-    on(affixHeaderRef.value, 'scroll', onHeaderScroll);
-  };
-
-  const onHeaderMouseLeave = () => {
-    off(affixHeaderRef.value, 'scroll', onHeaderScroll);
-  };
-
-  const onScrollbarMouseEnter = () => {
-    on(horizontalScrollbarRef.value, 'scroll', horizontalScrollbarScroll);
-  };
-
-  const onScrollbarMouseLeave = () => {
-    off(horizontalScrollbarRef.value, 'scroll', horizontalScrollbarScroll);
-  };
-
-  const onTableContentMouseEnter = () => {
-    on(tableContentRef.value, 'scroll', onTableContentScroll);
-  };
-
-  const onTableContentMouseLeave = () => {
-    off(tableContentRef.value, 'scroll', onTableContentScroll);
-  };
-
-  const addHorizontalScrollListeners = () => {
-    if (affixHeaderRef.value) {
-      on(affixHeaderRef.value, 'mouseenter', onHeaderMouseEnter);
-      on(affixHeaderRef.value, 'mouseleave', onHeaderMouseLeave);
+  const onFootMouseEnter = (event: UIEvent) => {
+    if (event.composedPath().includes(affixFooterRef.value)) {
+      removeHorizontalScrollListeners();
+      on(affixFooterRef.value, 'scroll', onFootScroll);
     }
+  };
 
-    if (props.footerAffixedBottom && affixFooterRef.value) {
-      on(affixFooterRef.value, 'mouseenter', onFootMouseEnter);
-      on(affixFooterRef.value, 'mouseleave', onFootMouseLeave);
+  const onHeaderMouseEnter = (event: UIEvent) => {
+    if (event.composedPath().includes(affixHeaderRef.value)) {
+      removeHorizontalScrollListeners();
+      on(affixHeaderRef.value, 'scroll', onHeaderScroll);
     }
+  };
 
-    if (props.horizontalScrollAffixedBottom && horizontalScrollbarRef.value) {
-      on(horizontalScrollbarRef.value, 'mouseenter', onScrollbarMouseEnter);
-      on(horizontalScrollbarRef.value, 'mouseleave', onScrollbarMouseLeave);
+  const onScrollbarMouseEnter = (event: UIEvent) => {
+    if (event.composedPath().includes(horizontalScrollbarRef.value)) {
+      removeHorizontalScrollListeners();
+      on(horizontalScrollbarRef.value, 'scroll', horizontalScrollbarScroll);
     }
+  };
 
-    if ((isAffixed.value || isVirtualScroll.value) && tableContentRef.value) {
-      on(tableContentRef.value, 'mouseenter', onTableContentMouseEnter);
-      on(tableContentRef.value, 'mouseleave', onTableContentMouseLeave);
+  const onTableContentMouseEnter = (event: UIEvent) => {
+    if (event.composedPath().includes(tableContentRef.value)) {
+      removeHorizontalScrollListeners();
+      on(tableContentRef.value, 'scroll', onTableContentScroll);
     }
   };
 
   const removeHorizontalScrollListeners = () => {
+    off(affixFooterRef.value, 'scroll', onFootScroll);
+    off(affixHeaderRef.value, 'scroll', onHeaderScroll);
+    off(horizontalScrollbarRef.value, 'scroll', horizontalScrollbarScroll);
+    off(tableContentRef.value, 'scroll', onTableContentScroll);
+  };
+
+  const addHorizontalScrollElementEnterListeners = () => {
+    if (affixHeaderRef.value) {
+      on(affixHeaderRef.value, 'mouseenter', onHeaderMouseEnter);
+      on(affixHeaderRef.value, 'touchstart', onHeaderMouseEnter);
+    }
+
+    if (props.footerAffixedBottom && affixFooterRef.value) {
+      on(affixFooterRef.value, 'mouseenter', onFootMouseEnter);
+      on(affixFooterRef.value, 'touchstart', onFootMouseEnter);
+    }
+
+    if (props.horizontalScrollAffixedBottom && horizontalScrollbarRef.value) {
+      on(horizontalScrollbarRef.value, 'mouseenter', onScrollbarMouseEnter);
+      on(horizontalScrollbarRef.value, 'touchstart', onScrollbarMouseEnter);
+    }
+
+    if ((isAffixed.value || isVirtualScroll.value) && tableContentRef.value) {
+      on(tableContentRef.value, 'mouseenter', onTableContentMouseEnter);
+      on(tableContentRef.value, 'touchstart', onTableContentMouseEnter);
+    }
+  };
+
+  const removeHorizontalScrollElementEnterListeners = () => {
     if (affixHeaderRef.value) {
       off(affixHeaderRef.value, 'mouseenter', onHeaderMouseEnter);
-      off(affixHeaderRef.value, 'mouseleave', onHeaderMouseLeave);
     }
     if (affixFooterRef.value) {
       off(affixFooterRef.value, 'mouseenter', onFootMouseEnter);
-      off(affixFooterRef.value, 'mouseleave', onFootMouseLeave);
     }
     if (tableContentRef.value) {
       off(tableContentRef.value, 'mouseenter', onTableContentMouseEnter);
-      off(tableContentRef.value, 'mouseleave', onTableContentMouseLeave);
     }
     if (horizontalScrollbarRef.value) {
       off(horizontalScrollbarRef.value, 'mouseenter', onScrollbarMouseEnter);
-      off(horizontalScrollbarRef.value, 'mouseleave', onScrollbarMouseLeave);
     }
   };
 
@@ -206,7 +205,7 @@ export default function useAffix(props: TdBaseTableProps) {
   };
 
   watch([affixHeaderRef, affixFooterRef, horizontalScrollbarRef, tableContentRef], () => {
-    addHorizontalScrollListeners();
+    addHorizontalScrollElementEnterListeners();
     onHorizontalScroll();
     updateAffixHeaderOrFooter();
   });
@@ -228,7 +227,7 @@ export default function useAffix(props: TdBaseTableProps) {
 
   onBeforeUnmount(() => {
     off(document, 'scroll', onDocumentScroll);
-    removeHorizontalScrollListeners();
+    removeHorizontalScrollElementEnterListeners();
   });
 
   const setTableContentRef = (tableContent: HTMLDivElement) => {

--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -180,6 +180,8 @@ export default function useAffix(props: TdBaseTableProps) {
     enterListenersRemoveCallback.forEach((callback) => {
       callback();
     });
+    // 清空数组
+    enterListenersRemoveCallback.length = 0;
   };
 
   const addHorizontalScrollElementEnterListeners = () => {

--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -104,11 +104,11 @@ export default function useAffix(props: TdBaseTableProps) {
     updateAffixHeaderOrFooter();
   };
 
-  // 包含移动端的 touch 事件
-  const enterEvent = ['mouseenter', 'touchstart'];
-  const leaveEvent = ['mouseleave', 'touchend'];
-
   const setupElementHorizontalScrollingListeners = (element: HTMLElement) => {
+    // 包含移动端的 touch 事件
+    const enterEvent = ['mouseenter', 'touchstart'];
+    const leaveEvent = ['mouseleave', 'touchend'];
+
     let isOverElement = false;
     let isScrolling = false;
 
@@ -155,6 +155,7 @@ export default function useAffix(props: TdBaseTableProps) {
     });
 
     function removeEnterListener() {
+      // 销毁进入移出监听器
       enterEvent.forEach((eventName) => {
         off(element, eventName, onElementEnter);
       });
@@ -162,6 +163,10 @@ export default function useAffix(props: TdBaseTableProps) {
       leaveEvent.forEach((eventName) => {
         off(element, eventName, onElementLeave);
       });
+
+      // 兜底销毁滚动监听器，理论上不需要这里来销毁，以防万一加上
+      off(element, 'scroll', onElementScroll);
+      off(element, 'scrollend', onElementScrollEnd);
     }
 
     return {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
移动端横向滑动，缺少相应的mouseenter事件，进行补充，但touch事件引申出如下两个问题

1. touch事件会透传触发，即affix表头同时触发header，用composePath进行判断，避免表头touch事件透传到content
2. 移动端存在惯性滑动，旧逻辑off scroll监听器的时机是移出当前滚动元素，修改为在移入新元素前，取消所有绑定，抢占式的维护只有一个scroll监听器，避免循环触发 scroll 的问题

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 表格在横向溢出时，移动端的滑动问题
- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
