### PR TITLE
fix: fix incomplete demo presentation

### DIFF
--- a/site/src/components/base-usage.vue
+++ b/site/src/components/base-usage.vue
@@ -6,7 +6,7 @@
       :key="item.value"
       :style="{
         width: '100%',
-        height: '100%',
+        height: `${item.value === 'slider' ? '100%' : 'auto'}`, // slider vertical 布局时，高度通过百分比获取，需要容器指定 height
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

![image](https://github.com/Tencent/tdesign-vue-next/assets/89014758/c85ce666-b87f-4cf1-be97-3beb2c25cb5b)

doc-usage 区域指定 `height: 100%` 后，可以使 slider vertical 布局显示正常（slider vertical 布局时 height 通过百分比获取，需要外部容器指定 height 高度），但是其他组件由于高度较大，溢出部分被截断不可见。

```css
align-items: safe center;
justify-content: safe center;
```
通过 safe 属性值可以解决上述问题，但兼容性还不够友好，Chrome 115 开始支持（见：https://www.w3.org/TR/css-align-3/#overflow-values  https://caniuse.com/?search=justify-content）

故，对于 slider demo 显式指定高度，其他组件设为 auto 自动获取

- fix: 修复 demo 展示不全

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
