### PR TITLE
fix(tree-select): 当 `valueType='object '` 时无初始化 value导致错误和意外产生取消选中

### DIFF
--- a/packages/components/tree-select/tree-select.tsx
+++ b/packages/components/tree-select/tree-select.tsx
@@ -187,8 +187,8 @@ export default defineComponent({
       }
       if (isObjectValue.value) {
         actived.value = isArray(treeSelectValue.value)
-          ? (treeSelectValue.value as Array<TreeSelectValue>).map((item) => (item as INodeOptions).value)
-          : [(treeSelectValue.value as INodeOptions).value];
+          ? (treeSelectValue.value as Array<TreeSelectValue>).map((item) => (item as INodeOptions)?.value)
+          : [(treeSelectValue.value as INodeOptions)?.value];
       } else {
         (actived.value as TreeSelectValue) = isArray(treeSelectValue.value)
           ? treeSelectValue.value
@@ -231,8 +231,8 @@ export default defineComponent({
       if (!props.multiple) {
         setInnerVisible(false, context);
       }
-      // 多选模式屏蔽 Active 事件
-      if (props.multiple) {
+      // 多选模式屏蔽 Active 事件和取消选中状态改变
+      if (props.multiple || !context.node.actived) {
         return;
       }
       // 单选模式重复选择不清空


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

<img width="714" alt=" 879086684" src="https://github.com/user-attachments/assets/4f25e1d3-a4d3-4fa0-ae2c-054451da9132" />

https://github.com/user-attachments/assets/236f8ae7-feb8-4c10-ada8-239fe78e643d

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select): 修复当 `valueType='object '` 时无初始化选中数据时产生意外错误
                           修复第二次点击已选中的 item 时 `onChange` 抛出的选中值为空并且取消 item 的选中状态的错误

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
