### PR TITLE
fix(table): resolve colspan handling for multi-header

### DIFF
--- a/src/table/_example/multi-header.vue
+++ b/src/table/_example/multi-header.vue
@@ -180,6 +180,7 @@ function getColumns(fixedLeftCol, fixedRightCol) {
               title: '审批单号',
               fixed: fixedRightCol ? 'right' : undefined,
               width: 120,
+              // colspan: 2,
             },
             {
               colKey: 'detail.email',

--- a/src/table/_example/multi-header.vue
+++ b/src/table/_example/multi-header.vue
@@ -180,7 +180,6 @@ function getColumns(fixedLeftCol, fixedRightCol) {
               title: '审批单号',
               fixed: fixedRightCol ? 'right' : undefined,
               width: 120,
-              // colspan: 2,
             },
             {
               colKey: 'detail.email',

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -77,17 +77,27 @@ export default defineComponent({
     // 单行表格合并
     const colspanSkipMap = computed(() => {
       const map: { [key: string]: boolean } = {};
-      const list = props.thList[0];
-      for (let i = 0, len = list.length; i < len; i++) {
-        const item = list[i];
-        if (item.colspan > 1) {
-          for (let j = i + 1; j < i + item.colspan; j++) {
-            if (list[j]) {
-              map[list[j].colKey] = true;
+
+      const processColumns = (columns: BaseTableColumns) => {
+        columns.forEach((item, i) => {
+          if (item.colspan > 1) {
+            for (let j = 1; j < item.colspan; j++) {
+              const nextIndex = i + j;
+              if (columns[nextIndex]) {
+                map[columns[nextIndex].colKey] = true;
+              }
             }
           }
-        }
-      }
+          // 如果有子列，递归处理
+          if (item.children) {
+            processColumns(item.children);
+          }
+        });
+      };
+
+      const list = props.thList[0];
+      processColumns(list);
+
       return map;
     });
 

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -79,12 +79,12 @@ export default defineComponent({
       const map: { [key: string]: boolean } = {};
 
       const processColumns = (columns: BaseTableColumns) => {
-        columns.forEach((item, i) => {
+        for (let i = 0, len = columns.length; i < len; i++) {
+          const item = columns[i];
           if (item.colspan > 1) {
-            for (let j = 1; j < item.colspan; j++) {
-              const nextIndex = i + j;
-              if (columns[nextIndex]) {
-                map[columns[nextIndex].colKey] = true;
+            for (let j = i + 1; j < i + item.colspan; j++) {
+              if (columns[j]) {
+                map[columns[j].colKey] = true;
               }
             }
           }
@@ -92,7 +92,7 @@ export default defineComponent({
           if (item.children) {
             processColumns(item.children);
           }
-        });
+        }
       };
 
       const list = props.thList[0];


### PR DESCRIPTION
Added support for multi-header to ensure correct colspan calculation for child columns.

closed #4667

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#4667](https://github.com/Tencent/tdesign-vue-next/issues/4667) 

### 💡 需求背景和解决方案

1. 多级表头下的表头通过colspan进行合并
2. 在`thead.tsx`下的`colspanSkipMap`函数下，增加`children`的处理逻辑


### 📝 更新日志


- fix(table): 多级表头下的通过colspan合并表头

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
