### PR TITLE
feat(select): add option removal handling for multiple selection

### DIFF
--- a/packages/components/select/option.tsx
+++ b/packages/components/select/option.tsx
@@ -118,8 +118,9 @@ export default defineComponent({
       const newValue = getNewMultipleValue(selectProvider.value.selectValue as SelectValue[], props.value);
       const selectedOptions = selectProvider.value.getSelectedOptions(newValue.value);
 
+      const currentOption = selectProvider.value.getSelectedOptions(props.value)?.[0];
       selectProvider.value.handleValueChange(newValue.value, {
-        option: selectedOptions.find((v) => v.value === props.value),
+        option: currentOption,
         selectedOptions,
         trigger: val ? 'check' : 'uncheck',
         e: context.e,

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -103,6 +103,13 @@ export default defineComponent({
         selectedOptions: getSelectedOptions(newVal),
         ...context,
       });
+      if (props.multiple && context.trigger === 'uncheck' && context.option) {
+        props.onRemove?.({
+          value: get(context.option, keys.value.value),
+          data: context.option,
+          e: context.e,
+        });
+      }
     };
 
     const [innerPopupVisible, setInnerPopupVisible] = useDefaultValue(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

ref #5302
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. `selectProvider.value.handleValueChange` 传递的 option 应该是从所有可选项中匹配，而不是最新的已选项中匹配
2. 在 `context.trigger === 'uncheck'`时触发 remove 事件

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(select): 取消勾选面板中的已选项时触发 `remove` 事件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
