### PR TITLE
fix: 🐛 修复元素可能为空引起的报错

### DIFF
--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -76,7 +76,7 @@ export default function useAffix(props: TdBaseTableProps) {
   };
 
   const updateAffixHeaderOrFooter = () => {
-    if (!isAffixed.value && !isVirtualScroll.value) return;
+    if (!isAffixed.value && !isVirtualScroll.value && !tableContentRef.value) return;
     const pos = tableContentRef.value?.getBoundingClientRect();
     const headerRect = tableContentRef.value?.querySelector('thead')?.getBoundingClientRect();
     const headerHeight = headerRect?.height || 0;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/4385
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
当表格dom元素未初始化时，会导致pos获取为空，后续逻辑报错，增加判断从而减少错误发生
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->


- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
