### PR TITLE
fix(textarea): `autosize` doesn't work in Firefox (#4103)

### DIFF
--- a/src/textarea/calcTextareaHeight.ts
+++ b/src/textarea/calcTextareaHeight.ts
@@ -13,7 +13,7 @@ const HIDDEN_TEXTAREA_STYLE = `
   max-height:none !important;
   height:0 !important;
   visibility:hidden !important;
-  overflow:hidden !important;
+  overflow-y:hidden !important;
   position:absolute !important;
   z-index:-1000 !important;
   top:0 !important;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
* #4103 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
这个 bug 应该是 Firefox 的问题。
Firefox 对 `textarea` 设置 overflow: hidden 后首次获取到的 `scrollHeight` 是错误的，导致初始化的容器高度是错误的。
我尝试将 `overflow: hidden` 去掉，但是会影响 Chrome 的样式，后面改成 `overflow-y: hidden` 后自测暂没发现问题。

或许跟下面这个远古 bug 有关。
https://bugzilla.mozilla.org/show_bug.cgi?id=33654

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): `autosize` 在 `Firefox` 中不生效。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
