### PR TITLE
fix(select): `checkAll` will check all filtered data of `reserveKeyword`

### DIFF
--- a/packages/components/select/hooks/useSelectOptions.ts
+++ b/packages/components/select/hooks/useSelectOptions.ts
@@ -113,7 +113,7 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
       if (isFunction(props.filter)) {
         return props.filter(`${inputValue.value}`, option);
       }
-
+      if ((option as TdOptionProps)?.checkAll === true) return true;
       return option.label?.toLowerCase?.().indexOf(`${inputValue.value}`.toLowerCase()) > -1;
     };
 

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -219,7 +219,7 @@ export default defineComponent({
      * @returns 可选选项的列表的 value
      */
     const getFilteredOptions = computed(() => {
-      const inputValue = innerInputValue.value.toLowerCase();
+      const inputValue = innerInputValue.value?.toLowerCase();
       return optionalList.value
         .filter((option) => {
           if (option.disabled) return false;
@@ -227,7 +227,7 @@ export default defineComponent({
             return props.filter(innerInputValue.value, option);
           }
 
-          return option.label.toLowerCase().includes(inputValue);
+          return option.label?.toLowerCase().includes(inputValue);
         })
         .map((option) => option.value);
     });

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -5,7 +5,6 @@ import { isFunction } from 'lodash-es';
 import { debounce } from 'lodash-es';
 import { cloneDeep } from 'lodash-es';
 import { get } from 'lodash-es';
-import { intersection } from 'lodash-es';
 import FakeArrow from '../common-components/fake-arrow';
 import SelectInput from '../select-input';
 import SelectPanel from './select-panel';
@@ -22,7 +21,7 @@ import { useSelectOptions } from './hooks/useSelectOptions';
 import useKeyboardControl from './hooks/useKeyboardControl';
 import type { PopupProps, PopupVisibleChangeContext } from '../popup';
 import type { SelectInputValueChangeContext } from '../select-input';
-import type { TdSelectProps, SelectValue, TdOptionProps } from './type';
+import type { TdSelectProps, SelectValue } from './type';
 import { SelectInputValueDisplayOptions } from '../select-input/useSingle';
 
 export default defineComponent({
@@ -244,7 +243,7 @@ export default defineComponent({
       const lockedValues = innerValue.value.filter((value: string | number | boolean) => {
         return optionsList.value.some((item) => item.value === value && item.disabled);
       });
-      const values = checked ? [...new Set([...getFilteredOptions.value, ...lockedValues])] : lockedValues.value;
+      const values = checked ? [...new Set([...getFilteredOptions.value, ...lockedValues])] : lockedValues;
       setInnerValue(values, { selectedOptions: getSelectedOptions(values), trigger: checked ? 'check' : 'clear' });
     };
 

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -1,10 +1,5 @@
 import { defineComponent, provide, computed, toRefs, watch, ref, nextTick, PropType } from 'vue';
-import { pick as picker } from 'lodash-es';
-import { isArray } from 'lodash-es';
-import { isFunction } from 'lodash-es';
-import { debounce } from 'lodash-es';
-import { cloneDeep } from 'lodash-es';
-import { get } from 'lodash-es';
+import { pick as picker, isArray, isFunction, debounce, cloneDeep, get, intersection } from 'lodash-es';
 import FakeArrow from '../common-components/fake-arrow';
 import SelectInput from '../select-input';
 import SelectPanel from './select-panel';
@@ -249,8 +244,9 @@ export default defineComponent({
 
     // 已选的长度
     const intersectionLen = computed(() => {
-      const validValues = new Set(getFilteredOptions.value);
-      return innerValue.value.filter((v: string | number | boolean) => validValues.has(v)).length;
+      const values = optionalList.value.map((item) => item.value);
+      const n = intersection(innerValue.value, values);
+      return n.length;
     });
 
     // 全选


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
Reset https://github.com/Tencent/tdesign-vue-next/pull/4898

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://github.com/user-attachments/assets/bfee38a6-7404-4e11-bf3e-129784771281

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 修复 `reserveKeyword` 与 `filterable` 在开启全选功能的使用问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
