### PR TITLE
perf(space): remove the duplicate filter for teleport child

### DIFF
--- a/packages/components/space/space.tsx
+++ b/packages/components/space/space.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, CSSProperties, Fragment, isVNode, Teleport } from 'vue';
+import { defineComponent, computed, CSSProperties, Fragment } from 'vue';
 import props from './props';
 import { usePrefixClass } from '../hooks/useConfig';
 import { useTNodeJSX } from '../hooks/tnode';
@@ -57,9 +57,6 @@ export default defineComponent({
       const children = getFlatChildren(getChildSlots());
       const separatorContent = renderTNodeJSX('separator');
       return children.map((child, index) => {
-        const isTeleport = isVNode(child) && child.type === Teleport;
-        if (isTeleport) return null;
-        // filter last child
         const showSeparator = index + 1 !== children.length && separatorContent;
         return (
           <Fragment>


### PR DESCRIPTION
Because the filtering of teleport child has been implemented in the useFlatChildrenSlots hook #5446

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
精简代码实现：因为在 useFlatChildrenSlots hook 中已实现对 teleport child 的过滤 #5446

### 📝 更新日志 

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- perf(Space): 移除对 teleport 子 Node 的过滤
--> 

- perf(Space): 移除对 teleport 子 Node 的重复过滤

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
