### PR TITLE
feat: support global attach config

### DIFF
--- a/src/config-provider/config-provider.en-US.md
+++ b/src/config-provider/config-provider.en-US.md
@@ -62,6 +62,7 @@ name | type | default | description | required
 alert | Object | - | Alert global configs。Typescript：`AlertConfig` | N
 anchor | Object | - | Anchor global configs。Typescript：`AnchorConfig` | N
 animation | Object | - | Typescript：`Partial<Record<'include'\|'exclude', Array<AnimationType>>>` `type AnimationType = 'ripple' \| 'expand' \| 'fade'`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+attach | String / Object / Function | - | Typescript：`AttachNode \| { imageViewer?: AttachNode; popup?: AttachNode; dialog?: AttachNode; drawer?: AttachNode; }`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 calendar | Object | - | Calendar global configs。Typescript：`CalendarConfig` | N
 cascader | Object | - | Cascader global configs。Typescript：`CascaderConfig` | N
 classPrefix | String | t | \- | N

--- a/src/config-provider/config-provider.md
+++ b/src/config-provider/config-provider.md
@@ -63,6 +63,7 @@ Vue.createApp({}).use(TDesign)
 alert | Object | - | 警告全局配置。TS 类型：`AlertConfig` | N
 anchor | Object | - | 锚点全局配置。TS 类型：`AnchorConfig` | N
 animation | Object | - | 动画效果控制，`ripple` 指波纹动画， `expand` 指展开动画，`fade` 指渐变动画。默认为 `{ include: ['ripple','expand','fade'], exclude: [] }`。TS 类型：`Partial<Record<'include'\|'exclude', Array<AnimationType>>>` `type AnimationType = 'ripple' \| 'expand' \| 'fade'`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/tree/develop/src/config-provider/type.ts) | N
+attach | String / Object / Function | - | TS 类型：`AttachNode \| { imageViewer?: AttachNode; popup?: AttachNode; dialog?: AttachNode; drawer?: AttachNode; }`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/src/common.ts) | N
 calendar | Object | - | 日历组件全局配置。TS 类型：`CalendarConfig` | N
 cascader | Object | - | 级联选择器全局配置。TS 类型：`CascaderConfig` | N
 classPrefix | String | t | CSS 类名前缀 | N

--- a/src/config-provider/type.ts
+++ b/src/config-provider/type.ts
@@ -10,7 +10,7 @@ import { ButtonProps } from '../button';
 import { FormErrorMessage } from '../form';
 import { MessageOptions } from '../message';
 import { ImageProps } from '../image';
-import { TNode, SizeEnum } from '../common';
+import { TNode, SizeEnum, AttachNode } from '../common';
 
 export interface GlobalConfigProvider {
   /**
@@ -25,6 +25,10 @@ export interface GlobalConfigProvider {
    * 动画效果控制，`ripple` 指波纹动画， `expand` 指展开动画，`fade` 指渐变动画。默认为 `{ include: ['ripple','expand','fade'], exclude: [] }`
    */
   animation?: Partial<Record<'include' | 'exclude', Array<AnimationType>>>;
+  /**
+   * null
+   */
+  attach?: AttachNode | { imageViewer?: AttachNode; popup?: AttachNode; dialog?: AttachNode; drawer?: AttachNode };
   /**
    * 日历组件全局配置
    */

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -11,7 +11,8 @@ import props from './props';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
 
 import { useConfig, usePrefixClass } from '../hooks/useConfig';
-import { useAction, useSameTarget, useAttach } from './hooks';
+import useAttach from '../hooks/useAttach';
+import { useAction, useSameTarget } from './hooks';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import useDestroyOnClose from '../hooks/useDestroyOnClose';
 import { getScrollbarWidth } from '../_common/js/utils/getScrollbarWidth';
@@ -103,6 +104,7 @@ export default defineComponent({
     const renderTNodeJSX = useTNodeJSX();
     const dialogEle = ref<HTMLElement | null>(null);
     const { globalConfig } = useConfig('dialog');
+    const attach = useAttach('dialog', props.attach);
     const { CloseIcon, InfoCircleFilledIcon, CheckCircleFilledIcon, ErrorCircleFilledIcon } = useGlobalIcon({
       CloseIcon: TdCloseIcon,
       InfoCircleFilledIcon: TdInfoCircleFilledIcon,
@@ -118,7 +120,7 @@ export default defineComponent({
     };
     const { getConfirmBtn, getCancelBtn } = useAction({ confirmBtnAction, cancelBtnAction });
     // teleport容器
-    const teleportElement = useTeleport(() => props.attach);
+    const teleportElement = useTeleport(() => attach.value);
     useDestroyOnClose();
     const timer = ref();
     const styleEl = ref();

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -9,8 +9,9 @@ import {
 import { DialogCloseContext } from './type';
 import props from './props';
 import { useGlobalIcon } from '../hooks/useGlobalIcon';
+
 import { useConfig, usePrefixClass } from '../hooks/useConfig';
-import { useAction, useSameTarget } from './hooks';
+import { useAction, useSameTarget, useAttach } from './hooks';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
 import useDestroyOnClose from '../hooks/useDestroyOnClose';
 import { getScrollbarWidth } from '../_common/js/utils/getScrollbarWidth';

--- a/src/dialog/props.ts
+++ b/src/dialog/props.ts
@@ -11,7 +11,6 @@ export default {
   /** 对话框挂载的节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body */
   attach: {
     type: [String, Function] as PropType<TdDialogProps['attach']>,
-    default: 'body'
   },
   /** 对话框内容 */
   body: {
@@ -32,7 +31,10 @@ export default {
     default: undefined,
   },
   /** 点击蒙层时是否触发关闭事件 */
-  closeOnOverlayClick: Boolean,
+  closeOnOverlayClick: {
+    type: Boolean,
+    default: undefined,
+  },
   /** 确认按钮。值为 null 则不显示确认按钮。值类型为字符串，则表示自定义按钮文本，值类型为 Object 则表示透传 Button 组件属性。使用 TNode 自定义按钮时，需自行控制确认事件 */
   confirmBtn: {
     type: [String, Object, Function, null] as PropType<TdDialogProps['confirmBtn']>,

--- a/src/dialog/props.ts
+++ b/src/dialog/props.ts
@@ -11,6 +11,7 @@ export default {
   /** 对话框挂载的节点。数据类型为 String 时，会被当作选择器处理，进行节点查询。示例：'body' 或 () => document.body */
   attach: {
     type: [String, Function] as PropType<TdDialogProps['attach']>,
+    default: 'body'
   },
   /** 对话框内容 */
   body: {

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -8,6 +8,8 @@ import props from './props';
 import { DrawerCloseContext } from './type';
 import { useAction } from '../dialog/hooks';
 import { useTNodeJSX, useContent } from '../hooks/tnode';
+import useAttach from '../hooks/useAttach';
+
 import { useDrag } from './hooks';
 import type { TdDrawerProps } from './type';
 import useTeleport from '../hooks/useTeleport';
@@ -29,10 +31,11 @@ export default defineComponent({
     const renderTNodeJSX = useTNodeJSX();
     const renderContent = useContent();
     const COMPONENT_NAME = usePrefixClass('drawer');
+    const attach = useAttach('drawer', props.attach);
     const { draggedSizeValue, enableDrag, draggableLineStyles } = useDrag(props as TdDrawerProps);
 
     // teleport容器
-    const teleportElement = useTeleport(() => props.attach);
+    const teleportElement = useTeleport(() => attach.value);
 
     const confirmBtnAction = (e: MouseEvent) => {
       props.onConfirm?.({ e });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useRipple';
 export * from './useVirtualScroll';
 export * from './useVModel';
 export * from './useImagePreviewUrl';
+export * from './useAttach';

--- a/src/hooks/useAttach.ts
+++ b/src/hooks/useAttach.ts
@@ -1,0 +1,21 @@
+import { computed } from 'vue';
+import { useConfig } from './useConfig';
+import type { AttachNode } from '../common';
+
+const defaultAttach = 'body';
+/**
+ * useAttach
+ *
+ * 挂载节点 优先级:
+ *
+ * props attach -> globalConfig.attach.component -> globalConfig.attach -> default = 'body'
+ */
+const useAttach = (name: string, attach: AttachNode) => {
+  const globalAttachConfig = useConfig('attach');
+
+  const attachVal = computed(() => attach || globalAttachConfig?.[name] || globalAttachConfig || defaultAttach);
+
+  return attachVal;
+};
+
+export default useAttach;

--- a/src/hooks/useAttach.ts
+++ b/src/hooks/useAttach.ts
@@ -11,10 +11,10 @@ const defaultAttach = 'body';
  * props attach -> globalConfig.attach.component -> globalConfig.attach -> default = 'body'
  */
 const useAttach = (name: string, attach: AttachNode) => {
-  const { globalConfig: globalAttachConfig } = useConfig('attach');
+  const { globalConfig } = useConfig();
 
   const attachVal = computed(
-    () => attach || globalAttachConfig.value[name] || globalAttachConfig.value || defaultAttach,
+    () => attach || globalConfig.value.attach?.[name] || globalConfig.value.attach || defaultAttach,
   );
 
   return attachVal;

--- a/src/hooks/useAttach.ts
+++ b/src/hooks/useAttach.ts
@@ -5,15 +5,17 @@ import type { AttachNode } from '../common';
 const defaultAttach = 'body';
 /**
  * useAttach
- *
- * 挂载节点 优先级:
- *
+ * @param attach
+ * @param name
+ * @returns
  * props attach -> globalConfig.attach.component -> globalConfig.attach -> default = 'body'
  */
 const useAttach = (name: string, attach: AttachNode) => {
-  const globalAttachConfig = useConfig('attach');
+  const { globalConfig: globalAttachConfig } = useConfig('attach');
 
-  const attachVal = computed(() => attach || globalAttachConfig?.[name] || globalAttachConfig || defaultAttach);
+  const attachVal = computed(
+    () => attach || globalAttachConfig.value[name] || globalAttachConfig.value || defaultAttach,
+  );
 
   return attachVal;
 };

--- a/src/image-viewer/image-viewer.tsx
+++ b/src/image-viewer/image-viewer.tsx
@@ -7,6 +7,8 @@ import useDefaultValue from '../hooks/useDefaultValue';
 import usePopupManager from '../hooks/usePopupManager';
 import useTeleport from '../hooks/useTeleport';
 import useVModel from '../hooks/useVModel';
+import useAttach from '../hooks/useAttach';
+
 import Image from '../image';
 import TImageItem from './base/ImageItem';
 import TImageViewerIcon from './base/ImageModalIcon';
@@ -25,6 +27,7 @@ export default defineComponent({
     const classPrefix = usePrefixClass();
     const COMPONENT_NAME = usePrefixClass('image-viewer');
     const renderTNodeJSX = useTNodeJSX();
+    const attach = useAttach('image-viewer', props.attach);
     const isExpand = ref(true);
     const showOverlayValue = computed(() => getOverlay(props));
 
@@ -34,7 +37,7 @@ export default defineComponent({
     const animationEnd = ref(true);
     const animationTimer = ref();
     // teleport容器
-    const teleportElement = useTeleport(() => props.attach);
+    const teleportElement = useTeleport(() => attach.value);
 
     const wrapClass = computed(() => [
       COMPONENT_NAME.value,

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -18,6 +18,7 @@ import {
   watch,
 } from 'vue';
 import { useContent, useTNodeJSX } from '../hooks';
+import useAttach from '../hooks/useAttach';
 import { useCommonClassName, usePrefixClass } from '../hooks/useConfig';
 import useVModel from '../hooks/useVModel';
 import { off, on, once } from '../utils/dom';
@@ -104,6 +105,7 @@ export default defineComponent({
     );
     const renderTNodeJSX = useTNodeJSX();
     const renderContent = useContent();
+    const attach = useAttach('popup', props.attach);
 
     /** popperjs instance */
     let popper: ReturnType<typeof createPopper>;
@@ -473,7 +475,7 @@ export default defineComponent({
             }
           }}
           visible={visible.value}
-          attach={props.attach}
+          attach={attach.value}
         >
           {{
             content: () => (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/3167
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(ConfiProvider): 新增`attach`全局配置，支持对`ImageViewer`、`Popup`、`Dialog`和`Drawer`进行挂载位置的全局配置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
