### PR TITLE
feat(dropdown): remove dropdown left special style

### DIFF
--- a/src/dropdown/dropdown-menu.tsx
+++ b/src/dropdown/dropdown-menu.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, ref, onMounted, h, reactive } from 'vue';
-import { ChevronRightIcon as TdChevronRightIcon, ChevronLeftIcon as TdChevronLeftIcon } from 'tdesign-icons-vue-next';
+import { ChevronRightIcon as TdChevronRightIcon } from 'tdesign-icons-vue-next';
 import DropdownItem from './dropdown-item';
 
 import { DropdownOption } from './type';
@@ -19,9 +19,8 @@ export default defineComponent({
     const scrollTopMap = reactive({});
     const menuRef = ref<HTMLElement>();
     const isOverMaxHeight = ref(false);
-    const { ChevronRightIcon, ChevronLeftIcon } = useGlobalIcon({
+    const { ChevronRightIcon } = useGlobalIcon({
       ChevronRightIcon: TdChevronRightIcon,
-      ChevronLeftIcon: TdChevronLeftIcon,
     });
 
     const handleItemClick = (options: { data: DropdownOption; context: { e: MouseEvent } }) => {
@@ -75,17 +74,8 @@ export default defineComponent({
                 isSubmenu={true}
               >
                 <div class={`${dropdownClass.value}__item-content`}>
-                  {props.direction === 'right' ? (
-                    <>
-                      <span class={`${dropdownClass.value}__item-text`}>{getContent(optionItem.content)}</span>
-                      <ChevronRightIcon class={`${dropdownClass.value}__item-direction`} size="16" />
-                    </>
-                  ) : (
-                    <>
-                      <ChevronLeftIcon class={`${dropdownClass.value}__item-direction`} size="16" />
-                      <span class={`${dropdownClass.value}__item-text`}>{getContent(optionItem.content)}</span>
-                    </>
-                  )}
+                  <span class={`${dropdownClass.value}__item-text`}>{getContent(optionItem.content)}</span>
+                  <ChevronRightIcon class={`${dropdownClass.value}__item-direction`} size="16" />
                 </div>
                 <div
                   class={[


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 跟进大部分用户反馈 不希望left direction的场景下将展开箭头与文案位置互换 去掉这部分特殊处理
处理前
<img width="351" alt="image" src="https://github.com/Tencent/tdesign-common/assets/26377630/15805968-3d91-45eb-9730-a32e33160614">

处理后
<img width="318" alt="image" src="https://github.com/Tencent/tdesign-common/assets/26377630/a58c51d5-b85b-4821-a701-42cfa4420413">

2. 更新common
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Dropdown): 移除对 `left` 的 `item` 样式特殊处理
- fix(DatePicker): 修复日期选择禁用后，后缀图标颜色改变的问题 @HaixingOoO 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
