### PR TITLE
fix(cascader): 修复Cascader 多选状态下 删除选项时触发多次change事件的问题

### DIFF
--- a/src/cascader/core/effect.ts
+++ b/src/cascader/core/effect.ts
@@ -134,8 +134,6 @@ export function handleRemoveTagEffect(
   const res = newValue.splice(index, 1);
   const node = treeStore.getNodes(res[0])[0];
 
-  setValue(newValue, 'uncheck', node.getModel());
-
   const checked = node.setChecked(!node.isChecked());
   // 处理不同数据类型
   const resValue =


### PR DESCRIPTION
closed #2778

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2778 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

修复Cascader 多选状态下 删除选项时触发多次change事件的问题

### 📝 更新日志

去除没必要的setValue

fix(Cascader): 修复 `cascader` 多选状态下 删除选项时触发多次 `change` 事件的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
