### PR TITLE
feat(slider): changeEnd 事件在点击刻度时触发以及点击游标需移动后 mouseup 才会触发changeEnd

### DIFF
--- a/src/slider/_example/marks.vue
+++ b/src/slider/_example/marks.vue
@@ -1,6 +1,6 @@
 <template>
   <t-space direction="vertical" class="slider-demo-container">
-    <t-slider v-model="value1" :show-tooltip="true" :marks="marks1" />
+    <t-slider v-model="value1" :show-tooltip="true" :marks="marks1" @change-end="onChangeEnd" />
 
     <t-slider v-model="value2" range :show-tooltip="true" :marks="marks2" />
 
@@ -13,6 +13,9 @@ import { ref } from 'vue';
 const value1 = ref(12);
 const value2 = ref([30, 70]);
 const value3 = ref(10);
+const onChangeEnd = (value) => {
+  console.log('change end value', value);
+};
 
 const marks1 = {
   0: '0°C',

--- a/src/slider/slider-button.tsx
+++ b/src/slider/slider-button.tsx
@@ -50,6 +50,7 @@ export default defineComponent({
     const { tooltipRef, tooltipProps, toggleTooltip, showTooltip } = useSliderTooltip(tooltipConfig);
     const parentProps = inject(sliderPropsInjectKey);
     const buttonRef = ref();
+    const dragged = ref(false);
 
     /** --------------------- slide button 相关状态start ------------------- */
     const slideButtonProps = reactive({
@@ -139,6 +140,7 @@ export default defineComponent({
       if (!slideButtonProps.dragging) {
         return;
       }
+      dragged.value = true;
       slideButtonProps.isClick = false;
       if (parentProps?.resetSize && isFunction(parentProps?.resetSize)) {
         parentProps.resetSize();
@@ -163,7 +165,8 @@ export default defineComponent({
           if (!slideButtonProps.isClick) {
             setPosition(slideButtonProps.newPos);
           }
-          ctx.emit('mouseup');
+          dragged.value && ctx.emit('mouseup');
+          dragged.value = false;
         }, 0);
         window.removeEventListener('mousemove', onDragging);
         window.removeEventListener('touchmove', onDragging);

--- a/src/slider/slider.tsx
+++ b/src/slider/slider.tsx
@@ -271,6 +271,8 @@ export default defineComponent({
       const value = Number((point / rangeDiff.value) * 100);
       setPosition(value);
       emitChange(point);
+      const fixValue = getFixValue();
+      props.onChangeEnd?.(fixValue);
     };
 
     /** 副作用监听 */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/issues/3772

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(slider): 点击游标需移动后 `mouseup` 时才触发 `changeEnd` 事件
- feat(slider): 点击刻度时触发 `changeEnd` 事件

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
