### PR TITLE
feat(form): form-item extra增加title attribute显示超长内容

### DIFF
--- a/src/form/__tests__/__snapshots__/form.test.jsx.snap
+++ b/src/form/__tests__/__snapshots__/form.test.jsx.snap
@@ -79,6 +79,7 @@ exports[`Form > function > clearValidate 1`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名必填"
     >
       姓名必填
     </div>,
@@ -87,6 +88,7 @@ exports[`Form > function > clearValidate 1`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,
@@ -100,6 +102,7 @@ exports[`Form > function > clearValidate 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,
@@ -113,6 +116,7 @@ exports[`Form > function > reset 1`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名必填"
     >
       姓名必填
     </div>,
@@ -121,6 +125,7 @@ exports[`Form > function > reset 1`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,
@@ -134,6 +139,7 @@ exports[`Form > function > reset 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名校验失败"
     >
       姓名校验失败
     </div>,
@@ -142,6 +148,7 @@ exports[`Form > function > reset 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="年龄校验失败"
     >
       年龄校验失败
     </div>,
@@ -155,6 +162,7 @@ exports[`Form > function > reset 3`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="年龄校验失败"
     >
       年龄校验失败
     </div>,
@@ -189,6 +197,7 @@ exports[`Form > function > validate 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名必填"
     >
       姓名必填
     </div>,
@@ -197,6 +206,7 @@ exports[`Form > function > validate 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,
@@ -280,6 +290,7 @@ exports[`Form > function > validateOnly 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名必填"
     >
       姓名必填
     </div>,
@@ -288,6 +299,7 @@ exports[`Form > function > validateOnly 2`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,
@@ -303,6 +315,7 @@ exports[`Form > function > validateOnly 4`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="姓名必填"
     >
       姓名必填
     </div>,
@@ -311,6 +324,7 @@ exports[`Form > function > validateOnly 4`] = `
     "isDisabled": [Function],
     "wrapperElement": <div
       class="t-input__extra"
+      title="age必填"
     >
       age必填
     </div>,

--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -378,7 +378,11 @@ export default defineComponent({
       return null;
     });
     const extraNode = computed<VNode>(() => {
-      const getExtraNode = (content: string) => <div class={CLASS_NAMES.value.extra}>{content}</div>;
+      const getExtraNode = (content: string) => (
+        <div class={CLASS_NAMES.value.extra} title={content}>
+          {content}
+        </div>
+      );
       const list = errorList.value;
       if (showErrorMessage.value && list?.[0]?.message) {
         return getExtraNode(list[0].message);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

目前在校验信息超长时省略，无法查看完整内容，增加title以最小方案解决此问题
<img width="838" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/13673257/266de237-9d6d-4156-820a-6ccfba3500e8">


### 📝 更新日志

- feat(form): 为Form Item校验信息增加title属性，用于鼠标停留时展示完整信息

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
