### PR TITLE
fix(input): fix the display issue of Input in Form readonly state

### DIFF
--- a/src/input/useInput.ts
+++ b/src/input/useInput.ts
@@ -4,6 +4,7 @@ import { FormItemInjectionKey } from '../form/const';
 import useVModel from '../hooks/useVModel';
 import { useDisabled } from '../hooks/useDisabled';
 import useLengthLimit from './useLengthLimit';
+import { useReadonly } from '../hooks/useReadonly';
 
 export function getOutputValue(val: InputValue, type: TdInputProps['type']) {
   if (type === 'number') {
@@ -25,6 +26,7 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
   const clearIconRef = ref(null);
   const innerClickElement = ref();
   const disabled = useDisabled();
+  const readonly = useReadonly();
   const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
 
   const isHover = ref(false);
@@ -44,7 +46,7 @@ export default function useInput(props: ExtendsTdInputProps, expose: (exposed: R
 
   const showClear = computed(() => {
     return (
-      ((innerValue.value && !disabled.value && props.clearable && !props.readonly) || props.showClearIconOnEmpty) &&
+      ((innerValue.value && !disabled.value && props.clearable && !readonly.value) || props.showClearIconOnEmpty) &&
       isHover.value
     );
   });


### PR DESCRIPTION
- Introduce `useReadonly` hook
- Use `readonly` instead of `props.readonly`
- Optimize the clear icon display logic to account for Form readonly state

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复在 `Form` 设置全局只读下 `Input` 组件的状态异常问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
