### PR TITLE
fix(Table): fix column width not being in sync when using auto layout and fixed table headers

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -28,6 +28,7 @@ import { useRowHighlight } from './hooks/useRowHighlight';
 import useHoverKeyboardEvent from './hooks/useHoverKeyboardEvent';
 import useElementLazyRender from '../hooks/useElementLazyRender';
 import isFunction from 'lodash/isFunction';
+import throttle from 'lodash/throttle';
 
 export const BASE_TABLE_EVENTS = ['page-change', 'cell-click', 'scroll', 'scrollX', 'scrollY'];
 export const BASE_TABLE_ALL_EVENTS = ROW_LISTENERS.map((t) => `row-${t}`).concat(BASE_TABLE_EVENTS);
@@ -204,6 +205,10 @@ export default defineComponent({
       });
     };
 
+    const syncThWidthList = throttle(() => {
+      updateThWidthList(getThWidthList('calculate'));
+    });
+
     // 虚拟滚动相关数据
     const virtualScrollParams = computed(() => ({
       data: props.data,
@@ -225,6 +230,9 @@ export default defineComponent({
       }
       lastScrollY = top;
       emitScrollEvent(e);
+      if (props.tableLayout === 'auto') {
+        syncThWidthList();
+      }
     };
 
     // used for top margin
@@ -250,6 +258,10 @@ export default defineComponent({
 
     watch(tableContentRef, () => {
       setTableContentRef(tableContentRef.value);
+      // auto 布局下，初始化表头列宽，避免 affix 表头列宽不对齐
+      if (props.tableLayout === 'auto') {
+        syncThWidthList();
+      }
     });
 
     // 应该有多种情况下需要更新 foot 高度

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -536,6 +536,11 @@ export default function useFixed(
       updateFixedStatus();
       updateColumnFixedShadow(tableContentRef.value, { skipScrollLimit: true });
     }
+
+    // auto 布局下，同步表头列宽，避免 affix 表头列宽不对齐
+    if (tableLayout.value === 'auto') {
+      updateThWidthList(getThWidthList('calculate'));
+    }
   };
 
   const onResize = debounce(() => {

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -442,6 +442,9 @@ export default function useFixed(
   const getThWidthList = (type?: 'default' | 'calculate') => {
     if (type === 'calculate') {
       const trList = tableContentRef.value?.querySelector('thead')?.children;
+      if (!trList) {
+        return {};
+      }
       return calculateThWidthList(trList);
     }
     return thWidthList.value || {};


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 💡 需求背景和解决方案

复现demo: https://stackblitz.com/edit/vrnfnd?file=package.json,src%2Fdemo.vue

当固定表头和 tableLayout:auto 搭配使用时，在列宽初始化和变化的场景，同步列宽到 thWidthList 中，以便 affix Header 的渲染可以获得与表格一致的列宽


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修正 tableLayout: auto 和 固定表头搭配使用的列宽不同步问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
