### PR TITLE
feat(TimePicker): hide now button when presets is set

### DIFF
--- a/src/time-picker/panel/time-picker-panel.tsx
+++ b/src/time-picker/panel/time-picker-panel.tsx
@@ -1,6 +1,7 @@
 import { defineComponent, toRefs, computed, ref, onMounted, nextTick, watch } from 'vue';
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import isUndefined from 'lodash/isUndefined';
 
 import { DEFAULT_STEPS, DEFAULT_FORMAT } from '../../_common/js/time-picker/const';
 import { panelProps } from './props';
@@ -67,6 +68,31 @@ export default defineComponent({
       }
     };
 
+    const renderFooter = () => {
+      if (!isUndefined(props.presets))
+        return Object.keys(props.presets || []).map((key: string) => (
+          <TButton
+            key={key}
+            theme="primary"
+            size="small"
+            variant="text"
+            onClick={() => handlePresetClick(props.presets[key])}
+          >
+            {key}
+          </TButton>
+        ));
+      return !showNowTimeBtn.value ? (
+        <TButton
+          theme="primary"
+          variant="text"
+          size="small"
+          onClick={() => props.onChange?.(dayjs().format(props.format))}
+        >
+          {globalConfig.value.now}
+        </TButton>
+      ) : null;
+    };
+
     // 渲染后执行update 使面板滚动至当前时间位置
     onMounted(() => {
       panelColUpdate();
@@ -105,28 +131,7 @@ export default defineComponent({
             >
               {globalConfig.value.confirm}
             </TButton>
-            {!showNowTimeBtn.value ? (
-              <TButton
-                theme="primary"
-                variant="text"
-                size="small"
-                onClick={() => props.onChange?.(dayjs().format(props.format))}
-              >
-                {globalConfig.value.now}
-              </TButton>
-            ) : null}
-            {props.presets &&
-              Object.keys(props.presets).map((key: string) => (
-                <TButton
-                  key={key}
-                  theme="primary"
-                  size="small"
-                  variant="text"
-                  onClick={() => handlePresetClick(props.presets[key])}
-                >
-                  {key}
-                </TButton>
-              ))}
+            {renderFooter()}
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/4170
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(TimePicker): 此刻按钮在设置`preset` API 时不再展示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
