### PR TITLE
fix(table): drag sort with asyncLoading would make asyncLoading to be the first row line

### DIFF
--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -121,9 +121,17 @@ export default defineComponent({
       setFilterPrimaryTableRef,
     } = useFilter(props, context);
 
+    const tableKey = ref(1);
+
+    const onTableRefresh = () => {
+      tableKey.value += 1;
+    };
+
     // 拖拽排序功能
     const dragSortParams = computed(() => ({
       showElement: showElement.value,
+      onTableRefresh,
+      tableKey: tableKey.value,
     }));
     const {
       isRowHandlerDraggable,
@@ -436,7 +444,6 @@ export default defineComponent({
       }
 
       return (
-        // @ts-ignore
         <BaseTable
           v-slots={context.slots}
           {...baseTableProps}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

可复现问题代码：https://stackblitz.com/edit/k63jyd?file=package.json,src%2Fdemo.vue
操作步骤：交换任意两行，“点击加载更多” 变到第一行，不符合预期

修复效果如下：

https://github.com/Tencent/tdesign-vue-next/assets/11605702/164a045b-be06-40c9-bcdd-c8aafd5e353e

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复行拖拽排序场景，异步加载行会变到第一行问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
