### PR TITLE
fix(Dialog): destroyOnClose 为 true 时 onBeforeOpen 事件重复触发的问题

### DIFF
--- a/packages/components/dialog/dialog.tsx
+++ b/packages/components/dialog/dialog.tsx
@@ -60,6 +60,7 @@ export default defineComponent({
     useDestroyOnClose();
     const timer = ref();
     const styleEl = ref();
+    const isDialogClosed = ref(false);
     // 是否模态形式的对话框
     const isModal = computed(() => props.mode === 'modal');
     // 是否非模态对话框
@@ -182,6 +183,7 @@ export default defineComponent({
 
     // 打开弹窗动画开始时事件
     const beforeEnter = () => {
+      isDialogClosed.value = false;
       props.onBeforeOpen?.();
     };
 
@@ -197,6 +199,7 @@ export default defineComponent({
 
     // 关闭弹窗动画结束时事件
     const afterLeave = () => {
+      isDialogClosed.value = true;
       dialogCardRef.value?.resetPosition?.();
       props.onClosed?.();
     };
@@ -235,11 +238,12 @@ export default defineComponent({
               ref={dialogCardRef}
               theme={theme}
               {...otherProps}
-              v-slots={context.slots}
               onConfirm={confirmBtnAction}
               onCancel={cancelBtnAction}
               onCloseBtnClick={closeBtnAction}
-            />
+            >
+              {!(props.destroyOnClose && isDialogClosed.value) && context.slots.default?.()}
+            </TDialogCard>
           </div>
         </div>
       );
@@ -289,11 +293,9 @@ export default defineComponent({
             onBeforeLeave={beforeLeave}
             onAfterLeave={afterLeave}
           >
-            {(!props.destroyOnClose || props.visible) && (
-              <div v-show={props.visible} class={ctxClass} style={ctxStyle} {...context.attrs}>
-                {view}
-              </div>
-            )}
+            <div v-show={props.visible} class={ctxClass} style={ctxStyle} {...context.attrs}>
+              {view}
+            </div>
           </Transition>
         </Teleport>
       );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/4835

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(Dialog): 修复 destroyOnClose 为 true 时 onBeforeOpen 事件重复触发的问题
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
