### PR TITLE
fix(form): `status` attribute being used validator

### DIFF
--- a/packages/components/form/form-item.tsx
+++ b/packages/components/form/form-item.tsx
@@ -100,6 +100,13 @@ export default defineComponent({
       },
     ]);
 
+    const statusClass = computed(
+      () =>
+        `${classPrefix.value}-is-${props.status || 'default'} ${
+          props.status === 'success' ? CLASS_NAMES.value.successBorder : ''
+        }`,
+    );
+
     const renderLabel = () => {
       if (Number(labelWidth.value) === 0) return;
 
@@ -165,6 +172,7 @@ export default defineComponent({
       }
       if (!errorList.value.length) return;
       const type = errorList.value[0].type || 'error';
+      if (props.status) return statusClass.value;
       return type === 'error' ? CLASS_NAMES.value.error : CLASS_NAMES.value.warning;
     });
     const contentClasses = computed(() => [CLASS_NAMES.value.controls, errorClasses.value]);
@@ -398,11 +406,7 @@ export default defineComponent({
     const tipsNode = computed<VNode>(() => {
       const tmpTips = renderContent('tips');
       if (!tmpTips) return null;
-      const tmpClasses = [
-        `${formItemClassPrefix.value}-tips`,
-        `${classPrefix.value}-tips`,
-        `${classPrefix.value}-is-${props.status || 'default'}`,
-      ];
+      const tmpClasses = [`${formItemClassPrefix.value}-tips`, `${classPrefix.value}-tips`, statusClass.value];
       return <div class={tmpClasses}>{tmpTips}</div>;
     });
 

--- a/packages/components/form/form.en-US.md
+++ b/packages/components/form/form.en-US.md
@@ -61,7 +61,7 @@ name | String | - | \- | N
 requiredMark | Boolean | undefined | \- | N
 rules | Array | - | Typescript：`Array<FormRule>` | N
 showErrorMessage | Boolean | undefined | \- | N
-status | String | - | Typescript：`'error' \| 'warning' \| 'success' \| 'validating'` | N
+status | String | - | Typescript：`'error' \| 'warning' \| 'success'` | N
 statusIcon | Boolean / Slot / Function | undefined | Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 successBorder | Boolean | false | \- | N
 tips | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N

--- a/packages/components/form/form.md
+++ b/packages/components/form/form.md
@@ -63,7 +63,7 @@ name | String | - | 表单字段名称 | N
 requiredMark | Boolean | undefined | 是否显示必填符号（*），优先级高于 Form.requiredMark | N
 rules | Array | - | 表单字段校验规则。TS 类型：`Array<FormRule>` | N
 showErrorMessage | Boolean | undefined | 校验不通过时，是否显示错误提示信息，优先级高于 `Form.showErrorMessage` | N
-status | String | - | 校验状态，可在需要完全自主控制校验状态时使用。TS 类型：`'error' \| 'warning' \| 'success' \| 'validating'` | N
+status | String | - | 校验状态，可在需要完全自主控制校验状态时使用。TS 类型：`'error' \| 'warning' \| 'success'` | N
 statusIcon | Boolean / Slot / Function | undefined | 校验状态图标，值为 `true` 显示默认图标，默认图标有 成功、失败、警告 等，不同的状态图标不同。`statusIcon` 值为 `false`，不显示图标。`statusIcon` 值类型为渲染函数，则可以自定义右侧状态图标。优先级高级 Form 的 statusIcon。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 successBorder | Boolean | false | 是否显示校验成功的边框，默认不显示 | N
 tips | String / Slot / Function | - | 自定义提示内容，样式跟随 `status` 变动，可在需要完全自主控制校验规则时使用。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N

--- a/packages/components/form/type.ts
+++ b/packages/components/form/type.ts
@@ -176,7 +176,7 @@ export interface TdFormItemProps {
    * 校验状态，可在需要完全自主控制校验状态时使用
    * @default ''
    */
-  status?: 'error' | 'warning' | 'success' | 'validating';
+  status?: 'error' | 'warning' | 'success';
   /**
    * 校验状态图标，值为 `true` 显示默认图标，默认图标有 成功、失败、警告 等，不同的状态图标不同。`statusIcon` 值为 `false`，不显示图标。`statusIcon` 值类型为渲染函数，则可以自定义右侧状态图标。优先级高级 Form 的 statusIcon
    */


### PR DESCRIPTION
chore: remove `statu`s intermediate  `'validating'`

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

当前 `status` 只能应用到 `tips`上，且 `'validating'` 并无样式实现

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Form): 修复`status` 属性没有应用到校验状态上的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
