### PR TITLE
fix(menu): 修复menu-item的props中to定义时缺少string类型问题

### DIFF
--- a/packages/components/menu/type.ts
+++ b/packages/components/menu/type.ts
@@ -193,7 +193,7 @@ export interface TdMenuItemProps {
   /**
    * 路由跳转目标，当且仅当 Router 存在时，该 API 有效
    */
-  to?: MenuRoute;
+  to?: string | MenuRoute;
   /**
    * 菜单项唯一标识
    */


### PR DESCRIPTION
修复menu-item的props中to定义时缺少string类型问题

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
解决tdesign-vue-next-starter路径的类型问题，会导致项目编译错误，实际是支持string类型的：
https://github.com/Tencent/tdesign-vue-next-starter/blob/develop/src/types/interface.d.ts#L18


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
解决tdesign-vue-next-starter路径的类型问题，会导致项目编译错误，实际是支持string类型的：
https://github.com/Tencent/tdesign-vue-next-starter/blob/develop/src/types/interface.d.ts#L18

<img width="1117" alt="Clipboard_Screenshot_1742279052" src="https://github.com/user-attachments/assets/ec4b69f2-2e4a-4d08-9d1c-b23b83048ebb" />


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): 修复menu-item的props中to定义时缺少string类型问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
