### PR TITLE
fix: 🐛 修复 tab 指示器受到 scale 影响的尺寸计算错误的问题

### DIFF
--- a/src/tabs/tab-nav-bar.tsx
+++ b/src/tabs/tab-nav-bar.tsx
@@ -31,12 +31,18 @@ export default defineComponent({
         if (props.navs[i].props.value === props.value) {
           break;
         }
-        offset += props.navs[i]?.el?.getBoundingClientRect()?.[sizePropName] || 0;
+        if (props.navs[i]?.el) {
+          const sizeWithUnit = getComputedStyle(props.navs[i].el as Element)[sizePropName as 'width' | 'left'];
+          const size = parseFloat(sizeWithUnit);
+          offset += size;
+        }
       }
       if (!props.navs[i]) return {};
       return {
         [offsetPropName]: `${offset}px`,
-        [sizePropName]: `${props.navs[i].el?.getBoundingClientRect()?.[sizePropName] || 0}px`,
+        [sizePropName]: props.navs[i].el
+          ? getComputedStyle(props.navs[i].el as Element)[sizePropName as 'width' | 'left']
+          : '0px',
       };
     };
     const update = () => (navBarStyle.value = getStyle());


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/4309

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
getBoundingClientRect 会受到 scale 影响，dialog 场景下定位会有问题，切换使用的api

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tabs): 优化 `scale` 下的指示器宽度错位的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
