### PR TITLE
fix(Table): validateTableCellData not exported

### DIFF
--- a/src/table/hooks/useEditableRow.ts
+++ b/src/table/hooks/useEditableRow.ts
@@ -214,6 +214,7 @@ export default function useRowEdit(props: PrimaryTableProps) {
     errorListMap,
     editableKeysMap,
     validateTableData,
+    validateTableCellData,
     validateRowData,
     onRuleChange,
     clearValidateData,

--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -152,6 +152,7 @@ export default defineComponent({
       editableKeysMap,
       validateRowData,
       validateTableData,
+      validateTableCellData,
       onRuleChange,
       clearValidateData,
       onUpdateEditedCell,
@@ -201,6 +202,7 @@ export default defineComponent({
     context.expose({
       validateRowData,
       validateTableData,
+      validateTableCellData,
       clearValidateData,
       refreshTable: () => {
         primaryTableRef.value.refreshTable();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- #4848 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

### #4848中的问题是因为使用了`validateRowData`方法，该方法只能校验单行的数据，且二次触发会导致上次数据丢失(覆盖)
![image](https://github.com/user-attachments/assets/e7831e6f-b409-4260-bea6-ec19d0e08313)
### 代码中有个`validateTableCellData`方法用来校验全部可编辑单元格，但该方法未导出。
### 使用该方法可以满足issue的需求，同时补充了缺失的问题。
![image](https://github.com/user-attachments/assets/8efd28ea-e12c-4c77-ac5f-48c21cda75f9)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复缺失`校验可编辑单元格`方法的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
