### PR TITLE
fix(select): fix Option in OptionGroup must be render in v-for

### DIFF
--- a/src/select/__tests__/index.test.jsx
+++ b/src/select/__tests__/index.test.jsx
@@ -271,4 +271,44 @@ describe('Select OptionGroup', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
   });
+
+  describe(':base', () => {
+    it('v-for and option works fine', async () => {
+      const Comp = {
+        components: {
+          TSelect: Select,
+          TOptionGroup: OptionGroup,
+          TOption: Option,
+        },
+        template: `
+          <t-select>
+            <t-option-group label='test'>
+              <t-option v-for='i in ["1", "2"]' :key='i' :label='i' :value='i'></t-option>
+              <t-option key='3' label='3'></t-option>
+            </t-option-group>
+            <t-option-group label='test'>
+              <t-option v-for='i in ["4", "5", "6"]' :key='i' :label='i' :value='i'></t-option>
+            </t-option-group>
+            <t-option-group label='test'>
+              <t-option key='7' label='7'></t-option>
+              <t-option key='8' label='8'></t-option>
+              <t-option key='9' label='9'></t-option>
+            </t-option-group>
+          </t-select>
+        `,
+      };
+
+      const wrapper = mount(Comp);
+      await wrapper.setProps({ popupProps: { visible: true } });
+
+      const panelNode = document.querySelector('.t-select__list');
+      const groupNode = document.querySelectorAll('.t-select-option-group');
+      expect(groupNode.length).toBe(3);
+      groupNode.forEach((item) => {
+        const option = item.querySelectorAll('.t-select-option');
+        expect(option.length).toBe(3);
+      });
+      panelNode.parentNode.removeChild(panelNode);
+    });
+  });
 });

--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -54,9 +54,9 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
           ...group.props,
           children: [] as TdOptionProps[],
         };
-        const res = (group.children as Slots).default();
-        if (!(isArray(res) && !!res[0]?.children)) continue;
-        for (const child of res?.[0]?.children as VNode[]) {
+        const res = getChildComponentSlots('Option', group.children as Slots);
+        if (!isArray(res)) continue;
+        for (const child of res) {
           groupOption.children.push({
             ...child.props,
             slots: child.children,

--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -1,4 +1,4 @@
-import { computed, Slots, VNode, Ref, ref } from 'vue';
+import { computed, Slots, Ref, ref } from 'vue';
 import isArray from 'lodash/isArray';
 import get from 'lodash/get';
 import isFunction from 'lodash/isFunction';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- #4317

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

通过group获取option时没有使用getChildComponentSlots来进行获取，而是默认认为是一个数组，没有处理不同的情况，导致发生问题，已经修改为getChildComponentSlots

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 修复`Option`在`OptionGroup`中必须使用 `v-for` 才可以使用的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
