### PR TITLE
fix(menu): do not eagerly access `$router` in rendering

### DIFF
--- a/src/menu/menu-item.tsx
+++ b/src/menu/menu-item.tsx
@@ -71,14 +71,12 @@ export default defineComponent({
     },
   },
   render() {
-    const router = this.router || this.$router;
-
     const liContent = (
       <li ref="itemRef" class={this.classes} onClick={this.handleClick}>
         {renderTNodeJSX(this, 'icon')}
         {this.routerLink ? (
           <a
-            href={this.href ? this.href : this.to ? router?.resolve(this.to).href : ''}
+            href={this.href ? this.href : this.to ? (this.router || this.$router)?.resolve(this.to).href : ''}
             target={this.target}
             class={`${this.classPrefix}-menu__item-link`}
             onClick={(e) => e.preventDefault()}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

(https://github.com/Tencent/tdesign-vue-next/issues/4718)

### 💡 需求背景和解决方案

感觉有点脏，如果可以的话最好有个统一的抽象惰性的方式。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): suppress warning if the project does not contain `vue-router`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
