### PR TITLE
fix(descriptions): check empty for item label and content

### DIFF
--- a/src/descriptions/__tests__/index.test.jsx
+++ b/src/descriptions/__tests__/index.test.jsx
@@ -156,6 +156,26 @@ describe('Descriptions', () => {
       // 检查第 1 个 tr 元素中是否只有 4 个 td 元素
       expect(firstTr.findAll('td')).toHaveLength(4);
     });
+
+    it(':items:undefined:null', () => {
+      const items = [
+        { label: undefined, content: 'TDesign' },
+        { label: 'Telephone Number', content: null },
+      ];
+      const wrapper = mount({
+        render() {
+          return <Descriptions items={items} />;
+        },
+      });
+
+      const tbody = wrapper.find('tbody');
+      const firstTr = tbody.findAll('tr')[0];
+      // 检查 第 1 个 td 是否为空
+      expect(firstTr.findAll('td')[0].text()).toBe('');
+
+      // 检查 第 4 个 td 是否为空
+      expect(firstTr.findAll('td')[3].text()).toBe('');
+    });
   });
 
   describe(':slots', () => {

--- a/src/descriptions/utils/index.ts
+++ b/src/descriptions/utils/index.ts
@@ -14,14 +14,14 @@ import { TdDescriptionItemProps } from '../type';
  * @param params
  * @returns
  */
-export function renderCustomNode(node: string | ((...args: any[]) => any) | ComponentOptions, params = {}) {
+export function renderCustomNode(node?: string | ((...args: any[]) => any) | ComponentOptions, params = {}) {
   if (isString(node)) {
     return node;
   }
   if (isFunction(node)) {
     return node(h, params);
   }
-  if (isFunction(node.render)) {
+  if (isFunction(node?.render)) {
     return node.render(h, params);
   }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
<img width="300" src="https://github.com/Tencent/tdesign-vue-next/assets/44194929/0384cd45-ef46-474f-b2a5-40b614750630">
<img width="300" alt="image" src="https://github.com/Tencent/tdesign-vue-next/assets/44194929/713dd15f-1bfb-47fa-8b1e-974bceef90c6">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Descriptions): check empty for items label and content

