### PR TITLE
fix(color-picker): right point cannot be dragged when mode is `linear-gradient` (#4015)

### DIFF
--- a/src/color-picker/panel/format/inputs.tsx
+++ b/src/color-picker/panel/format/inputs.tsx
@@ -88,8 +88,8 @@ export default defineComponent({
     const throttleUpdate = throttle(updateModelValue, 100);
 
     watch(() => {
-      const { saturation, hue, value, alpha } = props.color;
-      return [saturation, hue, value, alpha, props.format];
+      const { saturation, hue, value, alpha, css } = props.color;
+      return [saturation, hue, value, alpha, css, props.format];
     }, throttleUpdate);
 
     const handleChange = (key: string, v: number | string) => {

--- a/src/color-picker/panel/index.tsx
+++ b/src/color-picker/panel/index.tsx
@@ -44,7 +44,7 @@ export default defineComponent({
     const mode = ref<TdColorModes>(props.colorModes?.length === 1 ? props.colorModes[0] : 'monochrome');
     const isGradient = computed(() => mode.value === 'linear-gradient');
 
-    const color = computed<Color>(() => new Color(innerValue.value || defaultEmptyColor.value));
+    const color = ref(new Color(innerValue.value || defaultEmptyColor.value));
     const updateColor = () => color.value.update(innerValue.value || defaultEmptyColor.value);
 
     const formatModel = ref<TdColorPickerProps['format']>(color.value.isGradient ? 'CSS' : 'RGB');
@@ -161,6 +161,8 @@ export default defineComponent({
       } else {
         return;
       }
+
+      color.value.update(color.value.rgba);
       emitColorChange(changeTrigger);
     };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
fix #4015 
fix #4002 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复由 #4005 引起的问题，同时修复前置 issue #4002
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(color-picker): `linear-gradient` 模式无法拖动调整颜色。

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
