### PR TITLE
fix(input): autoWidth observe preInput dom instead of input dom

### DIFF
--- a/src/input/useInputWidth.ts
+++ b/src/input/useInputWidth.ts
@@ -19,7 +19,7 @@ export default function useInputWidth(
     inputRef.value.style.width = `${width || 0}px`;
   };
 
-  useResizeObserver(inputRef, () => {
+  useResizeObserver(inputPreRef, () => {
     if (autoWidth.value) {
       observerTimer.value = setTimeout(() => {
         updateInputWidth();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
无

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

选择器自动宽度偶尔会失效，排查逻辑后发现此处不合理的地方，理论上应该用preInput的resize去更新input，否则若input不发生resize，将无法根据pre更新宽度，易出现于dom挂载后绑定到ref的时机不可知，修正该逻辑，不确定是否为问题成因，未能稳定复现该场景

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
