### PR TITLE
feat(radio): enable readonly props

### DIFF
--- a/src/radio/props.ts
+++ b/src/radio/props.ts
@@ -39,6 +39,8 @@ export default {
     type: String,
     default: '',
   },
+  /** 只读状态 */
+  readonly: Boolean,
   /** 单选按钮的值 */
   value: {
     type: [String, Number, Boolean] as PropType<TdRadioProps['value']>,

--- a/src/radio/radio.en-US.md
+++ b/src/radio/radio.en-US.md
@@ -12,6 +12,7 @@ default | String / Slot / Function | - | Typescript：`string \| TNode`。[see m
 disabled | Boolean | undefined | \- | N
 label | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 name | String | - | \- | N
+readonly | Boolean | false | \- | N
 value | String / Number / Boolean | undefined | Typescript：`string \| number \| boolean` | N
 onChange | Function |  | Typescript：`(checked: boolean, context: { e: Event }) => void`<br/> | N
 onClick | Function |  | Typescript：`(context: { e: MouseEvent }) => void`<br/>trigger on click | N

--- a/src/radio/radio.md
+++ b/src/radio/radio.md
@@ -12,6 +12,7 @@ default | String / Slot / Function | - | 单选按钮内容，同 label。TS 类
 disabled | Boolean | undefined | 是否为禁用态。如果存在父组件 RadioGroup，默认值由 RadioGroup.disabled 控制。Radio.disabled 优先级高于 RadioGroup.disabled | N
 label | String / Slot / Function | - | 主文案。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 name | String | - | HTML 元素原生属性 | N
+readonly | Boolean | false | 只读状态 | N
 value | String / Number / Boolean | undefined | 单选按钮的值。TS 类型：`string \| number \| boolean` | N
 onChange | Function |  | TS 类型：`(checked: boolean, context: { e: Event }) => void`<br/>选中状态变化时触发 | N
 onClick | Function |  | TS 类型：`(context: { e: MouseEvent }) => void`<br/>点击时出发，一般用于外层阻止冒泡场景 | N

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -48,7 +48,7 @@ export default defineComponent({
     };
 
     const onLabelClick = (e: MouseEvent) => {
-      if (disabled.value) return;
+      if (disabled.value || props.readonly) return;
       props.onClick?.({ e });
 
       if (radioChecked.value && !allowUncheck.value) return;
@@ -88,6 +88,7 @@ export default defineComponent({
       name: radioGroup ? radioGroup.name : props.name,
       checked: radioChecked.value,
       disabled: disabled.value,
+      readonly: props.readonly,
       value: props.value,
     }));
 

--- a/src/radio/type.ts
+++ b/src/radio/type.ts
@@ -45,6 +45,11 @@ export interface TdRadioProps {
    */
   name?: string;
   /**
+   * 只读状态
+   * @default false
+   */
+  readonly?: boolean;
+  /**
    * 单选按钮的值
    */
   value?: string | number | boolean;
@@ -111,6 +116,7 @@ export interface RadioOptionObj {
   label?: string | TNode;
   value?: string | number | boolean;
   disabled?: boolean;
+  readonly?: boolean;
 }
 
 export type RadioValue = string | number | boolean;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fix #3811 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Radio): 新增 `readonly` 属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
