### PR TITLE
fix(config-provider): computed globalConfig reactivity

### DIFF
--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -69,7 +69,7 @@ export function useConfig<T extends keyof GlobalConfigProvider>(
 export const provideConfig = (props: ConfigProviderProps) => {
   const defaultData = cloneDeep(defaultGlobalConfig);
   const mergedGlobalConfig = computed(() =>
-    mergeWith(defaultData as unknown as GlobalConfigProvider, props.globalConfig),
+    Object.assign({}, mergeWith(defaultData as unknown as GlobalConfigProvider, props.globalConfig)),
   );
 
   provide(configProviderInjectKey, mergedGlobalConfig);


### PR DESCRIPTION
```html
<script>
const globalConfig = computed(() => {
    return locale.value === "zh-CN" ? zhCN : enUS
})
</script>
<template>
  <TConfigProvider :globalConfig="globalConfig">
      <TAlert :max-line="2">
          <-- ... !-->
      </TAlert>
  </TConfigProvider>
</template>
```
devtools查看 config-provider 中的globalConfig是具备响应式的
本地组件手动inject也是可以的，但是 TAlert 中的不会变
最终定位是computed返回的对象保持了引用：
https://github.com/Tencent/tdesign-vue-next/blob/ada18a13fcf3af25bfd1683d30457a334e2bf014/src/config-provider/useConfig.tsx#L70-L75

参考[useConfig](https://github.com/Tencent/tdesign-vue-next/blob/ada18a13fcf3af25bfd1683d30457a334e2bf014/src/config-provider/useConfig.tsx#L28) 本地node_modules手动修改测试可行：
```diff
-mergeWith(defaultData as unknown as GlobalConfigProvider, props.globalConfig),
+Object.assign({}, mergeWith(defaultData as unknown as GlobalConfigProvider, props.globalConfig)),
```



### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/4611
https://github.com/Tencent/tdesign-vue-next/issues/3854

### 📝 更新日志

- fix(ConfigProvider): 修复全局配置丢失响应式问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档无须补充
- [x] 代码演示无须提供
- [x] TypeScript 定义无须补充
- [x] Changelog 已提供或无须提供
