### PR TITLE
fix(dialog): beforeOpen double trigger

### DIFF
--- a/src/dialog/_usage/index.vue
+++ b/src/dialog/_usage/index.vue
@@ -4,7 +4,14 @@
     <template #dialog="{ configProps }"
       ><div>
         <t-button @click="visible = true">Open Modal</t-button>
-        <t-dialog v-bind="configProps" v-model:visible="visible">
+        <t-dialog
+          v-bind="configProps"
+          v-model:visible="visible"
+          @opened="opened"
+          @closed="closed"
+          @before-open="BeforeOpen"
+          @before-close="BeforeClose"
+        >
           <p>This is a dialog</p>
         </t-dialog>
       </div></template
@@ -24,9 +31,25 @@ const handleClick = () => {
 const configList = ref(configJson);
 const panelList = [{ label: 'dialog', value: 'dialog' }];
 
+const BeforeOpen = () => {
+  console.log('before open');
+};
+
+const BeforeClose = () => {
+  console.log('before close');
+};
+
+const opened = () => {
+  console.log('opened');
+};
+
+const closed = () => {
+  console.log('closed');
+};
+
 const usageCodeMap = {
   dialog:
-    '\n        <div>\n          <t-button @click="visible = true">Open Modal</t-button>\n          <t-dialog v-bind="configProps" v-model:visible="visible">\n            <p>This is a dialog</p>\n          </t-dialog>\n        </div>\n      ',
+    '\n        <div>\n          <t-button @click="visible = true">Open Modal</t-button>\n          <t-dialog v-bind="configProps" v-model:visible="visible" @opened="opened" @closed="closed" @before-open="BeforeOpen" @before-close="BeforeClose">\n            <p>This is a dialog</p>\n          </t-dialog>\n        </div>\n      ',
 };
 const usageCode = ref(`<template>${usageCodeMap[panelList[0].value].trim()}</template>`);
 

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -260,9 +260,9 @@ export default defineComponent({
     };
 
     // 打开弹窗动画开始时事件
-    const beforeEnter = debounce(() => {
+    const beforeEnter = () => {
       props.onBeforeOpen?.();
-    });
+    };
 
     // 打开弹窗动画结束时事件
     const afterEnter = () => {

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -18,6 +18,7 @@ import { getScrollbarWidth } from '../_common/js/utils/getScrollbarWidth';
 import type { TdDialogProps } from './type';
 import useTeleport from '../hooks/useTeleport';
 import usePopupManager from '../hooks/usePopupManager';
+import debounce from 'lodash/debounce';
 
 function GetCSSValue(v: string | number) {
   return Number.isNaN(Number(v)) ? v : `${Number(v)}px`;
@@ -259,9 +260,9 @@ export default defineComponent({
     };
 
     // 打开弹窗动画开始时事件
-    const beforeEnter = () => {
+    const beforeEnter = debounce(() => {
       props.onBeforeOpen?.();
-    };
+    });
 
     // 打开弹窗动画结束时事件
     const afterEnter = () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/4835

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dialog): 修复`Dialog`在开启`destroyOnClose`后`onBeforeOpen`会触发两次的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
