### PR TITLE
fix(loading): `preventScrollThrough` has no effect when using `LoadingPlugin` (#4037)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "devDependencies": {
     "@babel/cli": "^7.22.9",
     "@babel/core": "^7.22.9",
+    "@babel/helper-module-imports": "7.22.5",
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",
     "@babel/plugin-transform-object-assign": "^7.22.5",
     "@babel/plugin-transform-runtime": "^7.22.9",

--- a/src/loading/plugin.tsx
+++ b/src/loading/plugin.tsx
@@ -1,4 +1,5 @@
 import { App, Plugin, createApp, defineComponent, h, reactive } from 'vue';
+import merge from 'lodash/merge';
 import LoadingComponent from './loading';
 import { getAttach, removeClass, addClass } from '../utils/dom';
 import { TdLoadingProps, LoadingInstance, LoadingMethod } from './type';
@@ -6,10 +7,25 @@ import { usePrefixClass } from '../hooks/useConfig';
 
 let fullScreenLoadingInstance: LoadingInstance = null;
 
+function mergeDefaultProps(props: TdLoadingProps): TdLoadingProps {
+  const options: TdLoadingProps = merge(
+    {
+      fullscreen: false,
+      attach: 'body',
+      loading: true,
+      preventScrollThrough: true,
+    },
+    props,
+  );
+
+  return options;
+}
+
 function createLoading(props: TdLoadingProps): LoadingInstance {
+  const mergedProps = mergeDefaultProps(props);
   const component = defineComponent({
     setup() {
-      const loadingOptions = reactive(props);
+      const loadingOptions = reactive(mergedProps);
       return {
         loadingOptions,
       };
@@ -21,12 +37,18 @@ function createLoading(props: TdLoadingProps): LoadingInstance {
     },
   });
 
-  const attach = getAttach(props.attach);
+  const attach = getAttach(mergedProps.fullscreen ? 'body' : mergedProps.attach);
 
   const app = createApp(component);
   const loading = app.mount(document.createElement('div'));
   const parentRelativeClass = usePrefixClass('loading__parent--relative').value;
   const prefixClass = usePrefixClass('loading');
+  const lockClass = usePrefixClass('loading--lock');
+  const lockFullscreen = mergedProps.preventScrollThrough && mergedProps.fullscreen;
+
+  if (lockFullscreen) {
+    addClass(document.body, lockClass.value);
+  }
 
   if (attach) {
     addClass(attach, parentRelativeClass);
@@ -41,6 +63,7 @@ function createLoading(props: TdLoadingProps): LoadingInstance {
         item.remove();
       });
       removeClass(attach, parentRelativeClass);
+      removeClass(document.body, lockClass.value);
       app.unmount();
     },
   };
@@ -48,22 +71,19 @@ function createLoading(props: TdLoadingProps): LoadingInstance {
 }
 
 function produceLoading(props: boolean | TdLoadingProps): LoadingInstance {
-  const lockClass = usePrefixClass('loading--lock');
-
   // 全屏加载
   if (props === true) {
     fullScreenLoadingInstance = createLoading({
       fullscreen: true,
       loading: true,
       attach: 'body',
+      preventScrollThrough: true,
     });
     return fullScreenLoadingInstance;
   }
-  removeClass(document.body, lockClass.value);
 
   if (props === false) {
     // 销毁全屏实例
-    removeClass(document.body, lockClass.value);
     fullScreenLoadingInstance.hide();
     fullScreenLoadingInstance = null;
     return;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

* #4037 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 实现 `LoadingPlugin` 的 `preventScrollThrough` 逻辑。
2. 处理 `fullscreen = true` 时 `attach` 固定为 `body` 标签，保持和 `loading.tsx` 逻辑一致。

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(loading): 修复 `LoadingPlugin` 调用时 `preventScrollThrough` 参数无效。

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
