### PR TITLE
fix(dialog): 修复visible默认为true的情况 无法esc关闭的问题

### DIFF
--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -181,26 +181,30 @@ export default defineComponent({
     watch(
       () => props.visible,
       (value) => {
-        if (value) {
-          if ((isModal.value && !props.showInAttachedElement) || isFullScreen.value) {
-            if (props.preventScrollThrough) {
-              document.body.appendChild(styleEl.value);
-            }
-
-            nextTick(() => {
-              if (mousePosition && dialogEle.value) {
-                dialogEle.value.style.transformOrigin = `${mousePosition.x - dialogEle.value.offsetLeft}px ${
-                  mousePosition.y - dialogEle.value.offsetTop
-                }px`;
+        nextTick(() => {
+          if (value) {
+            if ((isModal.value && !props.showInAttachedElement) || isFullScreen.value) {
+              if (props.preventScrollThrough) {
+                document.body.appendChild(styleEl.value);
               }
-            });
+              () => {
+                if (mousePosition && dialogEle.value) {
+                  dialogEle.value.style.transformOrigin = `${mousePosition.x - dialogEle.value.offsetLeft}px ${
+                    mousePosition.y - dialogEle.value.offsetTop
+                  }px`;
+                }
+              };
+            }
+            // 清除鼠标焦点 避免entry事件多次触发（按钮弹出弹窗 不移除焦点 立即按Entry按键 会造成弹窗关闭再弹出）
+            (document.activeElement as HTMLElement)?.blur();
+          } else {
+            clearStyleFunc();
           }
-          // 清除鼠标焦点 避免entry事件多次触发（按钮弹出弹窗 不移除焦点 立即按Entry按键 会造成弹窗关闭再弹出）
-          (document.activeElement as HTMLElement)?.blur();
-        } else {
-          clearStyleFunc();
-        }
-        addKeyboardEvent(value);
+          addKeyboardEvent(value);
+        });
+      },
+      {
+        immediate: true,
       },
     );
 


### PR DESCRIPTION
closed #4153

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#4153 

### 💡 需求背景和解决方案

修复visible默认为true的情况 无法esc关闭的问题

### 📝 更新日志
fix(dialog): 修复visible默认为true的情况 无法esc关闭的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
