### PR TITLE
fix(image): `src = File` error triggered `handleError` (#3448)

### DIFF
--- a/src/hooks/useImagePreviewUrl.ts
+++ b/src/hooks/useImagePreviewUrl.ts
@@ -3,21 +3,24 @@ import { getFileUrlByFileRaw } from '../_common/js/upload/utils';
 
 export function useImagePreviewUrl(imgUrl: Ref<string | File> | ComputedRef<string | File>) {
   const previewUrl = ref('');
+  const loading = ref(true);
 
   watch(
     [imgUrl],
     ([imgUrl], [preImgUrl]) => {
       if (preImgUrl === imgUrl) return;
       if (typeof imgUrl === 'string') {
+        loading.value = false;
         previewUrl.value = imgUrl;
         return;
       }
       getFileUrlByFileRaw(imgUrl).then((url) => {
+        loading.value = false;
         previewUrl.value = url;
       });
     },
     { immediate: true },
   );
 
-  return { previewUrl };
+  return { loading, previewUrl };
 }

--- a/src/image/image.tsx
+++ b/src/image/image.tsx
@@ -55,11 +55,13 @@ export default defineComponent({
       { immediate: true },
     );
 
-    const { previewUrl } = useImagePreviewUrl(imageStrSrc);
+    const { loading, previewUrl } = useImagePreviewUrl(imageStrSrc);
 
-    watch([previewUrl], () => {
-      hasError.value = false;
-      isLoaded.value = false;
+    watch([loading], () => {
+      if (!loading) {
+        hasError.value = false;
+        isLoaded.value = false;
+      }
     });
 
     const shouldLoad = ref(!props.lazy);
@@ -196,6 +198,7 @@ export default defineComponent({
 
           {(hasError.value || !shouldLoad.value) && <div class={`${classPrefix.value}-image`} />}
           {!(hasError.value || !shouldLoad.value) &&
+            !loading.value &&
             (props.srcset && Object.keys(props.srcset).length ? renderImageSrcset() : renderImage())}
           {!(hasError.value || !shouldLoad.value) && !isLoaded.value && (
             <div class={`${classPrefix.value}-image__loading`}>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
* #3448 

### 💡 需求背景和解决方案
背景：
`src = File` 时通过 `useImagePreviewUrl` 获取 `previewUrl`，由于异步的原因，执行 `renderImage()` 时 
`previewUrl` 为空，触发了 `handleError` 逻辑导致 `loading` 视图没有展示。

方案：
`useImagePreviewUrl` 增加了 `loading` 标识是否加载完 `previewUrl`。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(image): 修复了 `src = File` 时 `loading` 视图没有展示。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
