### PR TITLE
feat(color-picker): 支持切换触发器为无文字按键，支持悬浮时打开面板，扩展鼠标事件

### DIFF
--- a/packages/components/color-picker/color-picker.en-US.md
+++ b/packages/components/color-picker/color-picker.en-US.md
@@ -1,6 +1,7 @@
 :: BASE_DOC ::
 
 ## API
+
 ### ColorPicker Props
 
 name | type | default | description | required
@@ -9,12 +10,15 @@ borderless | Boolean | false | \- | N
 clearable | Boolean | false | \- | N
 closeBtn | String / Boolean / Slot / Function | true | Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 colorModes | Array | ["monochrome", "linear-gradient"] | Typescript：`Array<'monochrome' \| 'linear-gradient'>` | N
-disabled | Boolean | - | \- | N
+disabled | Boolean | undefined | \- | N
 enableAlpha | Boolean | false | \- | N
 enableMultipleGradient | Boolean | true | \- | N
-format | String | RGB | options: RGB/RGBA/HSL/HSLA/HSB/HSV/HSVA/HEX/CMYK/CSS | N
+format | String | RGB | When `enableAlpha` is true, `HEX8/RGBA/HSLA/HSVA` are valid。options: HEX/HEX8/RGB/RGBA/HSL/HSLA/HSV/HSVA/CMYK/CSS | N
 inputProps | Object | - | Typescript：`InputProps`，[Input API Documents](./input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 multiple | Boolean | false | \- | N
+onMouseenter | Function | - | Triggered when mouse move in component.。Typescript：`(context: { e: MouseEvent }) => void` | N
+onMouseleave | Function | - | Triggered when mouse move out component.。Typescript：`(context: { e: MouseEvent }) => void` | N
+openOnHover | Boolean | false | Open panel when hover | N
 popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 recentColors | Array | [] | used color recently。`v-model:recentColors` is supported。Typescript：`boolean \| Array<string> \| null` | N
 defaultRecentColors | Array | [] | used color recently。uncontrolled property。Typescript：`boolean \| Array<string> \| null` | N
@@ -22,6 +26,7 @@ selectInputProps | Object | - | Typescript：`SelectInputProps`，[SelectInput A
 showPrimaryColorPreview | Boolean | true | \- | N
 size | String | medium | options: small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 swatchColors | Array | - | swatch colors。Typescript：`Array<string> \| null` | N
+triggerType | String | input | Trigger component type. Default value is input, display hex color, supports keyin/clear. In button mode only display color, no text, supports clear.。options: input/button。Typescript：`'input' \| 'button'` | N
 value | String | - | color value。`v-model` and `v-model:value` is supported | N
 defaultValue | String | - | color value。uncontrolled property | N
 onChange | Function |  | Typescript：`(value: string, context: { color: ColorObject; trigger: ColorPickerChangeTrigger }) => void`<br/>[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts)。<br/>`type ColorPickerChangeTrigger = 'palette-saturation-brightness' \| 'palette-saturation' \| 'palette-brightness' \| 'palette-hue-bar' \| 'palette-alpha-bar' \| 'input' \| 'preset' \| 'recent' `<br/> | N

--- a/packages/components/color-picker/color-picker.md
+++ b/packages/components/color-picker/color-picker.md
@@ -1,6 +1,7 @@
 :: BASE_DOC ::
 
 ## API
+
 ### ColorPicker Props
 
 名称 | 类型 | 默认值 | 描述 | 必传
@@ -9,12 +10,15 @@ borderless | Boolean | false | 无边框模式 | N
 clearable | Boolean | false | 是否可清空 | N
 closeBtn | String / Boolean / Slot / Function | true | 关闭按钮，值为 `true` 显示默认关闭按钮；值为 `false` 或 `undefined` 则不显示关闭按钮；值类型为函数，则表示自定义关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 colorModes | Array | ["monochrome", "linear-gradient"] | 颜色模式选择。同时支持单色和渐变两种模式，可仅使用单色或者渐变其中一种模式，也可以同时使用。`monochrome` 表示单色，`linear-gradient` 表示渐变色。TS 类型：`Array<'monochrome' \| 'linear-gradient'>` | N
-disabled | Boolean | - | 是否禁用组件 | N
+disabled | Boolean | undefined | 是否禁用组件 | N
 enableAlpha | Boolean | false | 是否开启透明通道 | N
 enableMultipleGradient | Boolean | true | 是否允许开启通过点击渐变轴增加渐变梯度，默认开启，关闭时只会存在起始和结束两个颜色 | N
-format | String | RGB | 格式化色值。`enableAlpha` 为真时，`RGBA/HSLA/HSVA` 等值有效。可选项：RGB/RGBA/HSL/HSLA/HSB/HSV/HSVA/HEX/CMYK/CSS | N
+format | String | RGB | 格式化色值。`enableAlpha` 为真时，`HEX8/RGBA/HSLA/HSVA` 有效。可选项：HEX/HEX8/RGB/RGBA/HSL/HSLA/HSV/HSVA/CMYK/CSS | N
 inputProps | Object | - | 透传 Input 输入框组件全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 multiple | Boolean | false | 【开发中】是否允许选中多个颜色 | N
+onMouseenter | Function | - | 鼠标进入触发器组件时触发事件。TS 类型：`(context: { e: MouseEvent }) => void` | N
+onMouseleave | Function | - | 鼠标退出触发器组件时触发事件。TS 类型：`(context: { e: MouseEvent }) => void` | N
+openOnHover | Boolean | false | 是否悬浮时打开颜色选择器面板 | N
 popupProps | Object | - | 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts) | N
 recentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。支持语法糖 `v-model:recentColors`。TS 类型：`boolean \| Array<string> \| null` | N
 defaultRecentColors | Array | [] | 最近使用的颜色。值为 [] 表示以组件内部的“最近使用颜色”为准，值长度大于 0 则以该值为准显示“最近使用颜色”。值为 null 则完全不显示“最近使用颜色”。非受控属性。TS 类型：`boolean \| Array<string> \| null` | N
@@ -22,6 +26,7 @@ selectInputProps | Object | - | 透传 SelectInputProps 筛选器输入框组件
 showPrimaryColorPreview | Boolean | true | 是否展示颜色选择条右侧的颜色预览区域 | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 swatchColors | Array | - | 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色。TS 类型：`Array<string> \| null` | N
+triggerType | String | input | 触发器类型，默认为input组件，可显示16进制色值，支持输入/清空。button模式下仅回显色块，无文本，支持清空。可选项：input/button。TS 类型：`'input' \| 'button'` | N
 value | String | - | 色值。支持语法糖 `v-model` 或 `v-model:value` | N
 defaultValue | String | - | 色值。非受控属性 | N
 onChange | Function |  | TS 类型：`(value: string, context: { color: ColorObject; trigger: ColorPickerChangeTrigger }) => void`<br/>选中的色值发生变化时触发，第一个参数 `value` 表示新色值，`context.color` 表示当前调色板控制器的色值，`context.trigger` 表示触发颜色变化的来源。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/color-picker/type.ts)。<br/>`type ColorPickerChangeTrigger = 'palette-saturation-brightness' \| 'palette-saturation' \| 'palette-brightness' \| 'palette-hue-bar' \| 'palette-alpha-bar' \| 'input' \| 'preset' \| 'recent' `<br/> | N

--- a/packages/components/color-picker/color-picker.tsx
+++ b/packages/components/color-picker/color-picker.tsx
@@ -24,6 +24,20 @@ export default defineComponent({
 
     const handleClear = (context: { e: MouseEvent }) => props.onClear?.(context);
 
+    const isHover = ref(false);
+
+    // 按键trigger的clearable依赖此鼠标事件
+    const mouseEvent = (v: boolean) => (isHover.value = v);
+    const onMouseenter = (e: MouseEvent) => {
+      mouseEvent(true);
+      if (props.openOnHover) setVisible(true);
+      props.onMouseenter?.({ e });
+    };
+    const onMouseleave = (e: MouseEvent) => {
+      mouseEvent(false);
+      props.onMouseleave?.({ e });
+    };
+
     const renderPopupContent = () => {
       if (props.disabled) {
         return null;
@@ -65,7 +79,13 @@ export default defineComponent({
       };
       return (
         <TPopup {...popProps} content={renderPopupContent}>
-          <div class={`${baseClassName.value}__trigger`} onClick={() => setVisible(!visible.value)} ref={refTrigger}>
+          <div
+            class={`${baseClassName.value}__trigger`}
+            onClick={() => setVisible(!visible.value)}
+            ref={refTrigger}
+            onMouseenter={onMouseenter}
+            onMouseleave={onMouseleave}
+          >
             {renderTNodeJSXDefault(
               'default',
               <DefaultTrigger
@@ -74,9 +94,11 @@ export default defineComponent({
                 disabled={props.disabled}
                 clearable={props.clearable}
                 input-props={props.inputProps}
+                isHover={isHover.value}
                 onTriggerChange={setInnerValue}
                 onTriggerClear={handleClear}
                 size={props.size}
+                triggerType={props.triggerType}
               />,
             )}
           </div>

--- a/packages/components/color-picker/components/trigger/index.tsx
+++ b/packages/components/color-picker/components/trigger/index.tsx
@@ -1,9 +1,12 @@
-import { defineComponent, PropType, ref, watch } from 'vue';
+import { computed, defineComponent, PropType, ref, watch } from 'vue';
+import TButton from '../../../button';
 import TInput from '../../../input';
 import { Color } from '../../utils';
-import { TdColorPickerProps } from '../../type';
+import { ColorObject, ColorPickerChangeTrigger, TdColorPickerProps } from '../../type';
 import { useBaseClassName } from '../../hooks';
 import { useCommonClassName } from '../../../hooks/useConfig';
+import { CloseCircleFilledIcon as TdCloseCircleFilledIcon } from 'tdesign-icons-vue-next';
+import { useGlobalIcon } from '../../../hooks/useGlobalIcon';
 
 export default defineComponent({
   name: 'DefaultTrigger',
@@ -33,21 +36,27 @@ export default defineComponent({
         };
       },
     },
+    isHover: {
+      type: Boolean,
+      default: false,
+    },
     onTriggerChange: {
-      type: Function,
-      default: () => {
-        return () => {};
-      },
+      type: Function as PropType<
+        (value: string, context?: { color: ColorObject; trigger: ColorPickerChangeTrigger }) => void
+      >,
+      default: () => {},
     },
     onTriggerClear: {
-      type: Function,
-      default: () => {
-        return () => {};
-      },
+      type: Function as PropType<(context: { e: MouseEvent }) => void>,
+      default: () => {},
     },
     size: {
       type: String as PropType<TdColorPickerProps['size']>,
       default: 'medium',
+    },
+    triggerType: {
+      type: String as PropType<TdColorPickerProps['triggerType']>,
+      default: 'input',
     },
   },
   setup(props) {
@@ -55,9 +64,14 @@ export default defineComponent({
     const value = ref(props.color);
     const { SIZE: sizeClassNames } = useCommonClassName();
     watch(
-      () => [props.color],
-      () => (value.value = props.color),
+      () => props.color,
+      (newColor) => {
+        value.value = newColor;
+      },
     );
+    const { CloseCircleFilledIcon } = useGlobalIcon({
+      CloseCircleFilledIcon: TdCloseCircleFilledIcon,
+    });
 
     const handleChange = (input: string) => {
       if (input === props.color) {
@@ -72,6 +86,17 @@ export default defineComponent({
     };
 
     const handleClear = (context: { e: MouseEvent }) => props.onTriggerClear?.(context);
+    const handleInnerClear = (context: { e: MouseEvent }) => {
+      // 按键trigger在此清空value，input trigger在input组件内部清空
+      value.value = '';
+      // 避免触发外层打开panel
+      context.e.stopPropagation();
+      handleClear(context);
+    };
+
+    const showClear = computed(() => {
+      return value.value && !props.disabled && props.clearable && props.isHover;
+    });
 
     return () => {
       const inputSlots = {
@@ -93,19 +118,40 @@ export default defineComponent({
           );
         },
       };
+      const renderBtnTrigger = () => {
+        return (
+          <>
+            <TButton variant="outline" shape="square" size={props.size} disabled={props.disabled}>
+              {inputSlots.label()}
+            </TButton>
+            {showClear.value && (
+              <CloseCircleFilledIcon
+                class={`${baseClassName.value}__trigger--btn__clear-icon`}
+                onClick={handleInnerClear}
+              />
+            )}
+          </>
+        );
+      };
+
       return (
-        <TInput
-          borderless={props.borderless}
-          clearable={props.clearable}
-          size={props.size}
-          v-slots={inputSlots}
-          v-model={value.value}
-          disabled={props.disabled}
-          onBlur={handleChange}
-          onChange={handleChange}
-          onClear={handleClear}
-          {...props.inputProps}
-        />
+        <>
+          {props.triggerType === 'input' && (
+            <TInput
+              borderless={props.borderless}
+              clearable={props.clearable}
+              size={props.size}
+              v-slots={inputSlots}
+              v-model={value.value}
+              disabled={props.disabled}
+              onBlur={handleChange}
+              onChange={handleChange}
+              onClear={handleClear}
+              {...props.inputProps}
+            />
+          )}
+          {props.triggerType === 'button' && renderBtnTrigger()}
+        </>
       );
     };
   },

--- a/packages/components/color-picker/props.ts
+++ b/packages/components/color-picker/props.ts
@@ -23,7 +23,10 @@ export default {
     default: (): TdColorPickerProps['colorModes'] => ['monochrome', 'linear-gradient'],
   },
   /** 是否禁用组件 */
-  disabled: Boolean,
+  disabled: {
+    type: Boolean,
+    default: undefined,
+  },
   /** 是否开启透明通道 */
   enableAlpha: Boolean,
   /** 是否允许开启通过点击渐变轴增加渐变梯度，默认开启，关闭时只会存在起始和结束两个颜色 */
@@ -31,13 +34,13 @@ export default {
     type: Boolean,
     default: true,
   },
-  /** 格式化色值。`enableAlpha` 为真时，`RGBA/HSLA/HSVA` 等值有效 */
+  /** 格式化色值。`enableAlpha` 为真时，`HEX8/RGBA/HSLA/HSVA` 有效 */
   format: {
     type: String as PropType<TdColorPickerProps['format']>,
     default: 'RGB' as TdColorPickerProps['format'],
     validator(val: TdColorPickerProps['format']): boolean {
       if (!val) return true;
-      return ['RGB', 'RGBA', 'HSL', 'HSLA', 'HSB', 'HSV', 'HSVA', 'HEX', 'CMYK', 'CSS'].includes(val);
+      return ['HEX', 'HEX8', 'RGB', 'RGBA', 'HSL', 'HSLA', 'HSV', 'HSVA', 'CMYK', 'CSS'].includes(val);
     },
   },
   /** 透传 Input 输入框组件全部属性 */
@@ -46,6 +49,16 @@ export default {
   },
   /** 【开发中】是否允许选中多个颜色 */
   multiple: Boolean,
+  /** 鼠标进入触发器组件时触发事件 */
+  onMouseenter: {
+    type: Function as PropType<TdColorPickerProps['onMouseenter']>,
+  },
+  /** 鼠标退出触发器组件时触发事件 */
+  onMouseleave: {
+    type: Function as PropType<TdColorPickerProps['onMouseleave']>,
+  },
+  /** 是否悬浮时打开颜色选择器面板 */
+  openOnHover: Boolean,
   /** 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等 */
   popupProps: {
     type: Object as PropType<TdColorPickerProps['popupProps']>,
@@ -81,6 +94,15 @@ export default {
   /** 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色 */
   swatchColors: {
     type: Array as PropType<TdColorPickerProps['swatchColors']>,
+  },
+  /** 触发器类型，默认为input组件，可显示16进制色值，支持输入/清空。button模式下仅回显色块，无文本，支持清空 */
+  triggerType: {
+    type: String as PropType<TdColorPickerProps['triggerType']>,
+    default: 'input' as TdColorPickerProps['triggerType'],
+    validator(val: TdColorPickerProps['triggerType']): boolean {
+      if (!val) return true;
+      return ['input', 'button'].includes(val);
+    },
   },
   /** 色值 */
   value: {

--- a/packages/components/color-picker/type.ts
+++ b/packages/components/color-picker/type.ts
@@ -45,10 +45,10 @@ export interface TdColorPickerProps {
    */
   enableMultipleGradient?: boolean;
   /**
-   * 格式化色值。`enableAlpha` 为真时，`RGBA/HSLA/HSVA` 等值有效
+   * 格式化色值。`enableAlpha` 为真时，`HEX8/RGBA/HSLA/HSVA` 有效
    * @default RGB
    */
-  format?: 'RGB' | 'RGBA' | 'HSL' | 'HSLA' | 'HSB' | 'HSV' | 'HSVA' | 'HEX' | 'CMYK' | 'CSS';
+  format?: 'HEX' | 'HEX8' | 'RGB' | 'RGBA' | 'HSL' | 'HSLA' | 'HSV' | 'HSVA' | 'CMYK' | 'CSS';
   /**
    * 透传 Input 输入框组件全部属性
    */
@@ -58,6 +58,19 @@ export interface TdColorPickerProps {
    * @default false
    */
   multiple?: boolean;
+  /**
+   * 鼠标进入触发器组件时触发事件
+   */
+  onMouseenter?: (context: { e: MouseEvent }) => void;
+  /**
+   * 鼠标退出触发器组件时触发事件
+   */
+  onMouseleave?: (context: { e: MouseEvent }) => void;
+  /**
+   * 是否悬浮时打开颜色选择器面板
+   * @default false
+   */
+  openOnHover?: boolean;
   /**
    * 透传 Popup 组件全部属性，如 `placement` `overlayStyle` `overlayClassName` `trigger`等
    */
@@ -90,6 +103,11 @@ export interface TdColorPickerProps {
    * 系统预设的颜色样例，值为 `null` 或 `[]` 则不显示系统色，值为 `undefined` 会显示组件内置的系统默认色
    */
   swatchColors?: Array<string> | null;
+  /**
+   * 触发器类型，默认为input组件，可显示16进制色值，支持输入/清空。button模式下仅回显色块，无文本，支持清空
+   * @default input
+   */
+  triggerType?: 'input' | 'button';
   /**
    * 色值
    * @default ''


### PR DESCRIPTION
supports triggerType:input/button to render trigger as input component or no text button

supports openOnHover:boolean to open panel when hover on trigger

update auto-generated file from api

closed #5378
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5378

### 💡 需求背景和解决方案

非破坏性，默认值为旧行为input组件，增加参数控制触发器切换为无图Button

### 📝 更新日志

- feat(color-picker): feat(color-picker): 支持切换触发器为无文字按键，支持悬浮时打开面板，扩展鼠标事件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
