### PR TITLE
fix(Input): 优化 scale 下的自动宽度错位的问题

### DIFF
--- a/src/input/useInputWidth.ts
+++ b/src/input/useInputWidth.ts
@@ -15,7 +15,8 @@ export default function useInputWidth(
 
   const updateInputWidth = () => {
     if (!inputPreRef.value || !inputRef.value) return;
-    const { width } = inputPreRef.value.getBoundingClientRect();
+    // 使用 offsetWidth，会丢失精度，但是在配合 transform 的场景下，不会受到 scale 影响从而设置到错误的宽度
+    const width = inputPreRef.value.offsetWidth;
     inputRef.value.style.width = `${width || 0}px`;
   };
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 💡 需求背景和解决方案
getBoundingClientRect 会受到 scale 影响，在 dialog 等有时长的过渡动画下，获取到错误的宽度，引起自动宽度的错位

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 优化 scale 下的自动宽度错位的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
