### PR TITLE
fix(DatePicker): fix preset invalid when needConfirm is false

### DIFF
--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, watch, ref } from 'vue';
+import { defineComponent, computed, watch } from 'vue';
 import dayjs from 'dayjs';
 import isFunction from 'lodash/isFunction';
 
@@ -60,17 +60,8 @@ export default defineComponent({
       };
     });
 
-    const popupCloseByPreset = ref(false);
     watch(popupVisible, (visible) => {
       // 如果不需要确认，直接保存当前值
-      // 存在一种可能性，点击 preset 时，不会更新 input
-      if ((popupCloseByPreset.value = true)) {
-        inputValue.value = formatDate(value.value, {
-          format: formatRef.value.format,
-        });
-        popupCloseByPreset.value = false;
-        return;
-      }
       if (!props.needConfirm && props.enableTimePicker && !visible) {
         const nextValue = formatDate(inputValue.value, {
           format: formatRef.value.format,
@@ -250,7 +241,10 @@ export default defineComponent({
           trigger: 'preset',
         },
       );
-
+      // 更新到 input，避免 needConfirm 导致值被覆盖
+      inputValue.value = formatDate(presetVal, {
+        format: formatRef.value.format,
+      });
       popupVisible.value = false;
     }
 

--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, watch } from 'vue';
+import { defineComponent, computed, watch, ref } from 'vue';
 import dayjs from 'dayjs';
 import isFunction from 'lodash/isFunction';
 
@@ -60,8 +60,17 @@ export default defineComponent({
       };
     });
 
+    const popupCloseByPreset = ref(false);
     watch(popupVisible, (visible) => {
       // 如果不需要确认，直接保存当前值
+      // 存在一种可能性，点击 preset 时，不会更新 input
+      if ((popupCloseByPreset.value = true)) {
+        inputValue.value = formatDate(value.value, {
+          format: formatRef.value.format,
+        });
+        popupCloseByPreset.value = false;
+        return;
+      }
       if (!props.needConfirm && props.enableTimePicker && !visible) {
         const nextValue = formatDate(inputValue.value, {
           format: formatRef.value.format,
@@ -149,6 +158,7 @@ export default defineComponent({
             trigger: 'pick',
           },
         );
+        popupCloseByPreset.value = true;
         popupVisible.value = false;
       }
 

--- a/src/date-picker/DatePicker.tsx
+++ b/src/date-picker/DatePicker.tsx
@@ -149,7 +149,6 @@ export default defineComponent({
             trigger: 'pick',
           },
         );
-        popupCloseByPreset.value = true;
         popupVisible.value = false;
       }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/4767
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
原逻辑浮窗关闭时，needConfirm 为 false时，会读入 input 结果并将其设置到 value，preset 选择后只更改了 value，未对 input 进行修改，导致关闭时被旧的 input 值覆盖。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(DatePicker): 修正 `needConfirm` 为 `false` 的场景下，`preset` 选择失效的问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
