### PR TITLE
feat(dialog): add dialogStyle and dialogClassName API

### DIFF
--- a/src/dialog/__tests__/index.test.jsx
+++ b/src/dialog/__tests__/index.test.jsx
@@ -192,6 +192,36 @@ describe('Dialog', () => {
       await nextTick();
       expect(dialog.classes()).toContain('t-dialog--draggable');
     });
+
+    it(':dialogClassName', async () => {
+      const visible = ref(true);
+      const wrapper = mount(() => (
+        <Dialog
+          v-model:visible={visible.value}
+          dialogClassName="custom-class"
+          mode="modeless"
+          body="this is content"
+        ></Dialog>
+      ));
+      const dialog = wrapper.find('.t-dialog');
+      await nextTick();
+      expect(dialog.classes()).toContain('custom-class');
+    });
+
+    it(':dialogStyle', async () => {
+      const visible = ref(true);
+      const wrapper = mount(() => (
+        <Dialog
+          v-model:visible={visible.value}
+          dialogStyle={{ padding: '99px' }}
+          mode="modeless"
+          body="this is content"
+        ></Dialog>
+      ));
+      const dialog = wrapper.find('.t-dialog');
+      await nextTick();
+      expect(getComputedStyle(dialog.element, null).padding).toBe('99px');
+    });
   });
 
   describe(':events', () => {

--- a/src/dialog/dialog.en-US.md
+++ b/src/dialog/dialog.en-US.md
@@ -55,6 +55,8 @@ confirmBtn | String / Object / Slot / Function | - | TypeScript: `string \| Butt
 confirmLoading | Boolean | undefined | confirm button loading status | N
 confirmOnEnter | Boolean | - | confirm on enter | N
 default | String / Slot / Function | - | TypeScript: `string \| TNode`. [see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+dialogClassName | String | - | \- | N
+dialogStyle | Object | - | Styles that apply to the dialog box itself。Typescript：`Styles`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 destroyOnClose | Boolean | false | \- | N
 draggable | Boolean | false | \- | N
 footer | Boolean / Slot / Function | true | TypeScript: `boolean \| TNode`. [see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/dialog/dialog.md
+++ b/src/dialog/dialog.md
@@ -86,6 +86,8 @@ confirmBtn | String / Object / Slot / Function | - | 确认按钮。值为 null 
 confirmLoading | Boolean | undefined | 确认按钮加载状态 | N
 confirmOnEnter | Boolean | - | 是否在按下回车键时，触发确认事件 | N
 default | String / Slot / Function | - | 对话框内容，同 body。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
+dialogClassName | String | - | 弹框元素类名，示例：'t-class-dialog-first t-class-dialog-second' | N
+dialogStyle | Object | - | 作用于对话框本身的样式。TS 类型：`Styles`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 destroyOnClose | Boolean | false | 是否在关闭弹框的时候销毁子元素 | N
 draggable | Boolean | false | 对话框是否可以拖拽（仅在非模态对话框时有效） | N
 footer | Boolean / Slot / Function | true | 底部操作栏，默认会有“确认”和“取消”两个按钮。值为 true 显示默认操作按钮，值为 false 不显示任何内容，值类型为 Function 表示自定义底部内容。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -162,6 +162,7 @@ export default defineComponent({
         `${COMPONENT_NAME.value}`,
         `${COMPONENT_NAME.value}__modal-${props.theme}`,
         isModeLess.value && props.draggable && `${COMPONENT_NAME.value}--draggable`,
+        props.dialogClassName,
       ];
 
       if (isFullScreen.value) {
@@ -172,7 +173,7 @@ export default defineComponent({
       return dialogClass;
     });
     const dialogStyle = computed(() => {
-      return !isFullScreen.value ? { width: GetCSSValue(props.width) } : {}; // width全屏模式不生效
+      return !isFullScreen.value ? { width: GetCSSValue(props.width), ...props.dialogStyle } : { ...props.dialogStyle }; // width全屏模式不生效
     });
     const { isLastDialog } = usePopupManager('dialog', {
       visible: computedVisible,

--- a/src/dialog/props.ts
+++ b/src/dialog/props.ts
@@ -52,6 +52,14 @@ export default {
   },
   /** 是否在关闭弹框的时候销毁子元素 */
   destroyOnClose: Boolean,
+  dialogClassName: {
+    type: String,
+    default: '',
+  },
+  /** 作用于对话框本身的样式 */
+  dialogStyle: {
+    type: Object as PropType<TdDialogProps['dialogStyle']>,
+  },
   /** 对话框是否可以拖拽（仅在非模态对话框时有效） */
   draggable: Boolean,
   /** 底部操作栏，默认会有“确认”和“取消”两个按钮。值为 true 显示默认操作按钮，值为 false 不显示任何内容，值类型为 Function 表示自定义底部内容 */

--- a/src/dialog/type.ts
+++ b/src/dialog/type.ts
@@ -55,6 +55,15 @@ export interface TdDialogProps {
    */
   destroyOnClose?: boolean;
   /**
+   * 弹框元素类名，示例：'t-class-dialog-first t-class-dialog-second'
+   * @default ''
+   */
+  dialogClassName?: string;
+  /**
+   * 作用于对话框本身的样式
+   */
+  dialogStyle?: Styles;
+  /**
    * 对话框是否可以拖拽（仅在非模态对话框时有效）
    * @default false
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/4300
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Dialog): 新增 `dialogStyle` 和 `dialogClassName` API，作用于弹窗本身，方便对弹窗本身样式进行调整

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
