### PR TITLE
fix(Table): DonT Register Drag Events When NoChildren

### DIFF
--- a/packages/components/table/hooks/useDragSort.ts
+++ b/packages/components/table/hooks/useDragSort.ts
@@ -64,7 +64,11 @@ export default function useDragSort(
 
   // 行拖拽排序
   const registerRowDragEvent = (element: HTMLDivElement): void => {
-    if (!isRowHandlerDraggable.value && !isRowDraggable.value) return;
+    /**
+     * fix: https://github.com/Tencent/tdesign-vue-next/issues/4985
+     * 若table内容未渲染（即element子元素为空），拖拽事件不注册
+     */
+    if (element?.children?.length === 0 && !isRowHandlerDraggable.value && !isRowDraggable.value) return;
     const dragContainer = element?.querySelector('tbody');
     if (!dragContainer) {
       console.error('tbody does not exist.');


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- https://github.com/Tencent/tdesign-vue-next/issues/4985
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#### Drawer未出现时 Table内容未渲染，就无法成功的注册拖拽事件
<img width="453" alt="image" src="https://github.com/user-attachments/assets/d61695e0-4714-40ad-8544-a12a915153b4" />

#### 新增判断规则：若Table子元素合集为空，就不再继续注册事件
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 表格内容未渲染时，设置`drag-sort`拖动事件报错的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
