### PR TITLE
fix(Datepicker): value display wrong with special format

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "@babel/plugin-transform-object-assign": "^7.22.5",
     "@babel/plugin-transform-runtime": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
-    "@babel/helper-module-imports": "7.22.5",
     "@commitlint/cli": "^16.3.0",
     "@commitlint/config-conventional": "^15.0.0",
     "@rollup/plugin-babel": "^5.3.1",

--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -7,7 +7,7 @@ import { usePrefixClass, useConfig } from '../hooks/useConfig';
 import { useFormDisabled } from '../form/hooks';
 import useSingle from './hooks/useSingle';
 import { parseToDayjs, getDefaultFormat, formatTime, formatDate } from '../_common/js/date-picker/format';
-import { subtractMonth, addMonth, extractTimeObj } from '../_common/js/date-picker/utils';
+import { subtractMonth, addMonth, extractTimeObj, covertToDate } from '../_common/js/date-picker/utils';
 import props from './props';
 import TSelectInput from '../select-input';
 import TSinglePanel from './panel/SinglePanel';
@@ -60,10 +60,12 @@ export default defineComponent({
     });
 
     watch(popupVisible, (visible) => {
-      cacheValue.value = formatDate(value.value, {
+      const dateValue = covertToDate(value.value as string, formatRef.value?.valueType);
+
+      cacheValue.value = formatDate(dateValue, {
         format: formatRef.value.format,
       });
-      inputValue.value = formatDate(value.value, {
+      inputValue.value = formatDate(dateValue, {
         format: formatRef.value.format,
       });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/3068
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- formatDate 方法需要Date对象来计算，部分场景下，value.value为普通字符串或时间戳，无法得出正确的结果，需统一转为Date再进行计算
- 相关PR https://github.com/Tencent/tdesign-common/pull/1746
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 修复 `format` 与 `valueType` 不一致的场景下计算错误的问题
- chore: remove duplicate dependency delcaration

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
