### PR TITLE
fix(TagInput): 修改 inputProps 中事件与 TagInput 事件冲突问题(#4802)

### DIFF
--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -13,6 +13,7 @@ import useHover from './hooks/useHover';
 import useDefault from '../hooks/useDefaultValue';
 import useDragSorter from './hooks/useDragSorter';
 import isArray from 'lodash/isArray';
+import isFunction from 'lodash/isFunction';
 import { useDisabled } from '../hooks/useDisabled';
 import { useReadonly } from '../hooks/useReadonly';
 
@@ -99,7 +100,24 @@ export default defineComponent({
       ),
     );
 
+    // 去掉 props.inputProps 中的所有事件
+    const inputPropsWithoutEvent = computed<TdTagInputProps['inputProps']>(() => {
+      if (inputProps.value) {
+        return (
+          Object.keys(inputProps.value)
+            // 依靠属性名以 on 开头及属性值为函数来判断属性是否为事件
+            .filter((key) => !key.startsWith('on') && !isFunction(inputProps.value[key]))
+            .reduce((acc, key) => {
+              acc[key] = inputProps.value[key];
+              return acc;
+            }, {})
+        );
+      }
+      return {};
+    });
+
     const onInputEnter = (value: string, context: { e: KeyboardEvent }) => {
+      inputProps.value?.onEnter(value, context);
       // 阻止 Enter 默认行为，避免在 Form 中触发 submit 事件
       context.e?.preventDefault?.();
       setTInputValue('', { e: context.e, trigger: 'enter' });
@@ -111,16 +129,17 @@ export default defineComponent({
     };
 
     const onInputCompositionstart = (value: string, context: { e: CompositionEvent }) => {
-      isComposition.value = true;
       inputProps.value?.onCompositionstart?.(value, context);
+      isComposition.value = true;
     };
 
     const onInputCompositionend = (value: string, context: { e: CompositionEvent }) => {
-      isComposition.value = false;
       inputProps.value?.onCompositionend?.(value, context);
+      isComposition.value = false;
     };
 
     const onClick: TdInputProps['onClick'] = (ctx) => {
+      inputProps.value?.onClick?.(ctx);
       if (isDisabled.value) return;
       isFocused.value = true;
       tagInputRef.value.focus();
@@ -142,29 +161,39 @@ export default defineComponent({
     };
 
     const onMouseEnter: InputProps['onMouseenter'] = (context) => {
+      inputProps.value?.onMouseenter?.(context);
       addHover(context);
       scrollToRightOnEnter();
     };
 
     const onMouseLeave: InputProps['onMouseleave'] = (context) => {
+      inputProps.value?.onMouseleave?.(context);
       cancelHover(context);
       scrollToLeftOnLeave();
     };
 
     const onInnerFocus: InputProps['onFocus'] = (inputValue: string, context: { e: MouseEvent }) => {
+      inputProps.value?.onFocus?.(inputValue, context);
       if (isFocused.value) return;
       isFocused.value = true;
       props.onFocus?.(tagValue.value, { e: context.e, inputValue });
     };
 
     const onInnerBlur: InputProps['onFocus'] = (inputValue: string, context: { e: MouseEvent }) => {
+      inputProps.value?.onBlur?.(inputValue, context);
       isFocused.value = false;
       setTInputValue('', { e: context.e, trigger: 'blur' });
       props.onBlur?.(tagValue.value, { e: context.e, inputValue });
     };
 
     const onInnerChange: StrInputProps['onChange'] = (val, context) => {
+      inputProps.value?.onChange?.(val, context);
       setTInputValue(val, { ...context, trigger: 'input' });
+    };
+
+    const onInputWheel: InputProps['onWheel'] = (context) => {
+      inputProps.value?.onWheel?.(context);
+      onWheel(context);
     };
 
     watch(
@@ -203,7 +232,6 @@ export default defineComponent({
       onInputBackspaceKeyUp,
       onInputBackspaceKeyDown,
       renderLabel,
-      onWheel,
       scrollToRightOnEnter,
       scrollToLeftOnLeave,
       onClick,
@@ -211,9 +239,11 @@ export default defineComponent({
       onClose,
       onInputCompositionstart,
       onInputCompositionend,
+      onInputWheel,
       classes,
       isDisabled,
       isReadonly,
+      inputPropsWithoutEvent,
     };
   },
 
@@ -262,7 +292,7 @@ export default defineComponent({
         suffixIcon={() => suffixIconNode}
         prefixIcon={() => prefixIconNode}
         keepWrapperWidth={!this.autoWidth}
-        onWheel={this.onWheel}
+        onWheel={this.onInputWheel}
         onChange={this.onInnerChange}
         onPaste={this.onPaste}
         onEnter={this.onInputEnter}
@@ -275,7 +305,10 @@ export default defineComponent({
         onClick={this.onClick}
         onCompositionstart={this.onInputCompositionstart}
         onCompositionend={this.onInputCompositionend}
-        {...(this.inputProps as TdTagInputProps['inputProps'])}
+        onClear={inputProps?.onClear}
+        onKeypress={inputProps?.onKeypress}
+        onValidate={inputProps?.onValidate}
+        {...this.inputPropsWithoutEvent}
       />
     );
   },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#4802 

### 💡 需求背景和解决方案

可能是 jsx 中会出现的问题
```
const events = { onChange: 方法1 }
const onChange = 方法2

<MyComponent onChange={onChange} {...events}></MyComponent>
```
比如这个例子，使用解构赋值的方式向 MyComponent 传入了两个 onChange 事件，这时候 MyComponent 中接收到的 onChange 就是  [方法1, 方法2] 组成的数组，而并非期待的一个函数

解决方法：我创建了一个  inputPropsWithoutEvent 变量，这个变量会过滤 inputProps 中的事件，而事件则是放在组件调用的事件方法中去调用。我把 inputProps 中的方法放在第一执行顺位，以 onChange 事件为例，正常逻辑去想肯定是 input 先 change 再然后是 TagInput change。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TagInput): 修改 inputProps 中事件与 TagInput 事件冲突问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
