### PR TITLE
feat(Select): set fuzzy match option as the first result when using  default filter

### DIFF
--- a/packages/components/select/hooks/useSelectOptions.ts
+++ b/packages/components/select/hooks/useSelectOptions.ts
@@ -117,7 +117,7 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
       return option.label?.toLowerCase?.().indexOf(`${inputValue.value}`.toLowerCase()) > -1;
     };
 
-    const res: SelectOption[] = [];
+    let res: SelectOption[] = [];
 
     options.value.forEach((option) => {
       if ((option as SelectOptionGroup).children) {
@@ -130,6 +130,15 @@ export const useSelectOptions = (props: TdSelectProps, keys: Ref<KeysType>, inpu
         res.push(option);
       }
     });
+
+    if (!isFunction(props.filter)) {
+      // 使用默认 filter，增加表现，调整全等项到首尾，避免全等项位于最后
+      // inputValue: ab
+      // options abcde, abcd, abc,  ab
+      const exactMatch = res.filter((item) => item.label === inputValue.value);
+      const fuzzyMatch = res.filter((item) => item.label !== inputValue.value);
+      res = exactMatch.concat(fuzzyMatch);
+    }
 
     return res;
   });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 新特性提交

### 💡 需求背景和解决方案
问题，在一些选项数量多的场景下，使用默认排序，较短的匹配项可能会被排在很后面，默认的搜索行为应该要能够优先展示全等项

https://stackblitz.com/edit/dmwb73st?file=package.json,src%2Fdemo.vue

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 默认搜索方法优先展示全等项

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供