### PR TITLE
fix(select): fix onEnter context.value error when using keyboard to manipulate

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -421,8 +421,11 @@ export default defineComponent({
               props.onClear?.({ e });
             }}
             onEnter={(inputValue, { e }) => {
-              props.onEnter?.({ inputValue: `${innerInputValue.value}`, e, value: innerValue.value });
-              handleCreate();
+              // onEnter和handleKeyDown的Enter事件同时触发，需要通过setTimeout设置先后
+              setTimeout(() => {
+                props.onEnter?.({ inputValue: `${innerInputValue.value}`, e, value: innerValue.value });
+                handleCreate();
+              }, 0);
             }}
             onBlur={(inputValue, { e }) => {
               props.onBlur?.({ e, value: innerValue.value });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#4283

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

键盘上下键选中选项通过 onEnter 事件获取的context.value 错误，是因为当按下Enter按键时，会先触发onEnter回调函数，再触发useKeyboardControl中的handleKeyDown对应的Enter事件，导致先执行回调，再修改数据。目的就是要改成先触发Enter事件再触发onEnter回调函数，目前考虑两种方法，第一种使用setTimeout让onEnter回调函数事件缓于Enter事件，第二种是根据hoverIndex和innerPopupVisible判断当处于打开并且选中状态时按下Enter案件不触发onEnter，而是通过handleKeyDown对应的Enter事件进行触发对应的回调函数，第一种要用到setTimeout，第二种要用到nextTick，这里考虑到简单的变动选择第一种方案

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 修复键盘上下键选中选项后 onEnter 事件获取的context.value 错误的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
