### PR TITLE
fix(tag-input): prevent backspace event in readonly mode

### DIFF
--- a/src/tag-input/__tests__/index.test.jsx
+++ b/src/tag-input/__tests__/index.test.jsx
@@ -90,12 +90,28 @@ describe('TagInput', () => {
       expect(input.element.getAttribute('placeholder')).toBe('请输入');
     });
 
-    it(':readonly', () => {
+    it(':readonly', async () => {
       const value = ref('123');
+      const tags = ref(['Vue', 'React', 'Vue', 'React', 'Vue', 'React', 'Vue', 'React']);
+
       const wrapper = mount(() => <TagInput readonly inputValue={value.value} />);
       const input = wrapper.find('.t-input__inner');
       value.value = '123123';
       expect(input.element.value).toBe('123');
+
+      // readonly = false and able backspace
+      const onRemoveFnOn = vi.fn();
+      const wrapper1 = mount(() => <TagInput v-model={tags.value} onRemove={onRemoveFnOn} />);
+      wrapper1.find('input').trigger('keydown.backspace');
+      await wrapper1.vm.$nextTick();
+      expect(onRemoveFnOn).toHaveBeenCalled();
+
+      // readonly = true and prevent backspace
+      const onRemoveFnUn = vi.fn();
+      const wrapper2 = mount(() => <TagInput readonly v-model={tags.value} />);
+      wrapper2.find('input').trigger('keydown.backspace');
+      await wrapper2.vm.$nextTick();
+      expect(onRemoveFnUn).not.toHaveBeenCalled();
     });
 
     it(':size', () => {

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -60,7 +60,7 @@ export default function useTagList(props: TagInputProps) {
   // 按下回退键，删除标签
   const onInputBackspaceKeyDown = (value: InputValue, context: { e: KeyboardEvent }) => {
     const { e } = context;
-    if (!tagValue.value || !tagValue.value.length || e.key === 'Process') return;
+    if (!tagValue.value || !tagValue.value.length || e.key === 'Process' || isReadonly.value) return;
     // 回车键删除，输入框值为空时，才允许 Backspace 删除标签
     const isDelete = /(Backspace|NumpadDelete)/i.test(e.code) || /(Backspace|NumpadDelete)/i.test(e.key);
     if (!value && isDelete) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tag-input):修复在`readonly`模式下仍可以通过Backspace按键删除已选项的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
