### PR TITLE
TD Mono: packages/tdesign-vue-next for npm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,18 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
-  "cSpell.words": ["tdesign", "popconfirm", "cascader", "tnode", "backtop", "wechat", "miniprogram","nuxt","codesandbox"]
+  "cSpell.words": [
+    "backtop",
+    "cascader",
+    "codesandbox",
+    "miniprogram",
+    "nuxt",
+    "popconfirm",
+    "popperjs",
+    "precaching",
+    "tdesign",
+    "tdoc",
+    "tnode",
+    "wechat"
+  ]
 }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 重构

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5014

### 💡 需求背景和解决方案

如 issue 描述：

实现 vue-next 的对外发包功能，因此本次改动仅需要考虑的事情如下：

- [ ] 正确的 package.json
- [ ] 正确打包
- [ ] ci 修改

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor: packages/tdesign-vue-next for npm
