### PR TITLE
fix(select): `group` title not exist still renders children

### DIFF
--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -33,7 +33,7 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
           dynamicIndex++;
           return res;
         };
-        if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
+        if ((option as SelectOptionGroup).children) {
           return {
             ...option,
             children: (option as SelectOptionGroup).children.map((child) => getFormatOption(child)),
@@ -84,7 +84,7 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
     const res: TdOptionProps[] = [];
     const getOptionsList = (options: TdOptionProps[]) => {
       for (const option of options) {
-        if ((option as SelectOptionGroup).group) {
+        if ((option as SelectOptionGroup).children) {
           getOptionsList((option as SelectOptionGroup).children);
         } else {
           res.push(option);
@@ -120,7 +120,7 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
     const res: SelectOption[] = [];
 
     options.value.forEach((option) => {
-      if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
+      if ((option as SelectOptionGroup).children) {
         res.push({
           ...option,
           children: (option as SelectOptionGroup).children.filter(filterMethods),

--- a/src/select/option-group-props.ts
+++ b/src/select/option-group-props.ts
@@ -13,6 +13,5 @@ export default {
   /** 分组别名 */
   label: {
     type: String,
-    default: '',
   },
 };

--- a/src/select/optionGroup.tsx
+++ b/src/select/optionGroup.tsx
@@ -23,7 +23,7 @@ export default defineComponent({
 
     return () => (
       <li class={classes.value}>
-        <div class={`${COMPONENT_NAME.value}__header`}>{props.label}</div>
+        {(props.label ?? false) && <div class={`${COMPONENT_NAME.value}__header`}>{props.label}</div>}
         {renderTNodeJSX('default')}
       </li>
     );

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -64,7 +64,7 @@ export default defineComponent({
       return (
         <ul class={`${COMPONENT_NAME.value}__list`}>
           {options.map((item: SelectOptionGroup & TdOptionProps & { slots: Slots } & { $index: number }, index) => {
-            if (item.group) {
+            if (item.children) {
               return (
                 <OptionGroup label={item.group} divider={item.divider}>
                   {renderOptionsContent(item.children)}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
对于 https://github.com/Tencent/tdesign-vue/pull/3445 功能的同步

<img width="315" alt="17358709662644" src="https://github.com/user-attachments/assets/9ddd7209-dc0a-4dbe-84fe-97293e54861f" />

<img width="486" alt="17358710099824" src="https://github.com/user-attachments/assets/ff27b160-5f4e-4ca8-ae94-9cdb82654ec9" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 修复分组情况下标题不存在 `group` 的渲染报错的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
