### PR TITLE
fix(Select): select all error when `valueType = 'object'`

### DIFF
--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -245,21 +245,21 @@ export default defineComponent({
      *    - 过滤条件下，如果 checked 为 false，则只保留已选中的 disabled 选项。
      */
     const onCheckAllChange = (checked: boolean) => {
-      const { value } = keys.value;
       if (!props.multiple) return;
+      const { value } = keys.value;
       // disabled状态的选项，不参与全选的计算，始终保留
       const lockedValues = innerValue.value.filter((value: string | number | boolean) => {
         return optionsList.value.find((item) => item.value === value && item.disabled);
       });
 
       const activeValues = optionalList.value.map((option) => option.value);
-      const orgValueFormatter =
+      const formattedOrgValue =
         props.valueType === 'object'
           ? (orgValue.value as Array<SelectValue>).map((v) => get(v, value))
           : orgValue.value;
 
       const values = checked
-        ? [...new Set([...(orgValueFormatter as Array<SelectValue>), ...activeValues, ...lockedValues])]
+        ? [...new Set([...(formattedOrgValue as Array<SelectValue>), ...activeValues, ...lockedValues])]
         : [...lockedValues];
       setInnerValue(values, { selectedOptions: getSelectedOptions(values), trigger: checked ? 'check' : 'clear' });
     };

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -245,6 +245,7 @@ export default defineComponent({
      *    - 过滤条件下，如果 checked 为 false，则只保留已选中的 disabled 选项。
      */
     const onCheckAllChange = (checked: boolean) => {
+      const { value } = keys.value;
       if (!props.multiple) return;
       // disabled状态的选项，不参与全选的计算，始终保留
       const lockedValues = innerValue.value.filter((value: string | number | boolean) => {
@@ -252,8 +253,13 @@ export default defineComponent({
       });
 
       const activeValues = optionalList.value.map((option) => option.value);
+      const orgValueFormatter =
+        props.valueType === 'object'
+          ? (orgValue.value as Array<SelectValue>).map((v) => get(v, value))
+          : orgValue.value;
+
       const values = checked
-        ? [...new Set([...(orgValue.value as Array<SelectValue>), ...activeValues, ...lockedValues])]
+        ? [...new Set([...(orgValueFormatter as Array<SelectValue>), ...activeValues, ...lockedValues])]
         : [...lockedValues];
       setInnerValue(values, { selectedOptions: getSelectedOptions(values), trigger: checked ? 'check' : 'clear' });
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当 `valueType = 'object'` 时如果使用 filter 进行筛选数据，然后点击全选就会产生tag 显示错误。

https://github.com/user-attachments/assets/157b2317-5c24-4de2-a99e-e0c7509c3b55

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->




- fix(Select): 修复当 `valueType = 'object'` 时，在有已选择数据的情况下筛选数据，全选产生错误 Tag 显示的问题。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
