### PR TITLE
fix(form): 替换lodash的template功能,避免由此导致的nuxt编译异常

### DIFF
--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -26,7 +26,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import lodashGet from 'lodash/get';
 import lodashSet from 'lodash/set';
 import isNil from 'lodash/isNil';
-import lodashTemplate from 'lodash/template';
 
 import { validate } from './form-model';
 import {
@@ -52,6 +51,7 @@ import {
 
 import { useConfig, usePrefixClass, useTNodeJSX } from '../hooks';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
+import template from '../utils/string-template';
 
 export type FormItemValidateResult<T extends Data = Data> = { [key in keyof T]: boolean | AllValidateResult[] };
 
@@ -253,9 +253,8 @@ export default defineComponent({
         .map((item: ErrorListType) => {
           Object.keys(item).forEach((key) => {
             if (!item.message && errorMessages.value[key]) {
-              const compiled = lodashTemplate(errorMessages.value[key]);
               const name = isString(props.label) ? props.label : props.name;
-              item.message = compiled({
+              item.message = template(errorMessages.value[key], {
                 name,
                 validate: item[key],
               });

--- a/src/utils/string-template.ts
+++ b/src/utils/string-template.ts
@@ -1,0 +1,11 @@
+/**
+ * 用正则实现模板字符串功能
+ * @param str 模板字符串
+ * @param vars 取值的对象
+ * @returns 替换后的字符串
+ */
+function template<T>(str: string, vars: T): string {
+  return str.replace(/\${(.*?)}/g, (_, prop: string) => vars[prop.trim()] || '');
+}
+
+export default template;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/3458

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
经排查是nuxt nitro编译问题，由lodash的template函数触发，该功能只在form-item中使用了变量替换功能，因此采用正则替换的方式替代该函数。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(nuxt): 修复在`nuxt`中使用 `Form` 组件无法正常构建的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
