### PR TITLE
fix(Dialog): don't render header dom when header and closeBtn are false

### DIFF
--- a/src/dialog/__tests__/index.test.jsx
+++ b/src/dialog/__tests__/index.test.jsx
@@ -81,6 +81,16 @@ describe('Dialog', () => {
       expect(header.text()).toBe('this is header');
     });
 
+    it(':header:false', async () => {
+      const visible = ref(true);
+      const wrapper = mount(() => (
+        <Dialog v-model:visible={visible.value} header={false} closeBtn={false} body="this is content"></Dialog>
+      ));
+      const header = wrapper.find('.t-dialog__header');
+      await nextTick();
+      expect(header.exists()).toBeFalsy();
+    });
+
     it(':placement', async () => {
       const placementList = ['top', 'center'];
       const visible = ref(true);

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -377,7 +377,7 @@ export default defineComponent({
               v-draggable={isModeLess.value && props.draggable}
               ref={dialogEle}
             >
-              {(headerContent || props.closeBtn) && (
+              {(headerContent || headerContent === 0 || props.closeBtn) && (
                 <div class={headerClassName} onMousedown={onStopDown}>
                   <div class={`${COMPONENT_NAME.value}__header-content`}>
                     {getIcon()}

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -330,6 +330,11 @@ export default defineComponent({
           })}
         </div>
       );
+
+      const headerContent = renderTNodeJSX('header', defaultHeader);
+
+      const footerContent = renderTNodeJSX('footer', defaultFooter);
+
       const headerClassName = isFullScreen.value
         ? [`${COMPONENT_NAME.value}__header`, `${COMPONENT_NAME.value}__header--fullscreen`]
         : `${COMPONENT_NAME.value}__header`;
@@ -340,8 +345,6 @@ export default defineComponent({
 
       const bodyClassName =
         props.theme === 'default' ? [`${COMPONENT_NAME.value}__body`] : [`${COMPONENT_NAME.value}__body__icon`];
-
-      const footerContent = renderTNodeJSX('footer', defaultFooter);
 
       if (isFullScreen.value && footerContent) {
         bodyClassName.push(`${COMPONENT_NAME.value}__body--fullscreen`);
@@ -374,18 +377,20 @@ export default defineComponent({
               v-draggable={isModeLess.value && props.draggable}
               ref={dialogEle}
             >
-              <div class={headerClassName} onMousedown={onStopDown}>
-                <div class={`${COMPONENT_NAME.value}__header-content`}>
-                  {getIcon()}
-                  {renderTNodeJSX('header', defaultHeader)}
-                </div>
+              {(headerContent || props.closeBtn) && (
+                <div class={headerClassName} onMousedown={onStopDown}>
+                  <div class={`${COMPONENT_NAME.value}__header-content`}>
+                    {getIcon()}
+                    {headerContent}
+                  </div>
 
-                {props.closeBtn ? (
-                  <span class={closeClassName} onClick={closeBtnAction}>
-                    {renderTNodeJSX('closeBtn', defaultCloseBtn)}
-                  </span>
-                ) : null}
-              </div>
+                  {props.closeBtn ? (
+                    <span class={closeClassName} onClick={closeBtnAction}>
+                      {renderTNodeJSX('closeBtn', defaultCloseBtn)}
+                    </span>
+                  ) : null}
+                </div>
+              )}
               <div class={bodyClassName} onMousedown={onStopDown}>
                 {body}
               </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- #4832 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 当 `header` 和 `closeBtn` 都为 `false` 时，不渲染 `header dom`

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
