### PR TITLE
fix(pagination): fix pageSize param when page change

### DIFF
--- a/src/pagination/pagination.tsx
+++ b/src/pagination/pagination.tsx
@@ -9,7 +9,7 @@ import {
   ChevronRightDoubleIcon as TdChevronRightDoubleIcon,
   EllipsisIcon as TdEllipsisIcon,
 } from 'tdesign-icons-vue-next';
-import { TdPaginationProps } from '../pagination/type';
+import { PageInfo, TdPaginationProps } from '../pagination/type';
 import { useConfig, usePrefixClass } from '../hooks/useConfig';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
 import TInputNumber from '../input-number';
@@ -147,7 +147,7 @@ export default defineComponent({
       (val) => (jumpIndex.value = val),
     );
 
-    const toPage: (pageIndex: number, isTriggerChange?: boolean) => void = (pageIndex, isTriggerChange) => {
+    const toPage: (pageIndex: number, pageInfo?: PageInfo) => void = (pageIndex, pageInfo) => {
       if (props.disabled) {
         return;
       }
@@ -159,13 +159,12 @@ export default defineComponent({
       }
       if (innerCurrent.value !== current) {
         const prev = innerCurrent.value;
-        const pageInfo = {
+        pageInfo = pageInfo || {
           current,
           previous: prev,
           pageSize: innerPageSize.value,
         };
-
-        if (isTriggerChange !== false) {
+        if (pageInfo) {
           setInnerCurrent(current, pageInfo);
           props.onChange?.(pageInfo);
         } else {
@@ -214,7 +213,7 @@ export default defineComponent({
       };
       setInnerPageSize(pageSize, pageInfo);
       if (isIndexChange) {
-        toPage(pageCount, true);
+        toPage(pageCount, pageInfo);
       } else {
         props.onChange?.(pageInfo);
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- #4430

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

表格改变每页行数时，@page-change事件参数不正确是因为在pageSize发生改变且会改变目前current值时，触发的handlePageChange会先执行setInnerPageSize，如果没有对onPageSize进行处理，会无法更新pageSize的值，而后触发的toPage函数获取pageInfo时，会尝试从props中进行获取，这就会导致获取不到最新的pageSize，从而引发bug

这里发现原来的isTriggerChange仅在上述情况下会使用，所以将其改为了pageInfo用于直接传入数据，避免了从props中无法出现最新值的问题


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Pagination): 修复`pagination`在`pageSize`改变时`onChange`无法获取最新pageSize的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
