### PR TITLE
[Table] 修正数据长度变化时，虚拟滚动表格总高度计算错误的问题

### DIFF
--- a/src/hooks/useVirtualScrollNew.ts
+++ b/src/hooks/useVirtualScrollNew.ts
@@ -206,15 +206,16 @@ const useVirtualScroll = (container: Ref<HTMLElement | null>, params: UseVirtual
       // 有可能初始化时，resize 监听没触发，尝试设置初始化容器高度
       containerHeight.value = container.value.getBoundingClientRect().height;
 
-      // 暂时对于 table 和 tree 场景，信任之前缓存的行高
-      // 后续优化可能提供一个参数，进行监听从而清除记录的行高会更好
-      if (trHeightList.length === 0) {
-        const initHeightList: number[] = Array(params.value.data.length).fill(tScroll.value.rowHeight || 47);
+      if (trHeightList.length !== params.value.data.length) {
+        // 暂时对于 table 和 tree 场景，信任之前缓存的行高
+        // 后续优化可能提供一个参数，进行监听从而清除记录的行高会更好
+        const initHeightList: number[] = Array.from(trHeightList);
+        // 数据长度如果发生变化，裁剪高度记录的数组，避免算出异常的总高度
+        initHeightList.length = params.value.data.length;
+        initHeightList.fill(tScroll.value.rowHeight || 47);
         trHeightList = initHeightList;
       }
 
-      // 数据长度如果发生变化，裁剪高度记录的数组，避免算出异常的总高度
-      trHeightList = trHeightList.slice(0, params.value.data.length);
       scrollHeight.value = sum(trHeightList);
 
       // 清除记录的滚动顺序

--- a/src/hooks/useVirtualScrollNew.ts
+++ b/src/hooks/useVirtualScrollNew.ts
@@ -212,6 +212,9 @@ const useVirtualScroll = (container: Ref<HTMLElement | null>, params: UseVirtual
         const initHeightList: number[] = Array(params.value.data.length).fill(tScroll.value.rowHeight || 47);
         trHeightList = initHeightList;
       }
+
+      // 数据长度如果发生变化，裁剪高度记录的数组，避免算出异常的总高度
+      trHeightList = trHeightList.slice(0, params.value.data.length);
       scrollHeight.value = sum(trHeightList);
 
       // 清除记录的滚动顺序


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

虚拟滚动场景下，数据长度变化时，需要裁剪缓存的高度数组，避免计算出错误的滚动总高度

复现和验证 demo 如下

https://stackblitz.com/edit/a2afwr?file=package.json,src%2Fdemo.vue

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->



- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
