### PR TITLE
fix(cascader): fix lost prefixIcon and suffixIcon

### DIFF
--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -47,6 +47,10 @@ export default defineComponent({
     );
 
     const renderSuffixIcon = () => {
+      if (props.suffixIcon || slots.suffixIcon) {
+        return renderTNodeJSX('suffixIcon');
+      }
+
       const { visible, disabled } = cascaderContext.value;
       return (
         <FakeArrow
@@ -114,6 +118,8 @@ export default defineComponent({
           borderless={props.borderless}
           label={renderLabel}
           valueDisplay={renderValueDisplay}
+          prefixIcon={props.prefixIcon}
+          suffix={props.suffix}
           suffixIcon={() => renderSuffixIcon()}
           popupProps={{
             ...(props.popupProps as TdCascaderProps['popupProps']),
@@ -167,8 +173,8 @@ export default defineComponent({
           }}
           v-slots={{
             label: slots.label,
-            suffix: props.suffix,
-            prefixIcon: props.prefixIcon,
+            suffix: slots.suffix,
+            prefixIcon: slots.prefixIcon,
             panel: () => (
               <Panel
                 option={props.option}

--- a/src/select-input/interface.ts
+++ b/src/select-input/interface.ts
@@ -1,6 +1,7 @@
 import { TdSelectInputProps } from './type';
 
 export interface SelectInputCommonProperties {
+  size?: TdSelectInputProps['size'];
   status?: TdSelectInputProps['status'];
   tips?: TdSelectInputProps['tips'];
   clearable?: TdSelectInputProps['clearable'];

--- a/src/select-input/interface.ts
+++ b/src/select-input/interface.ts
@@ -8,6 +8,7 @@ export interface SelectInputCommonProperties {
   label?: TdSelectInputProps['label'];
   placeholder?: TdSelectInputProps['placeholder'];
   readonly?: TdSelectInputProps['readonly'];
+  prefixIcon?: TdSelectInputProps['prefixIcon'];
   suffix?: TdSelectInputProps['suffix'];
   suffixIcon?: TdSelectInputProps['suffixIcon'];
   onPaste?: TdSelectInputProps['onPaste'];

--- a/src/select-input/props.ts
+++ b/src/select-input/props.ts
@@ -23,7 +23,10 @@ export default {
     type: Function as PropType<TdSelectInputProps['collapsedItems']>,
   },
   /** 是否禁用 */
-  disabled: Boolean,
+  disabled: {
+    type: Boolean,
+    default: undefined,
+  },
   /** 透传 Input 输入框组件全部属性 */
   inputProps: {
     type: Object as PropType<TdSelectInputProps['inputProps']>,

--- a/src/select-input/props.ts
+++ b/src/select-input/props.ts
@@ -23,10 +23,7 @@ export default {
     type: Function as PropType<TdSelectInputProps['collapsedItems']>,
   },
   /** 是否禁用 */
-  disabled: {
-    type: Boolean,
-    default: undefined,
-  },
+  disabled: Boolean,
   /** 透传 Input 输入框组件全部属性 */
   inputProps: {
     type: Object as PropType<TdSelectInputProps['inputProps']>,
@@ -77,10 +74,23 @@ export default {
   },
   /** 是否显示下拉框，非受控属性 */
   defaultPopupVisible: Boolean,
+  /** 组件前置图标 */
+  prefixIcon: {
+    type: Function as PropType<TdSelectInputProps['prefixIcon']>,
+  },
   /** 只读状态，值为真会隐藏输入框，且无法打开下拉框 */
   readonly: Boolean,
   /** 多选且可搜索时，是否在选中一个选项后保留当前的搜索关键词 */
   reserveKeyword: Boolean,
+  /** 组件尺寸 */
+  size: {
+    type: String as PropType<TdSelectInputProps['size']>,
+    default: 'medium' as TdSelectInputProps['size'],
+    validator(val: TdSelectInputProps['size']): boolean {
+      if (!val) return true;
+      return ['small', 'medium', 'large'].includes(val);
+    },
+  },
   /** 输入框状态 */
   status: {
     type: String as PropType<TdSelectInputProps['status']>,

--- a/src/select-input/select-input.en-US.md
+++ b/src/select-input/select-input.en-US.md
@@ -26,8 +26,10 @@ placeholder | String | - | placeholder description | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select-input/type.ts) | N
 popupVisible | Boolean | - | `v-model:popupVisible` is supported | N
 defaultPopupVisible | Boolean | - | uncontrolled property | N
+prefixIcon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | \- | N
 reserveKeyword | Boolean | false | \- | N
+size | String | medium | options: small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 status | String | default | options: default/success/warning/error | N
 suffix | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 suffixIcon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/select-input/select-input.md
+++ b/src/select-input/select-input.md
@@ -26,8 +26,10 @@ placeholder | String | - | 占位符 | N
 popupProps | Object | - | 透传 Popup 浮层组件全部属性。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/select-input/type.ts) | N
 popupVisible | Boolean | - | 是否显示下拉框。支持语法糖 `v-model:popupVisible` | N
 defaultPopupVisible | Boolean | - | 是否显示下拉框。非受控属性 | N
+prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 readonly | Boolean | false | 只读状态，值为真会隐藏输入框，且无法打开下拉框 | N
 reserveKeyword | Boolean | false | 多选且可搜索时，是否在选中一个选项后保留当前的搜索关键词 | N
+size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 status | String | default | 输入框状态。可选项：default/success/warning/error | N
 suffix | String / Slot / Function | - | 后置图标前的后置内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 suffixIcon | Slot / Function | - | 组件后置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/select-input/type.ts
+++ b/src/select-input/type.ts
@@ -9,7 +9,7 @@ import { PopupProps } from '../popup';
 import { TagInputProps, TagInputValue, TagInputChangeContext } from '../tag-input';
 import { TagProps } from '../tag';
 import { PopupVisibleChangeContext } from '../popup';
-import { TNode } from '../common';
+import { TNode, SizeEnum } from '../common';
 
 export interface TdSelectInputProps {
   /**
@@ -107,6 +107,10 @@ export interface TdSelectInputProps {
    */
   defaultPopupVisible?: boolean;
   /**
+   * 组件前置图标
+   */
+  prefixIcon?: TNode;
+  /**
    * 只读状态，值为真会隐藏输入框，且无法打开下拉框
    * @default false
    */
@@ -116,6 +120,11 @@ export interface TdSelectInputProps {
    * @default false
    */
   reserveKeyword?: boolean;
+  /**
+   * 组件尺寸
+   * @default medium
+   */
+  size?: SizeEnum;
   /**
    * 输入框状态
    * @default default
@@ -196,12 +205,6 @@ export interface TdSelectInputProps {
    * 值变化时触发，参数 `context.trigger` 表示数据变化的触发来源；`context.index` 指当前变化项的下标；`context.item` 指当前变化项；`context.e` 表示事件参数
    */
   onTagChange?: (value: TagInputValue, context: SelectInputChangeContext) => void;
-}
-
-export interface SelectInputKeys {
-  label?: string;
-  value?: string;
-  children?: string;
 }
 
 export interface SelectInputKeys {

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -19,6 +19,7 @@ const COMMON_PROPERTIES = [
   'label',
   'placeholder',
   'readonly',
+  'prefixIcon',
   'suffix',
   'suffixIcon',
   'onPaste',

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -25,6 +25,7 @@ const COMMON_PROPERTIES = [
   'onPaste',
   'onMouseenter',
   'onMouseleave',
+  'size',
 ];
 
 const DEFAULT_KEYS = {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

prefixIcon和suffixIcon的slot不起作用

详情见 [#4225 ](https://github.com/Tencent/tdesign-vue-next/issues/4225)

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

由于cascader过去的api并未传入suffix，suffixIcon，prefixIcon，select-input未有prefixIcon这个api，因此做了对应修改，并且更新了select-input的文档

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复`prefixIcon`、`suffix`和`suffixIcon`的 slot 功能缺失的问题
- feat(SelectInput): 新增`size`属性

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
