### PR TITLE
fix(drawer): 修复拖拽调整size时，Drawer页内容会被选中的问题

### DIFF
--- a/packages/components/drawer/drawer.tsx
+++ b/packages/components/drawer/drawer.tsx
@@ -29,7 +29,7 @@ export default defineComponent({
     const renderTNodeJSX = useTNodeJSX();
     const renderContent = useContent();
     const COMPONENT_NAME = usePrefixClass('drawer');
-    const { draggedSizeValue, enableDrag, draggableLineStyles } = useDrag(props as TdDrawerProps);
+    const { draggedSizeValue, enableDrag, draggableLineStyles, draggingStyles } = useDrag(props as TdDrawerProps);
 
     // teleport容器
     const teleportElement = useTeleport(() => props.attach);
@@ -267,7 +267,7 @@ export default defineComponent({
             {...context.attrs}
           >
             {props.showOverlay && <div class={`${COMPONENT_NAME.value}__mask`} onClick={handleWrapperClick} />}
-            <div class={wrapperClasses.value} style={wrapperStyles.value}>
+            <div class={wrapperClasses.value} style={{ ...wrapperStyles.value, ...draggingStyles.value }}>
               {headerContent && <div class={`${COMPONENT_NAME.value}__header`}>{headerContent}</div>}
               {props.closeBtn && (
                 <div class={`${COMPONENT_NAME.value}__close-btn`} onClick={handleCloseBtnClick}>

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -87,7 +87,6 @@ export const useDrag = (props: TdDrawerProps) => {
     draggedSizeValue,
     enableDrag,
     draggableLineStyles,
-    isSizeDragging,
     draggingStyles,
   };
 };

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -76,12 +76,7 @@ export const useDrag = (props: TdDrawerProps) => {
     } as Styles;
   });
 
-  const draggingStyles = computed(
-    () =>
-      ({
-        userSelect: isSizeDragging.value ? 'none' : 'auto',
-      } as Styles),
-  );
+  const draggingStyles = computed<Styles>(() => (isSizeDragging.value ? { userSelect: 'none' } : {}));
 
   return {
     draggedSizeValue,

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -8,7 +8,8 @@ export const useDrag = (props: TdDrawerProps) => {
   const isSizeDragging = ref(false);
   const draggedSizeValue = ref<string>(null);
 
-  const enableDrag = () => {
+  const enableDrag = (e: MouseEvent) => {
+    e.stopPropagation(); // 阻止事件冒泡
     // mousedown绑定mousemove和mouseup事件
     document.addEventListener('mouseup', handleMouseup, true);
     document.addEventListener('mousemove', handleMousemove, true);
@@ -72,9 +73,21 @@ export const useDrag = (props: TdDrawerProps) => {
       width: isHorizontal ? '16px' : '100%',
       height: isHorizontal ? '100%' : '16px',
       cursor: isHorizontal ? 'col-resize' : 'row-resize',
-      userSelect: 'none',
     } as Styles;
   });
 
-  return { draggedSizeValue, enableDrag, draggableLineStyles };
+  const draggingStyles = computed(
+    () =>
+      ({
+        userSelect: isSizeDragging.value ? 'none' : 'auto',
+      } as Styles),
+  );
+
+  return {
+    draggedSizeValue,
+    enableDrag,
+    draggableLineStyles,
+    isSizeDragging,
+    draggingStyles,
+  };
 };

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -72,6 +72,7 @@ export const useDrag = (props: TdDrawerProps) => {
       width: isHorizontal ? '16px' : '100%',
       height: isHorizontal ? '100%' : '16px',
       cursor: isHorizontal ? 'col-resize' : 'row-resize',
+      userSelect: 'none',
     } as Styles;
   });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5216


<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题：Drawer 拖拽调整size时，Drawer页内容会被选中

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Drawer): 修复Drawer 拖拽调整size时，Drawer页内容会被选中

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
