### PR TITLE
fix(table): 修复树形模式关联选择时，全选与行选择返回的已选数据结构不一致的问题

### DIFF
--- a/packages/components/table/hooks/useTreeSelect.tsx
+++ b/packages/components/table/hooks/useTreeSelect.tsx
@@ -181,10 +181,12 @@ export default function useTreeSelect(props: TdEnhancedTableProps, treeDataMap: 
   }
 
   function onInnerSelectChange(rowKeys: SelectChangeParams[0], extraData: SelectChangeParams[1]) {
+    // 非关联选择无论单选多选直接返回，数据格式与非树形table一致
     if (!tree.value || tree.value.checkStrictly) {
       setTSelectedRowKeys(rowKeys, extraData);
       return;
     }
+    // 关联选择，行选择和全选，均使用getRowDataByKeys获取带tree元数据的结构返回
     if (extraData.currentRowKey === 'CHECK_ALL_BOX') {
       handleSelectAll(extraData);
     } else {
@@ -194,20 +196,20 @@ export default function useTreeSelect(props: TdEnhancedTableProps, treeDataMap: 
 
   function handleSelectAll(extraData: SelectChangeParams[1]) {
     const newRowKeys: Array<string | number> = [];
-    const newRowData: TableRowData[] = [];
     if (extraData.type === 'check') {
       const arr = [...treeDataMap.value.values()];
       for (let i = 0, len = arr.length; i < len; i++) {
         const item = arr[i];
         if (!item.disabled) {
-          newRowData.push(item.row);
           newRowKeys.push(get(item.row, rowDataKeys.value.rowKey));
         }
       }
     }
+    // 这里用getRowDataByKeys返回带row的节点对象（全选）
+    const newRowData = getRowDataByKeys({ treeDataMap: treeDataMap.value, selectedRowKeys: newRowKeys });
     const newExtraData = {
       ...extraData,
-      selectedRowData: newRowData || [],
+      selectedRowData: newRowData,
     };
     setTSelectedRowKeys(newRowKeys, newExtraData);
   }
@@ -230,6 +232,7 @@ export default function useTreeSelect(props: TdEnhancedTableProps, treeDataMap: 
       }
     }
     newRowKeys = updateParentCheckedState(newRowKeys, extraData.currentRowKey, extraData.type);
+    // 这里用getRowDataByKeys返回带row的节点对象（行选择）
     const newRowData = getRowDataByKeys({ treeDataMap: treeDataMap.value, selectedRowKeys: newRowKeys });
     const newExtraData = {
       ...extraData,


### PR DESCRIPTION
BREAKING CHANGE: 非checkStrictly下，表头全选的数据格式会发生变化。非tree及checkStrictly非关联选择无变化。

closed #5467

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5467

### 💡 需求背景和解决方案

全选时使用和单选一样的getRowDataByKeys返回含元数据的结构

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
