### PR TITLE
refactor: internal/utils package-json

### DIFF
--- a/internal/utils/index.ts
+++ b/internal/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './src/paths';
+export * from './src/package-json';

--- a/internal/utils/package.json
+++ b/internal/utils/package.json
@@ -6,17 +6,31 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
   "exports": {
-    "types": "./types/index.d.ts",
-    "import": "./dist/es/index.js",
-    "default": "./dist/cjs/index.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/es/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./paths": {
+      "types": "./types/paths.d.ts",
+      "import": "./dist/es/paths.js",
+      "default": "./dist/cjs/paths.js"
+    },
+    "./package-json": {
+      "types": "./types/package-json.d.ts",
+      "import": "./dist/es/package-json.js",
+      "default": "./dist/cjs/package-json.js"
+    }
   },
   "scripts": {
-    "build": "rollup -c rollup.config.ts"
+    "build": "rollup -c rollup.config.ts && pnpm build:tsc", 
+    "build:tsc": "tsc --declaration --emitDeclarationOnly --rootDir . --outDir types --resolveJsonModule --esModuleInterop ./src/*.ts index.ts"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "rollup": "^2.79.1",
-    "rollup-plugin-delete": "^2.1.0"
+    "rollup-plugin-delete": "^2.1.0",
+    "rollup-plugin-multi-input": "^1.4.1"
   }
 }

--- a/internal/utils/rollup.config.ts
+++ b/internal/utils/rollup.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'rollup';
 import typescript from '@rollup/plugin-typescript';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import json from '@rollup/plugin-json';
 import del from 'rollup-plugin-delete';
+// @ts-ignore
+import multiInput from 'rollup-plugin-multi-input';
 
 export default defineConfig({
-  input: './index.ts',
+  input: ['./index.ts', './src/*.ts'],
   output: [
     {
       dir: 'dist/cjs',
@@ -16,11 +19,13 @@ export default defineConfig({
     },
   ],
   plugins: [
+    multiInput(),
     typescript({
-      // TODO: 等 tsconfig.json 完善后这里加上
-      // declaration: true,
+      resolveJsonModule: true,
+      allowSyntheticDefaultImports: true,
     }),
     nodeResolve(),
+    json(),
     del({ targets: 'dist' }),
   ],
 });

--- a/internal/utils/src/package-json.ts
+++ b/internal/utils/src/package-json.ts
@@ -1,0 +1,9 @@
+// import { workspaceRoot, resolveWorkSpaceRoot } from './paths';
+// const rootPackageJson = require(resolveWorkSpaceRoot('package.json'));
+
+// TODO 这样写的好处是有类型，用 require 的写法是不是也可以手动指定类型呀，就是有点麻烦
+import rootPackageJson from '../../../package.json';
+import tdesignVueNextPackageJson from 'tdesign-vue-next/package.json';
+import tdesignVueNextSitePackageJson from 'tdesign-vue-next/site/package.json';
+
+export { rootPackageJson, tdesignVueNextPackageJson, tdesignVueNextSitePackageJson };

--- a/internal/utils/src/paths.ts
+++ b/internal/utils/src/paths.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path';
+import { resolve } from 'path';
 
 export { resolve };
 
@@ -11,6 +11,8 @@ export const componentsRoot = resolve(packagesRoot, 'components');
 // packages/tdesign-vue-next
 export const tdesignVueNextRoot = resolve(packagesRoot, 'tdesign-vue-next');
 
+// resolve workspaceRoot
+export const resolveWorkSpaceRoot = (...args: string[]) => resolve(workspaceRoot, ...args);
 // resolve packagesRoot
 export const resolvePackagesRoot = (...args: string[]) => resolve(packagesRoot, ...args);
 // resolve componentsRoot

--- a/internal/utils/types/index.d.ts
+++ b/internal/utils/types/index.d.ts
@@ -1,1 +1,2 @@
-export * from '../index';
+export * from './src/paths';
+export * from './src/package-json';

--- a/internal/utils/types/src/package-json.d.ts
+++ b/internal/utils/types/src/package-json.d.ts
@@ -1,0 +1,4 @@
+import rootPackageJson from '../../../package.json';
+import tdesignVueNextPackageJson from 'tdesign-vue-next/package.json';
+import tdesignVueNextSitePackageJson from 'tdesign-vue-next/site/package.json';
+export { rootPackageJson, tdesignVueNextPackageJson, tdesignVueNextSitePackageJson };

--- a/internal/utils/types/src/paths.d.ts
+++ b/internal/utils/types/src/paths.d.ts
@@ -1,0 +1,17 @@
+import { resolve } from 'path';
+export { resolve };
+export declare const workspaceRoot: string;
+export declare const packagesRoot: string;
+export declare const componentsRoot: string;
+export declare const tdesignVueNextRoot: string;
+export declare const resolveWorkSpaceRoot: (...args: string[]) => string;
+export declare const resolvePackagesRoot: (...args: string[]) => string;
+export declare const resolveComponentsRoot: (...args: string[]) => string;
+export declare const resolveTDesignVueNextRoot: (...args: string[]) => string;
+/**
+ * getRelativeWorkspaceRootPath
+ * @description get the relative path from the workspaceRoot directory
+ * @param absolutePath string
+ * @returns string
+ */
+export declare const getRelativeWorkspaceRootPath: (absolutePath: string) => string;

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "node": ">= 18"
   },
   "scripts": {
+    "pnpm:devPreinstall": "pnpm run init",
+    "postinstall": "husky install && pnpm -C internal/utils build",
     "init": "git submodule init && git submodule update",
-    "start": "pnpm run init && pnpm dev",
+    "start": "pnpm dev",
     "dev": "pnpm -C packages/tdesign-vue-next/site dev",
     "site": "pnpm -C packages/tdesign-vue-next/site build",
     "site:intranet": "pnpm -C packages/tdesign-vue-next/site intranet",
@@ -40,8 +42,7 @@
     "test:unit-coverage": "pnpm -C packages/tdesign-vue-next/test test:unit-coverage",
     "test:snap": "pnpm -C packages/tdesign-vue-next/test test:snap",
     "test:snap-update": "pnpm -C packages/tdesign-vue-next/test test:snap-update",
-    "robot": "publish-cli robot-msg",
-    "prepare": "husky install && pnpm -C internal/utils build"
+    "robot": "publish-cli robot-msg"
   },
   "author": "tdesign",
   "license": "MIT",

--- a/packages/tdesign-vue-next/site/plugin-doc/md-to-vue.js
+++ b/packages/tdesign-vue-next/site/plugin-doc/md-to-vue.js
@@ -6,7 +6,7 @@ import matter from 'gray-matter';
 import { compileUsage, getGitTimestamp } from '../../../../packages/common/docs/compile';
 // TODO: 同上
 import camelCase from 'lodash/camelCase';
-import { resolvePackagesRoot } from '@tdesign/internal-utils';
+import { resolvePackagesRoot } from '@tdesign/internal-utils/paths';
 
 import testCoverage from '../test-coverage';
 

--- a/packages/tdesign-vue-next/site/plugin-doc/transforms.js
+++ b/packages/tdesign-vue-next/site/plugin-doc/transforms.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import { resolvePackagesRoot } from '@tdesign/internal-utils';
+import { resolvePackagesRoot } from '@tdesign/internal-utils/paths';
 
 import mdToVue from './md-to-vue';
 

--- a/packages/tdesign-vue-next/site/src/components/codeSandbox/content.js
+++ b/packages/tdesign-vue-next/site/src/components/codeSandbox/content.js
@@ -1,5 +1,4 @@
-import orgPkg from '../../../package.json';
-import tdesignVueNextPkg from '../../../../package.json';
+import { tdesignVueNextPackageJson, tdesignVueNextSitePackageJson } from '@tdesign/internal-utils/package-json';
 
 export const htmlContent = `<div id="app"></div>`;
 
@@ -44,10 +43,10 @@ export const packageJSONContent = (name) => {
   return {
     name: name,
     dependencies: {
-      vue: orgPkg.dependencies.vue,
-      less: orgPkg.devDependencies.less,
-      'tdesign-vue-next': tdesignVueNextPkg.version,
-      'tdesign-icons-vue-next': tdesignVueNextPkg.dependencies['tdesign-icons-vue-next'],
+      vue: tdesignVueNextSitePackageJson.dependencies.vue,
+      less: tdesignVueNextSitePackageJson.devDependencies.less,
+      'tdesign-vue-next': tdesignVueNextPackageJson.version,
+      'tdesign-icons-vue-next': tdesignVueNextPackageJson.dependencies['tdesign-icons-vue-next'],
     },
     devDependencies: {
       '@vue/cli-plugin-babel': '~4.5.0',

--- a/packages/tdesign-vue-next/site/src/components/components.jsx
+++ b/packages/tdesign-vue-next/site/src/components/components.jsx
@@ -2,9 +2,7 @@ import { defineComponent } from 'vue';
 import semver from 'semver';
 import siteConfig from '../../site.config';
 import { htmlContent, mainJsContent, styleContent, packageJSONContent } from './codeSandbox/content';
-
-// TODO
-import packageJson from '../../../package.json';
+import { tdesignVueNextPackageJson } from '@tdesign/internal-utils/package-json';
 
 const { docs, enDocs } = JSON.parse(JSON.stringify(siteConfig).replace(/component:.+/g, ''));
 
@@ -30,7 +28,7 @@ const docsMap = {
   en: enDocs,
 };
 
-const currentVersion = packageJson.version.replace(/\./g, '_');
+const currentVersion = tdesignVueNextPackageJson.version.replace(/\./g, '_');
 const registryUrl = 'https://service-edbzjd6y-1257786608.hk.apigw.tencentcs.com/release/npm/versions/tdesign-vue-next';
 
 // 过滤小版本号
@@ -52,7 +50,7 @@ export default defineComponent({
   data() {
     return {
       loaded: false,
-      version: packageJson.version,
+      version: tdesignVueNextPackageJson.version,
       options: [],
     };
   },
@@ -110,7 +108,7 @@ export default defineComponent({
       const historyUrl = `//${version}-tdesign-vue-next.surge.sh`;
       window.open(historyUrl, '_blank');
       this.$nextTick(() => {
-        this.version = packageJson.version;
+        this.version = tdesignVueNextPackageJson.version;
       });
     },
   },

--- a/packages/tdesign-vue-next/site/src/components/stackblitz/content.js
+++ b/packages/tdesign-vue-next/site/src/components/stackblitz/content.js
@@ -1,5 +1,4 @@
-import orgPkg from '../../../package.json';
-import tdesignVueNextPkg from '../../../../package.json';
+import { tdesignVueNextPackageJson, tdesignVueNextSitePackageJson } from '@tdesign/internal-utils/package-json';
 
 export const htmlContent = `
   <div id="app"></div>
@@ -71,16 +70,16 @@ export const packageJSONContent = JSON.stringify(
       serve: 'vite preview',
     },
     dependencies: {
-      vue: orgPkg.dependencies.vue,
-      less: orgPkg.devDependencies.less,
-      'tdesign-vue-next': tdesignVueNextPkg.version,
-      'tdesign-icons-vue-next': tdesignVueNextPkg.dependencies['tdesign-icons-vue-next'],
+      vue: tdesignVueNextSitePackageJson.dependencies.vue,
+      less: tdesignVueNextSitePackageJson.devDependencies.less,
+      'tdesign-vue-next': tdesignVueNextPackageJson.version,
+      'tdesign-icons-vue-next': tdesignVueNextPackageJson.dependencies['tdesign-icons-vue-next'],
     },
     devDependencies: {
-      vite: orgPkg.devDependencies.vite,
-      '@vue/compiler-sfc': orgPkg.devDependencies['@vue/compiler-sfc'],
-      '@vitejs/plugin-vue': orgPkg.devDependencies['@vitejs/plugin-vue'],
-      '@vitejs/plugin-vue-jsx': orgPkg.devDependencies['@vitejs/plugin-vue-jsx'],
+      vite: tdesignVueNextSitePackageJson.devDependencies.vite,
+      '@vue/compiler-sfc': tdesignVueNextSitePackageJson.devDependencies['@vue/compiler-sfc'],
+      '@vitejs/plugin-vue': tdesignVueNextSitePackageJson.devDependencies['@vitejs/plugin-vue'],
+      '@vitejs/plugin-vue-jsx': tdesignVueNextSitePackageJson.devDependencies['@vitejs/plugin-vue-jsx'],
     },
   },
   null,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 重构

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/5045

### 💡 需求背景和解决方案

仓库内部使用的 utils 之 _package.json_ 文件引用

- _package.json_ 文件引用 相关
    多处文件均需要 _package.json_ 文件引用，目前的获取方式是直接使用的是相对路径，比如:
    <img width="400" alt="image" src="https://github.com/user-attachments/assets/52278d94-d78b-458e-adae-c0991d312c7b" />
    <img width="400" alt="image" src="https://github.com/user-attachments/assets/b7ea8a1e-1035-4fd9-9e72-165f8f1afaef" />


**处理方式**
- [x] 收拢 package-json 文件出口，更便捷地处理 package-json  文件

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- refactor: internal/utils package-json
