### PR TITLE
fix(table): The effects on Virtual DOM after sortablejs operates DOM.

### DIFF
--- a/src/table/hooks/useDragSort.ts
+++ b/src/table/hooks/useDragSort.ts
@@ -1,7 +1,6 @@
 // 表格 行拖拽 + 列拖拽功能
 import { SetupContext, computed, toRefs, ref, watch, h, ComputedRef } from 'vue';
 import Sortable, { SortableEvent, SortableOptions, MoveEvent } from 'sortablejs';
-import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';
 import { TableRowData, TdPrimaryTableProps, DragSortContext, PrimaryTableCol } from '../type';
 import useClassName from './useClassName';
@@ -12,6 +11,17 @@ import { BaseTableColumns } from '../interface';
 import { getColumnDataByKey, getColumnIndexByKey } from '../../_common/js/table/utils';
 import { SimplePageInfo } from '../interface';
 
+function removeNode(node: HTMLElement) {
+  if (node.parentElement !== null) {
+    node.parentElement.removeChild(node);
+  }
+}
+
+function insertNodeAt(fatherNode: HTMLElement, node: HTMLElement, position: number) {
+  const refNode = position === 0 ? fatherNode.children[0] : fatherNode.children[position - 1].nextSibling;
+  fatherNode.insertBefore(node, refNode);
+}
+
 export default function useDragSort(
   props: TdPrimaryTableProps,
   context: SetupContext,
@@ -21,9 +31,9 @@ export default function useDragSort(
     tableKey: number;
   }>,
 ) {
-  const { sortOnRowDraggable, dragSort, data, rowKey } = toRefs(props);
+  const { sortOnRowDraggable, dragSort, data } = toRefs(props);
   const innerPagination = ref(props.pagination);
-  const { tableDraggableClasses, tableBaseClass, tableFullRowClasses } = useClassName();
+  const { tableDraggableClasses, tableBaseClass, tableFullRowClasses, tableExpandClasses } = useClassName();
   const columns = ref<PrimaryTableCol[]>(props.columns || []);
   const { onTableRefresh } = params.value;
   const primaryTableRef = ref(null);
@@ -39,29 +49,14 @@ export default function useDragSort(
   );
   // 列拖拽判断条件
   const isColDraggable = computed(() => ['col', 'row-handler-col'].includes(dragSort.value));
-  // 行拖拽排序，存储上一次的变化结果
-  const lastRowList = ref([]);
   // 列拖拽排序，存储上一次的变化结果
   const lastColList = ref([]);
-
-  // 行拖拽实例
-  let dragRowInstanceTmp: Sortable = null;
   // 列拖拽实例
   let dragColInstanceTmp: Sortable = null;
 
   if (props.sortOnRowDraggable) {
     log.error('Table', "`sortOnRowDraggable` is going to be deprecated, use dragSort='row' instead.");
   }
-
-  watch(
-    () => [...data.value],
-    (data) => {
-      lastRowList.value = data?.map((item) => get(item, rowKey.value)) || [];
-      onTableRefresh?.();
-    },
-    { immediate: true },
-  );
-
   watch(
     () => [...columns.value],
     (columns) => {
@@ -95,12 +90,13 @@ export default function useDragSort(
       ghostClass: tableDraggableClasses.ghost,
       chosenClass: tableDraggableClasses.chosen,
       dragClass: tableDraggableClasses.dragging,
-      filter: `.${tableFullRowClasses.base}`, // 过滤首行尾行固定
+      filter: `.${tableFullRowClasses.base},.${tableExpandClasses.row}`, // 过滤首行尾行固定，过滤展开行
       onMove: (evt: MoveEvent) => !hasClass(evt.related, tableFullRowClasses.base),
       onEnd(evt: SortableEvent) {
         if (evt.newIndex === evt.oldIndex) return;
         // 处理受控：拖拽列表恢复原始排序
-        dragRowInstanceTmp?.sort(lastRowList.value);
+        removeNode(evt.item);
+        insertNodeAt(evt.from, evt.item, evt.oldIndex);
         let { oldIndex: currentIndex, newIndex: targetIndex } = evt;
         if (
           (isFunction(props.firstFullRow) && props.firstFullRow(h)) ||
@@ -133,15 +129,13 @@ export default function useDragSort(
 
     if (!dragContainer) return;
     if (isRowDraggable.value) {
-      dragRowInstanceTmp = new Sortable(dragContainer, { ...baseOptions });
+      new Sortable(dragContainer, { ...baseOptions });
     } else {
-      dragRowInstanceTmp = new Sortable(dragContainer, {
+      new Sortable(dragContainer, {
         ...baseOptions,
         handle: `.${tableDraggableClasses.handle}`,
       });
     }
-
-    lastRowList.value = dragRowInstanceTmp.toArray();
   };
 
   const registerOneLevelColDragEvent = (container: HTMLElement, recover: boolean) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/issues/2847
https://github.com/Tencent/tdesign-vue-next/issues/3567

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.sortablejs拖拽会操作原生DOM，导致Vue的虚拟DOM监听异常，和数据层渲染不一致。
2.移除使用sortable实例直接操作DOM的代码。
3.参考[vue.draggable.next](https://github.com/SortableJS/vue.draggable.next/)，通过拖拽后手动还原DOM位置，保证虚拟DOM和DOM的一致性。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复sortablejs操作DOM后对虚拟DOM产生的副作用。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
