### PR TITLE
feat(DatePicker): optimize range picker panel header click logic

### DIFF
--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -133,7 +133,7 @@ export default defineComponent({
     }
 
     // 日期点击
-    function onCellClick(date: Date, { e, partial }: { e: MouseEvent; partial: DateRangePickerPartial }) {
+    function onCellClick(date: Date, { e }: { e: MouseEvent; partial: DateRangePickerPartial }) {
       props.onPick?.(date, { e, partial: activeIndex.value ? 'end' : 'start' });
 
       isHoverCell.value = false;

--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -239,7 +239,7 @@ export default defineComponent({
             // eslint-disable-next-line prefer-destructuring
             nextYear[0] = nextYear[1];
             if (nextMonth[0] >= nextMonth[1]) {
-              nextMonth[0] -= 1;
+              nextMonth[0] = nextMonth[1] - 1;
               if (nextMonth[0] === -1) {
                 // 处理跨年的边界场景
                 nextMonth[0] = 11;

--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -20,6 +20,7 @@ import {
   initYearMonthTime,
 } from '../_common/js/date-picker/format';
 import { subtractMonth, addMonth, extractTimeObj } from '../_common/js/date-picker/utils';
+import { dateCorrection } from './utils';
 
 export default defineComponent({
   name: 'TDateRangePicker',
@@ -207,48 +208,14 @@ export default defineComponent({
 
       let nextYear = [...year.value];
       nextYear[partialIndex] = next.getFullYear();
-      const nextMonth = [...month.value];
+      let nextMonth = [...month.value];
       nextMonth[partialIndex] = next.getMonth();
       const onlyYearSelect = ['year', 'quarter', 'month'].includes(props.mode);
 
-      // 保证左侧时间不大于右侧
-      if (partialIndex === 0) {
-        if (nextYear[1] <= nextYear[0]) {
-          if (onlyYearSelect) nextYear[1] = nextYear[0] + 1;
-          else {
-            // eslint-disable-next-line prefer-destructuring
-            nextYear[1] = nextYear[0];
-            if (nextMonth[1] <= nextMonth[0]) {
-              nextMonth[1] = nextMonth[0] + 1;
-              if (nextMonth[1] === 12) {
-                // 处理跨年的边界场景
-                nextMonth[1] = 0;
-                nextYear = [nextYear[0], nextYear[1] + 1];
-              }
-            }
-          }
-        }
-      }
-
-      // 保证左侧时间不大于右侧
-      if (partialIndex === 1) {
-        if (nextYear[0] >= nextYear[1]) {
-          // 年/季度/月份场景下，头部只有年选择器，直接 - 1
-          if (onlyYearSelect) nextYear[0] = nextYear[1] - 1;
-          else {
-            // eslint-disable-next-line prefer-destructuring
-            nextYear[0] = nextYear[1];
-            if (nextMonth[0] >= nextMonth[1]) {
-              nextMonth[0] = nextMonth[1] - 1;
-              if (nextMonth[0] === -1) {
-                // 处理跨年的边界场景
-                nextMonth[0] = 11;
-                nextYear = [nextYear[0] - 1, nextYear[1]];
-              }
-            }
-          }
-        }
-      }
+      // 头部日期切换修正
+      const correctedDate = dateCorrection(partialIndex, nextYear, nextMonth, onlyYearSelect);
+      nextYear = correctedDate.nextYear;
+      nextMonth = correctedDate.nextMonth;
 
       year.value = nextYear;
       month.value = nextMonth;
@@ -360,46 +327,16 @@ export default defineComponent({
       let partialIndex = partial === 'start' ? 0 : 1;
       if (props.enableTimePicker) partialIndex = activeIndex.value;
 
-      const nextYear = [...year.value];
-      const nextMonth = [...month.value];
+      let nextYear = [...year.value];
+      let nextMonth = [...month.value];
 
       nextYear[partialIndex] = nextVal;
       const onlyYearSelect = ['year', 'quarter', 'month'].includes(props.mode);
 
-      // 保证左侧时间不大于右侧
-      if (partialIndex === 0) {
-        if (nextYear[1] <= nextYear[0]) {
-          if (onlyYearSelect) nextYear[1] = nextYear[0] + 1;
-          else {
-            // 日期，周选择场景，还有月份选择器，需要再处理月份选择器的边界问题
-            // eslint-disable-next-line prefer-destructuring
-            nextYear[1] = nextYear[0];
-            nextMonth[1] = nextMonth[0] + 1;
-            if (nextMonth[1] === 12) {
-              // 处理跨年的边界场景
-              nextMonth[1] = 0;
-              nextYear[1] += 1;
-            }
-          }
-        }
-      }
-      if (partialIndex === 1) {
-        if (nextYear[0] >= nextYear[1]) {
-          // 年/季度/月份场景下，头部只有年选择器，直接 - 1
-          if (onlyYearSelect) nextYear[0] = nextYear[1] - 1;
-          else {
-            // 日期，周选择场景，还有月份选择器，需要再处理月份选择器的边界问题
-            // eslint-disable-next-line prefer-destructuring
-            nextYear[0] = nextYear[1];
-            nextMonth[0] = nextMonth[1] - 1;
-            if (nextMonth[0] === -1) {
-              // 处理跨年的边界场景
-              nextMonth[0] = 11;
-              nextYear[0] -= 1;
-            }
-          }
-        }
-      }
+      // 头部日期切换修正
+      const correctedDate = dateCorrection(partialIndex, nextYear, nextMonth, onlyYearSelect);
+      nextYear = correctedDate.nextYear;
+      nextMonth = correctedDate.nextMonth;
 
       year.value = nextYear;
       if (!onlyYearSelect) month.value = nextMonth;

--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -146,18 +146,6 @@ export default defineComponent({
       cacheValue.value = nextValue;
       inputValue.value = nextValue;
 
-      // date 模式自动切换年月
-      if (props.mode === 'date') {
-        // 选择了不属于面板中展示月份的日期
-        const partialIndex = partial === 'start' ? 0 : 1;
-        const isAdditional = dayjs(date).month() !== month.value[partialIndex];
-        if (isAdditional) {
-          // 保证左侧时间小于右侧
-          if (activeIndex.value === 0) month.value = [dayjs(date).month(), Math.min(dayjs(date).month() + 1, 11)];
-          if (activeIndex.value === 1) month.value = [Math.max(dayjs(date).month() - 1, 0), dayjs(date).month()];
-        }
-      }
-
       // 有时间选择器走 confirm 逻辑
       if (props.enableTimePicker) return;
 
@@ -217,26 +205,48 @@ export default defineComponent({
         next = addMonth(current, monthCount);
       }
 
-      const nextYear = [...year.value];
+      let nextYear = [...year.value];
       nextYear[partialIndex] = next.getFullYear();
       const nextMonth = [...month.value];
       nextMonth[partialIndex] = next.getMonth();
+      const onlyYearSelect = ['year', 'quarter', 'month'].includes(props.mode);
 
       // 保证左侧时间不大于右侧
       if (partialIndex === 0) {
-        nextYear[1] = Math.max(nextYear[0], nextYear[1]);
-
-        if (nextYear[0] === nextYear[1]) {
-          nextMonth[1] = Math.max(nextMonth[0], nextMonth[1]);
+        if (nextYear[1] <= nextYear[0]) {
+          if (onlyYearSelect) nextYear[1] = nextYear[0] + 1;
+          else {
+            // eslint-disable-next-line prefer-destructuring
+            nextYear[1] = nextYear[0];
+            if (nextMonth[1] <= nextMonth[0]) {
+              nextMonth[1] = nextMonth[0] + 1;
+              if (nextMonth[1] === 12) {
+                // 处理跨年的边界场景
+                nextMonth[1] = 0;
+                nextYear = [nextYear[0], nextYear[1] + 1];
+              }
+            }
+          }
         }
       }
 
       // 保证左侧时间不大于右侧
       if (partialIndex === 1) {
-        nextYear[0] = Math.min(nextYear[0], nextYear[1]);
-
-        if (nextYear[0] === nextYear[1]) {
-          nextMonth[0] = Math.min(nextMonth[0], nextMonth[1]);
+        if (nextYear[0] >= nextYear[1]) {
+          // 年/季度/月份场景下，头部只有年选择器，直接 - 1
+          if (onlyYearSelect) nextYear[0] = nextYear[1] - 1;
+          else {
+            // eslint-disable-next-line prefer-destructuring
+            nextYear[0] = nextYear[1];
+            if (nextMonth[0] >= nextMonth[1]) {
+              nextMonth[0] -= 1;
+              if (nextMonth[0] === -1) {
+                // 处理跨年的边界场景
+                nextMonth[0] = 11;
+                nextYear = [nextYear[0] - 1, nextYear[1]];
+              }
+            }
+          }
         }
       }
 
@@ -351,12 +361,48 @@ export default defineComponent({
       if (props.enableTimePicker) partialIndex = activeIndex.value;
 
       const nextYear = [...year.value];
+      const nextMonth = [...month.value];
+
       nextYear[partialIndex] = nextVal;
+      const onlyYearSelect = ['year', 'quarter', 'month'].includes(props.mode);
+
       // 保证左侧时间不大于右侧
-      if (partialIndex === 0) nextYear[1] = Math.max(nextYear[0], nextYear[1]);
-      if (partialIndex === 1) nextYear[0] = Math.min(nextYear[0], nextYear[1]);
+      if (partialIndex === 0) {
+        if (nextYear[1] <= nextYear[0]) {
+          if (onlyYearSelect) nextYear[1] = nextYear[0] + 1;
+          else {
+            // 日期，周选择场景，还有月份选择器，需要再处理月份选择器的边界问题
+            // eslint-disable-next-line prefer-destructuring
+            nextYear[1] = nextYear[0];
+            nextMonth[1] = nextMonth[0] + 1;
+            if (nextMonth[1] === 12) {
+              // 处理跨年的边界场景
+              nextMonth[1] = 0;
+              nextYear[1] += 1;
+            }
+          }
+        }
+      }
+      if (partialIndex === 1) {
+        if (nextYear[0] >= nextYear[1]) {
+          // 年/季度/月份场景下，头部只有年选择器，直接 - 1
+          if (onlyYearSelect) nextYear[0] = nextYear[1] - 1;
+          else {
+            // 日期，周选择场景，还有月份选择器，需要再处理月份选择器的边界问题
+            // eslint-disable-next-line prefer-destructuring
+            nextYear[0] = nextYear[1];
+            nextMonth[0] = nextMonth[1] - 1;
+            if (nextMonth[0] === -1) {
+              // 处理跨年的边界场景
+              nextMonth[0] = 11;
+              nextYear[0] -= 1;
+            }
+          }
+        }
+      }
 
       year.value = nextYear;
+      if (!onlyYearSelect) month.value = nextMonth;
     }
 
     function onMonthChange(nextVal: number, { partial }: { partial: DateRangePickerPartial }) {
@@ -367,8 +413,29 @@ export default defineComponent({
       nextMonth[partialIndex] = nextVal;
       // 保证左侧时间不大于右侧
       if (year.value[0] === year.value[1]) {
-        if (partialIndex === 0) nextMonth[1] = Math.max(nextMonth[0], nextMonth[1]);
-        if (partialIndex === 1) nextMonth[0] = Math.min(nextMonth[0], nextMonth[1]);
+        if (partialIndex === 0) {
+          // 操作了左侧区间, 处理右侧区间小于或等于左侧区间的场景，交互上始终报错右侧比左侧大 1
+          if (nextMonth[1] <= nextMonth[0]) {
+            nextMonth[1] = nextMonth[0] + 1;
+            if (nextMonth[1] === 12) {
+              // 处理跨年的边界场景
+              nextMonth[1] = 0;
+              year.value = [year.value?.[0], year.value?.[1] + 1];
+            }
+          }
+        }
+        if (partialIndex === 1) {
+          // 操作了右侧区间, 处理右侧区间小于或等于左侧区间的场景，交互上始终报错左侧比右侧小 1
+          nextMonth[0] = Math.min(nextMonth[0], nextMonth[1]);
+          if (nextMonth[0] >= nextMonth[1]) {
+            nextMonth[0] -= 1;
+            if (nextMonth[0] === -1) {
+              // 处理跨年的边界场景
+              nextMonth[0] = 11;
+              year.value = [year.value?.[0] - 1, year.value?.[1]];
+            }
+          }
+        }
       }
 
       month.value = nextMonth;

--- a/src/date-picker/DateRangePickerPanel.tsx
+++ b/src/date-picker/DateRangePickerPanel.tsx
@@ -164,7 +164,7 @@ export default defineComponent({
             // eslint-disable-next-line prefer-destructuring
             nextYear[0] = nextYear[1];
             if (nextMonth[0] >= nextMonth[1]) {
-              nextMonth[0] -= 1;
+              nextMonth[0] = nextMonth[1] - 1;
               if (nextMonth[0] === -1) {
                 // 处理跨年的边界场景
                 nextMonth[0] = 11;

--- a/src/date-picker/utils.ts
+++ b/src/date-picker/utils.ts
@@ -1,0 +1,48 @@
+// 用于头部日期切换修正
+export function dateCorrection(
+  partialIndex: number,
+  preYear: Array<number>,
+  preMonth: Array<number>,
+  onlyYearSelect: boolean,
+) {
+  let nextYear = preYear;
+  const nextMonth = preMonth;
+  if (partialIndex === 0) {
+    if (nextYear[1] <= nextYear[0]) {
+      if (onlyYearSelect) nextYear[1] = nextYear[0] + 1;
+      else {
+        // eslint-disable-next-line prefer-destructuring
+        nextYear[1] = nextYear[0];
+        if (nextMonth[1] <= nextMonth[0]) {
+          nextMonth[1] = nextMonth[0] + 1;
+          if (nextMonth[1] === 12) {
+            // 处理跨年的边界场景
+            nextMonth[1] = 0;
+            nextYear = [nextYear[0], nextYear[1] + 1];
+          }
+        }
+      }
+    }
+  }
+
+  // 保证左侧时间不大于右侧
+  if (partialIndex === 1) {
+    if (nextYear[0] >= nextYear[1]) {
+      // 年/季度/月份场景下，头部只有年选择器，直接 - 1
+      if (onlyYearSelect) nextYear[0] = nextYear[1] - 1;
+      else {
+        // eslint-disable-next-line prefer-destructuring
+        nextYear[0] = nextYear[1];
+        if (nextMonth[0] >= nextMonth[1]) {
+          nextMonth[0] = nextMonth[1] - 1;
+          if (nextMonth[0] === -1) {
+            // 处理跨年的边界场景
+            nextMonth[0] = 11;
+            nextYear = [nextYear[0] - 1, nextYear[1]];
+          }
+        }
+      }
+    }
+  }
+  return { nextYear, nextMonth };
+}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
优化前，选择后左侧区间大于右侧区间只会同步右侧区间
<img width="656" alt="image" src="https://github.com/Tencent/tdesign-react/assets/26377630/83dc94be-5d10-4d83-b2ba-886ddf7efa13">
优化后，选择后左侧区间大于右侧区间，默认调整为左侧区间始终比右侧区间小1，增加可操作范围
<img width="612" alt="image" src="https://github.com/Tencent/tdesign-react/assets/26377630/45a8d779-1832-4296-be93-41cd7fa5b934">

切换年且只有年选择器：
1. 点击左侧，且左侧大于右侧，右侧要自动加1；
2. 点击右侧，且右侧小于左侧，左侧要自动减1；
切换年且要有月份选择器：
1. 点击左侧，且左侧大于右侧，右侧要自动切换至左侧年+月份 加1；
1. 点击右侧，且右侧小于左侧，左侧要自动切换至右侧年+月份 减1；
切换月份选择器：
1. 点击左侧，且左侧大于右侧，右侧要自动切换至左侧年+月份 加1；
1. 点击右侧，且右侧小于左侧，左侧要自动切换至右侧年+月份 减1；
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(DatePicker): 优化日期区间选择器头部区间的变化逻辑，选择后左侧区间大于右侧区间，则默认调整为左侧区间始终比右侧区间小 1

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
