### PR TITLE
fix(DatePicker): fix over parse when value type is Date

### DIFF
--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -14,6 +14,7 @@ import TSinglePanel from './panel/SinglePanel';
 
 import type { TdDatePickerProps } from './type';
 import type { DateValue } from './type';
+import isDate from 'lodash/isDate';
 
 export default defineComponent({
   name: 'TDatePicker',
@@ -60,7 +61,11 @@ export default defineComponent({
     });
 
     watch(popupVisible, (visible) => {
-      const dateValue = value.value ? covertToDate(value.value as string, formatRef.value?.valueType) : value.value;
+      const dateValue =
+        // Date 属性不再 parse，避免 dayjs 处理成 Invalid
+        value.value && !isDate(value.value)
+          ? covertToDate(value.value as string, formatRef.value?.valueType)
+          : value.value;
 
       cacheValue.value = formatDate(dateValue, {
         format: formatRef.value.format,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 💡 需求背景和解决方案

对于 Date 类型值，不再进行 parse，避免 dayjs 的异常处理

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 对于 `valueType = 'Date'` 不进行初始化的 parse

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
