### PR TITLE
fix: 🐛 修正affix表头滚动条的隐藏逻辑,默认不显示滚动条

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -476,14 +476,14 @@ export default defineComponent({
      */
     // IE 浏览器需要遮挡 header 吸顶滚动条，要减去 getBoundingClientRect.height 的滚动条高度 4 像素
     const IEHeaderWrap = getIEVersion() <= 11 ? 4 : 0;
-    const barWidth = this.isWidthOverflow ? this.scrollbarWidth : 0;
     const affixHeaderHeight = ref((this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap);
     // 等待表头渲染完成后再更新高度，有可能列变动带来多级表头的高度变化，错误高度会导致滚动条显示
     const timer = setTimeout(() => {
       affixHeaderHeight.value = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap;
       clearTimeout(timer);
     }, 0);
-    const affixHeaderWrapHeight = computed(() => affixHeaderHeight.value - barWidth);
+    // 不管何种情况下 affix 表头都不应该出现滚动条，滚动条使用内容区域即可，因为表头和内容存在滚动同步
+    const affixHeaderWrapHeight = computed(() => affixHeaderHeight.value - this.scrollbarWidth);
     // 两类场景：1. 虚拟滚动，永久显示表头，直到表头消失在可视区域； 2. 表头吸顶，根据滚动情况判断是否显示吸顶表头
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
     const affixHeaderWrapHeightStyle = computed(() => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修正affix表头滚动条的隐藏逻辑,默认不显示滚动条
吸顶表头本身就和内容存在滚动同步，使用内容区域的滚动条即可，避免双层滚动条

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修正affix表头滚动条的隐藏逻辑,默认不显示滚动条

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
