### PR TITLE
fix(Table): Keyboard Ignore Ctrl & Command

### DIFF
--- a/packages/components/table/hooks/useHoverKeyboardEvent.ts
+++ b/packages/components/table/hooks/useHoverKeyboardEvent.ts
@@ -74,7 +74,8 @@ export function useHoverKeyboardEvent(props: BaseTableProps, tableRef: Ref<HTMLD
       props.onActiveRowAction?.({ action: 'clear', activeRowList: [] });
     } else if (ALL_REG.test(code) && !props.activeRowType) {
       props.onActiveRowAction?.({ action: 'select-all', activeRowList: [] });
-    } else if (CLEAR_REG.test(code) && !props.activeRowType) {
+      // fix: https://github.com/Tencent/tdesign-vue-next/issues/4990 ↓
+    } else if (CLEAR_REG.test(code) && !props.activeRowType && !e.ctrlKey && !e.metaKey) {
       props.onActiveRowAction?.({ action: 'clear', activeRowList: [] });
     }
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- https://github.com/Tencent/tdesign-vue-next/issues/4990
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景
#### 排查发现是由Hook`useHoverKeyboardEvent`触发的清空事件，因`Ctrl C`有触发`C`键，故产生`误判`
![image](https://github.com/user-attachments/assets/59448470-a09c-42c6-812e-ef04a5cbf31a)
![image](https://github.com/user-attachments/assets/cba98d7b-8b56-4196-a54b-48c109a59974)
### 💡 解决方案
#### 新增`Ctrl键`和`Command键`判断
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 修复按下`Ctrl C`复制快捷键导致清空选中行的问题。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
