### PR TITLE
feat(Form): readonly API supports tag-input

### DIFF
--- a/src/form/form.en-US.md
+++ b/src/form/form.en-US.md
@@ -14,7 +14,7 @@ labelAlign | String | right | options: left/right/top | N
 labelWidth | String / Number | '100px' | \- | N
 layout | String | vertical | options: vertical/inline | N
 preventSubmitDefault | Boolean | true | \- | N
-readonly | Boolean | - | \- | N
+readonly | Boolean | undefined | Whether the entire form is read-only (* input, checkbox, TagInput, and InputNumber are only supported for the time being) | N
 requiredMark | Boolean | true | \- | N
 resetType | String | empty | options: empty/initial | N
 rules | Object | - | Typescript：`FormRules<FormData>` `type FormRules<T extends Data = any> = { [field in keyof T]?: Array<FormRule> }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/form/type.ts) | N

--- a/src/form/form.md
+++ b/src/form/form.md
@@ -16,7 +16,7 @@ labelAlign | String | right | 表单字段标签对齐方式：左对齐、右�
 labelWidth | String / Number | '100px' | 可以整体设置label标签宽度，默认为100px | N
 layout | String | vertical | 表单布局，有两种方式：纵向布局 和 行内布局。可选项：vertical/inline | N
 preventSubmitDefault | Boolean | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面），设置为 `true` 可以避免刷新 | N
-readonly | Boolean | undefined | 是否整个表单只读(* 暂时只支持 input、checkbox 和 input-number 使用) | N
+readonly | Boolean | undefined | 是否整个表单只读(* 暂时只支持 input、checkbox、TagInput和 InputNumber 使用) | N
 requiredMark | Boolean | true | 是否显示必填符号（*），默认显示 | N
 resetType | String | empty | 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值。可选项：empty/initial | N
 rules | Object | - | 表单字段校验规则。TS 类型：`FormRules<FormData>` `type FormRules<T extends Data = any> = { [field in keyof T]?: Array<FormRule> }`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/form/type.ts) | N

--- a/src/tag-input/props.ts
+++ b/src/tag-input/props.ts
@@ -71,7 +71,10 @@ export default {
     type: Function as PropType<TdTagInputProps['prefixIcon']>,
   },
   /** 只读状态，值为真会隐藏标签移除按钮和输入框 */
-  readonly: Boolean,
+  readonly: {
+    type: Boolean,
+    default: undefined,
+  },
   /** 组件尺寸 */
   size: {
     type: String as PropType<TdTagInputProps['size']>,

--- a/src/tag-input/tag-input.en-US.md
+++ b/src/tag-input/tag-input.en-US.md
@@ -21,7 +21,7 @@ max | Number | - | max tag number | N
 minCollapsedNum | Number | 0 | \- | N
 placeholder | String | undefined | placeholder description | N
 prefixIcon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-readonly | Boolean | false | \- | N
+readonly | Boolean | undefined | \- | N
 size | String | medium | options: small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 status | String | - | options: default/success/warning/error | N
 suffix | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/tag-input/tag-input.md
+++ b/src/tag-input/tag-input.md
@@ -21,7 +21,7 @@ max | Number | - | 最大允许输入的标签数量 | N
 minCollapsedNum | Number | 0 | 最小折叠数量，用于标签数量过多的情况下折叠选中项，超出该数值的选中项折叠。值为 0 则表示不折叠 | N
 placeholder | String | undefined | 占位符 | N
 prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
-readonly | Boolean | false | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
+readonly | Boolean | undefined | 只读状态，值为真会隐藏标签移除按钮和输入框 | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 status | String | - | 输入框状态。可选项：default/success/warning/error | N
 suffix | String / Slot / Function | - | 后置图标前的后置内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -14,6 +14,7 @@ import useDefault from '../hooks/useDefaultValue';
 import useDragSorter from './hooks/useDragSorter';
 import isArray from 'lodash/isArray';
 import { useDisabled } from '../hooks/useDisabled';
+import { useReadonly } from '../hooks/useReadonly';
 
 const useComponentClassName = () => {
   return {
@@ -33,6 +34,7 @@ export default defineComponent({
     const { CloseCircleFilledIcon } = useGlobalIcon({ CloseCircleFilledIcon: TdCloseCircleFilledIcon });
 
     const isDisabled = useDisabled();
+    const isReadonly = useReadonly();
 
     const { inputValue, inputProps } = toRefs(props);
     const [tInputValue, setTInputValue] = useDefault(
@@ -41,9 +43,9 @@ export default defineComponent({
       props.onInputChange,
       'inputValue',
     );
-    const { excessTagsDisplayType, readonly, clearable, placeholder } = toRefs(props);
+    const { excessTagsDisplayType, clearable, placeholder } = toRefs(props);
     const { isHover, addHover, cancelHover } = useHover({
-      readonly: props.readonly,
+      readonly: isReadonly.value,
       disabled: isDisabled.value,
       onMouseenter: props.onMouseenter,
       onMouseleave: props.onMouseleave,
@@ -89,7 +91,7 @@ export default defineComponent({
 
     const showClearIcon = computed(() =>
       Boolean(
-        !readonly.value &&
+        !isReadonly.value &&
           !isDisabled.value &&
           clearable.value &&
           isHover.value &&
@@ -211,6 +213,7 @@ export default defineComponent({
       onInputCompositionend,
       classes,
       isDisabled,
+      isReadonly,
     };
   },
 
@@ -236,7 +239,7 @@ export default defineComponent({
     // 左侧文本
     const label = renderTNodeJSX(this, 'label', { silent: true });
     const inputProps = this.inputProps as TdTagInputProps['inputProps'];
-    const readonly = this.readonly || inputProps?.readonly;
+    const readonly = this.isReadonly || inputProps?.readonly;
     return (
       <TInput
         ref="tagInputRef"

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -7,6 +7,7 @@ import useVModel from '../hooks/useVModel';
 import { usePrefixClass } from '../hooks/useConfig';
 import { useTNodeJSX } from '../hooks/tnode';
 import { useDisabled } from '../hooks/useDisabled';
+import { useReadonly } from '../hooks/useReadonly';
 
 export type ChangeParams = [TagInputChangeContext];
 
@@ -14,12 +15,13 @@ export type ChangeParams = [TagInputChangeContext];
 export default function useTagList(props: TagInputProps) {
   const renderTNode = useTNodeJSX();
   const classPrefix = usePrefixClass();
-  const { value, modelValue, onRemove, max, minCollapsedNum, size, readonly, tagProps, getDragProps } = toRefs(props);
+  const { value, modelValue, onRemove, max, minCollapsedNum, size, tagProps, getDragProps } = toRefs(props);
   // handle controlled property and uncontrolled property
   const [tagValue, setTagValue] = useVModel(value, modelValue, props.defaultValue || [], props.onChange);
   const oldInputValue = ref<InputValue>();
 
   const isDisabled = useDisabled();
+  const isReadonly = useReadonly();
 
   // 点击标签关闭按钮，删除标签
   const onClose = (p: { e?: MouseEvent; index: number }) => {
@@ -84,7 +86,7 @@ export default function useTagList(props: TagInputProps) {
               size={size.value}
               disabled={isDisabled.value}
               onClose={(context: { e: MouseEvent }) => onClose({ e: context.e, index })}
-              closable={!readonly.value && !isDisabled.value}
+              closable={!isReadonly.value && !isDisabled.value}
               {...getDragProps.value?.(index, item)}
               {...tagProps.value}
             >


### PR DESCRIPTION
- 修改 TagInput 组件 props 中 readonly 属性未 undefined
- 修改 useTagList.tsx 只读状态的获取方式，使用 useReadonly Hook 获取
- 修改 tag-input.tsx 只读状态的获取方式，使用 useReadonly Hook 获取

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Form): 支持通过表单的`readonly`属性影响`TagInput`组件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
