### PR TITLE
修复在指定format和valueType下，年份解析错误问题

### DIFF
--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -109,7 +109,8 @@ export default defineComponent({
         isHoverCell.value = false;
         isFirstValueSelected.value = false;
         inputValue.value = formatDate(value.value, {
-          format: formatRef.value.format,
+          format: formatRef.value.valueType,
+          targetFormat: formatRef.value.format,
         });
       }
     });

--- a/src/date-picker/hooks/useRange.tsx
+++ b/src/date-picker/hooks/useRange.tsx
@@ -148,7 +148,8 @@ export default function useRange(props: TdDateRangePickerProps) {
       if (!isValidDate(value, formatRef.value.format)) return;
 
       inputValue.value = formatDate(value, {
-        format: formatRef.value.format,
+        format: formatRef.value.valueType,
+        targetFormat: formatRef.value.format,
       });
     },
     {

--- a/src/date-picker/hooks/useRangeValue.ts
+++ b/src/date-picker/hooks/useRangeValue.ts
@@ -23,6 +23,7 @@ export default function useRangeValue(props: TdDateRangePickerProps) {
     getDefaultFormat({
       mode: props.mode,
       format: props.format,
+      valueType: props.valueType,
       enableTimePicker: props.enableTimePicker,
     }),
   );
@@ -70,7 +71,8 @@ export default function useRangeValue(props: TdDateRangePickerProps) {
     if (!isValidDate(value.value, formatRef.value.format)) return;
 
     cacheValue.value = formatDate(value.value, {
-      format: formatRef.value.format,
+      format: formatRef.value.valueType,
+      targetFormat: formatRef.value.format,
     });
     time.value = formatTime(
       value.value,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [√] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#4083 

### 💡 需求背景和解决方案
感觉得需要在文档中说清楚一些，valueType和format，在我的理解里头format用于展示用的，只用于最后将数据展示给用户的时候的格式转换；valueType是用于解析date-picker中的实际的value，用于实际处理计算的。

### 📝 更新日志
或许需要重新捋清楚这俩属性的定义以及实际使用，和common库中的formatDate的参数在名称上好像没对齐。
- fix(date-picker): 修复在指定format和valueType下，年份解析错误问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
