### PR TITLE
fix(color-picker): recentColors delete（同步至vue3仓库）

### DIFF
--- a/src/color-picker/panel/index.tsx
+++ b/src/color-picker/panel/index.tsx
@@ -277,7 +277,6 @@ export default defineComponent({
       baseClassName,
       statusClassNames,
       globalConfig,
-      recentColors,
       swatchColors,
       showPrimaryColorPreview,
       isGradient,
@@ -286,7 +285,7 @@ export default defineComponent({
       color: this.color,
       disabled: this.disabled,
     };
-    const showUsedColors = recentColors !== null && recentColors !== false;
+    const showUsedColors = this.recentlyUsedColors !== null && this.recentlyUsedColors !== false;
 
     let systemColors = swatchColors;
     if (systemColors === undefined) {

--- a/src/color-picker/panel/swatches.tsx
+++ b/src/color-picker/panel/swatches.tsx
@@ -60,13 +60,10 @@ export default defineComponent({
      * 移除颜色
      */
     const handleRemoveColor = () => {
-      const colors = [...props.colors];
+      const { colors } = props;
       const selectedIndex = selectedColorIndex.value;
-      if (selectedIndex > -1) {
-        colors.splice(selectedIndex, 1);
-      } else {
-        colors.length = 0;
-      }
+      if (selectedIndex === -1) return;
+      colors.splice(selectedIndex, 1);
       props.onChange(colors);
       setVisiblePopConfirm(false);
     };


### PR DESCRIPTION
vue2已merge，同步代码至vue3仓库

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#3383](https://github.com/Tencent/tdesign-vue/issues/3383)

[上一个PR](https://github.com/Tencent/tdesign-vue/pull/3384)

### 💡 需求背景和解决方案

最近颜色的删除功能：删除后需要重新选择一个最近颜色才能继续删除

### 📝 更新日志

- fix(color-picker): 最近使用颜色需要选中才能删除

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
