### PR TITLE
fix(select): fix warning when type of option value is boolean 

### DIFF
--- a/src/select/option-props.ts
+++ b/src/select/option-props.ts
@@ -32,6 +32,6 @@ export default {
   },
   /** 选项值 */
   value: {
-    type: [String, Number] as PropType<TdOptionProps['value']>,
+    type: [String, Number, Boolean] as PropType<TdOptionProps['value']>,
   },
 };

--- a/src/select/type.ts
+++ b/src/select/type.ts
@@ -233,7 +233,7 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
   /**
    * 当选择新创建的条目时触发
    */
-  onCreate?: (value: string | number) => void;
+  onCreate?: (value: string | number | boolean) => void;
   /**
    * 回车键按下时触发。`inputValue` 表示输入框的值，`value` 表示选中值
    */

--- a/src/select/type.ts
+++ b/src/select/type.ts
@@ -292,7 +292,7 @@ export interface TdOptionProps {
   /**
    * 选项值
    */
-  value?: string | number;
+  value?: string | number | boolean;
 }
 
 export interface TdOptionGroupProps {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#4922 


### 💡 需求背景和解决方案

需求背景：option 组件 value 原类型为 string | number，在使用 boolean 类型时控制台打印 vue 类型错误警告

解决方法：添加 boolean

### 📝 更新日志

- fix(select): 修复 option value 为 boolean 时控制台类型错误警告

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
