### PR TITLE
feat(form): support form id and button form API

### DIFF
--- a/src/button/button.en-US.md
+++ b/src/button/button.en-US.md
@@ -10,6 +10,7 @@ block | Boolean | false | make button to be a block-level element | N
 content | String / Slot / Function | - | button's children elements。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 default | String / Slot / Function | - | default slot。Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 disabled | Boolean | undefined | disable the button, make it can not be clicked | N
+form | String | undefined | native `form` attribute，which supports triggering events for a form with a specified id through the use of the form attribute. | N
 ghost | Boolean | false | make background-color to be transparent | N
 href | String | - | \- | N
 icon | Slot / Function | - | use it to set left icon in button。Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/button/button.md
+++ b/src/button/button.md
@@ -10,6 +10,7 @@ block | Boolean | false | 是否为块级元素 | N
 content | String / Slot / Function | - | 按钮内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 default | String / Slot / Function | - | 按钮内容。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 disabled | Boolean | undefined | 禁用状态。优先级：Button.disabled > Form.disabled | N
+form | String | undefined | 原生的form属性，支持用于通过form属性对于id的form的表单事件 | N
 ghost | Boolean | false | 是否为幽灵按钮（镂空按钮） | N
 href | String | - | 跳转地址。href 存在时，按钮标签默认使用 `<a>` 渲染；如果指定了 `tag` 则使用指定的标签渲染 | N
 icon | Slot / Function | - | 按钮内部图标，可完全自定义。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N

--- a/src/button/props.ts
+++ b/src/button/props.ts
@@ -23,6 +23,11 @@ export default {
     type: Boolean,
     default: undefined,
   },
+  /** 原生的form属性，支持用于通过form属性对于id的form的表单事件 */
+  form: {
+    type: String,
+    default: undefined,
+  },
   /** 是否为幽灵按钮（镂空按钮） */
   ghost: Boolean,
   /** 跳转地址。href 存在时，按钮标签默认使用 `<a>` 渲染；如果指定了 `tag` 则使用指定的标签渲染 */

--- a/src/button/type.ts
+++ b/src/button/type.ts
@@ -26,6 +26,10 @@ export interface TdButtonProps {
    */
   disabled?: boolean;
   /**
+   * 原生的form属性，支持用于通过form属性对于id的form的表单事件
+   */
+  form?: string;
+  /**
    * 是否为幽灵按钮（镂空按钮）
    * @default false
    */
@@ -44,10 +48,10 @@ export interface TdButtonProps {
    * @default false
    */
   loading?: boolean;
-   /**
+  /**
    * 透传加载组件全部属性
    */
-   loadingProps?: Partial<LoadingProps>;
+  loadingProps?: Partial<LoadingProps>;
   /**
    * 按钮形状，有 4 种：长方形、正方形、圆角长方形、圆形
    * @default rectangle

--- a/src/form/form.en-US.md
+++ b/src/form/form.en-US.md
@@ -11,6 +11,7 @@ data | Object | {} | Typescript：`FormData` | N
 disabled | Boolean | undefined | \- | N
 errorMessage | Object | - | Typescript：`FormErrorMessage` | N
 formControlledComponents | Array | - | Typescript：`Array<string>` | N
+id | String | undefined | native id attribute of the form，which supports being used in conjunction with non-form buttons through the form attribute to trigger form events | N
 labelAlign | String | right | options: left/right/top | N
 labelWidth | String / Number | '100px' | \- | N
 layout | String | vertical | options: vertical/inline | N

--- a/src/form/form.md
+++ b/src/form/form.md
@@ -13,6 +13,7 @@ data | Object | {} | 表单数据。TS 类型：`FormData` | N
 disabled | Boolean | undefined | 是否禁用整个表单 | N
 errorMessage | Object | - | 表单错误信息配置，示例：`{ idcard: '请输入正确的身份证号码', max: '字符长度不能超过 ${max}' }`。TS 类型：`FormErrorMessage` | N
 formControlledComponents | Array | - | 允许表单统一控制禁用状态的自定义组件名称列表。默认会有组件库的全部输入类组件：TInput、TInputNumber、TCascader、TSelect、TOption、TSwitch、TCheckbox、TCheckboxGroup、TRadio、TRadioGroup、TTreeSelect、TDatePicker、TTimePicker、TUpload、TTransfer、TSlider。对于自定义组件，组件内部需要包含可以控制表单禁用状态的变量 `formDisabled`。示例：`['CustomUpload', 'CustomInput']`。TS 类型：`Array<string>` | N
+id | String | undefined | 表单原生的id属性，支持用于配合非表单内的按钮通过form属性来触发表单事件 | N
 labelAlign | String | right | 表单字段标签对齐方式：左对齐、右对齐、顶部对齐。可选项：left/right/top | N
 labelWidth | String / Number | '100px' | 可以整体设置label标签宽度，默认为100px | N
 layout | String | vertical | 表单布局，有两种方式：纵向布局 和 行内布局。可选项：vertical/inline | N

--- a/src/form/props.ts
+++ b/src/form/props.ts
@@ -28,6 +28,11 @@ export default {
   formControlledComponents: {
     type: Array as PropType<TdFormProps['formControlledComponents']>,
   },
+  /** 表单原生的id属性，支持用于配合非表单内的按钮通过form属性来触发表单事件 */
+  id: {
+    type: String,
+    default: undefined,
+  },
   /** 表单字段标签对齐方式：左对齐、右对齐、顶部对齐 */
   labelAlign: {
     type: String as PropType<TdFormProps['labelAlign']>,

--- a/src/form/type.ts
+++ b/src/form/type.ts
@@ -32,6 +32,10 @@ export interface TdFormProps<FormData extends Data = Data> {
    */
   formControlledComponents?: Array<string>;
   /**
+   * 表单原生的id属性，支持用于配合非表单内的按钮通过form属性来触发表单事件
+   */
+  id?: string;
+  /**
    * 表单字段标签对齐方式：左对齐、右对齐、顶部对齐
    * @default right
    */

--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -149,7 +149,7 @@ export default defineComponent({
       onRuleChange,
       clearValidateData,
       onUpdateEditedCell,
-      getEditRowData,
+      // getEditRowData,
       onPrimaryTableCellEditChange,
     } = useEditableRow(props);
 
@@ -209,6 +209,7 @@ export default defineComponent({
       baseTableRef: primaryTableRef,
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const onEditableCellChange: EditableCellProps['onChange'] = (params) => {
       props.onRowEdit?.(params);
       const rowValue = get(params.editedRow, props.rowKey || 'id');
@@ -273,12 +274,11 @@ export default defineComponent({
           item.cell = (h, p: PrimaryTableCellParams<TableRowData>) => {
             const cellProps: EditableCellProps = {
               ...p,
-              row: getEditRowData(p),
               oldCell,
               rowKey: props.rowKey || 'id',
               tableBaseClass,
               cellEmptyContent: props.cellEmptyContent,
-              onChange: onEditableCellChange,
+              onChange: props.onRowEdit,
               onValidate: props.onRowValidate,
               onRuleChange,
               onEditableChange: onPrimaryTableCellEditChange,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/4448
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Form): 新增`id` API，表单原生的 id 属性，支持用于配合非表单内的按钮通过 form 属性来触发表单事件
- feat(Button): 新增`form` API，原生的 form 属性，支持用于通过 form 属性触发对应 id 的 form 的表单事件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
