### PR TITLE
feat(textarea): enable props allow-input-over-max

### DIFF
--- a/src/textarea/props.ts
+++ b/src/textarea/props.ts
@@ -8,6 +8,10 @@ import { TdTextareaProps } from './type';
 import { PropType } from 'vue';
 
 export default {
+  allowInputOverMax: {
+    type: Boolean,
+    default: false,
+  },
   /** 自动聚焦，拉起键盘 */
   autofocus: Boolean,
   /** 高度自动撑开。 autosize = true 表示组件高度自动撑开，同时，依旧允许手动拖高度。如果设置了 autosize.maxRows 或者 autosize.minRows 则不允许手动调整高度 */
@@ -72,4 +76,6 @@ export default {
   onKeypress: Function as PropType<TdTextareaProps['onKeypress']>,
   /** 释放键盘时触发 */
   onKeyup: Function as PropType<TdTextareaProps['onKeyup']>,
+  /** 字数超出限制时触发 */
+  onValidate: Function as PropType<TdTextareaProps['onValidate']>,
 };

--- a/src/textarea/textarea.en-US.md
+++ b/src/textarea/textarea.en-US.md
@@ -24,6 +24,7 @@ onFocus | Function |  | Typescript：`(value: TextareaValue, context : { e: Focu
 onKeydown | Function |  | Typescript：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/> | N
 onKeypress | Function |  | Typescript：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/> | N
 onKeyup | Function |  | Typescript：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/> | N
+onValidate | Function |  | Typescript：`(context: { error?: 'exceed-maximum' \| 'below-minimum' }) => void`<br/>trigger on text length being over max length or max character | N
 
 ### Textarea Events
 

--- a/src/textarea/textarea.md
+++ b/src/textarea/textarea.md
@@ -24,6 +24,7 @@ onFocus | Function |  | TS 类型：`(value: TextareaValue, context : { e: Focus
 onKeydown | Function |  | TS 类型：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/>键盘按下时触发 | N
 onKeypress | Function |  | TS 类型：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/>按下字符键时触发（keydown -> keypress -> keyup） | N
 onKeyup | Function |  | TS 类型：`(value: TextareaValue, context: { e: KeyboardEvent }) => void`<br/>释放键盘时触发 | N
+onValidate | Function |  | TS 类型：`(context: { error?: 'exceed-maximum' \| 'below-minimum' }) => void`<br/>字数超出限制时触发 | N
 
 ### Textarea Events
 

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -27,6 +27,7 @@ import { usePrefixClass, useCommonClassName } from '../hooks/useConfig';
 
 import props from './props';
 import type { TextareaValue, TdTextareaProps } from './type';
+import useLengthLimit from '../input/useLengthLimit';
 
 function getValidAttrs(obj: object): object {
   const newObj = {};
@@ -159,7 +160,7 @@ export default defineComponent({
         disabled: disabled.value,
         readonly: props.readonly,
         placeholder: props.placeholder,
-        maxlength: props.maxlength || undefined,
+        maxlength: (!props.allowInputOverMax && props.maxlength) || undefined,
         name: props.name || undefined,
       });
     });
@@ -170,6 +171,16 @@ export default defineComponent({
       }
       return characterInfo;
     });
+
+    const limitParams = computed(() => ({
+      value: [undefined, null].includes(innerValue.value) ? undefined : String(innerValue.value),
+      status: props.status,
+      maxlength: Number(props.maxlength),
+      maxcharacter: props.maxcharacter,
+      allowInputOverMax: props.allowInputOverMax,
+      onValidate: props.onValidate,
+    }));
+    const { tStatus } = useLengthLimit(limitParams);
 
     // watch
     watch(
@@ -224,7 +235,7 @@ export default defineComponent({
       const classes = computed(() => [
         `${name.value}__inner`,
         {
-          [`${prefix.value}-is-${props.status}`]: props.status,
+          [`${prefix.value}-is-${tStatus.value}`]: tStatus.value,
           [STATUS.value.disabled]: disabled.value,
           [STATUS.value.focused]: focused.value,
           [`${prefix.value}-resize-none`]: typeof props.autosize === 'object',

--- a/src/textarea/type.ts
+++ b/src/textarea/type.ts
@@ -8,6 +8,11 @@ import { TNode } from '../common';
 
 export interface TdTextareaProps {
   /**
+   * 超出maxlength或maxcharacter之后是否还允许输入
+   * @default false
+   */
+  allowInputOverMax?: boolean;
+  /**
    * 自动聚焦，拉起键盘
    * @default false
    */
@@ -88,6 +93,10 @@ export interface TdTextareaProps {
    * 释放键盘时触发
    */
   onKeyup?: (value: TextareaValue, context: { e: KeyboardEvent }) => void;
+  /**
+   * 字数超出限制时触发
+   */
+  onValidate?: (context: { error?: 'exceed-maximum' | 'below-minimum' }) => void;
 }
 
 export type TextareaValue = string | number;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#4084

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Textarea): 新增 `allow-input-over-max` 属性
- feat(Textarea): 新增`onValidate` 事件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
