### PR TITLE
chat-action 组件 isGood/isBad 参数合并为 comment 参数

### DIFF
--- a/.kuai.yaml
+++ b/.kuai.yaml
@@ -1,0 +1,5 @@
+#`快码`插件配置文件，将其提交到git仓库是使用该插件的最佳实践。
+
+fastPublishCommand:
+  value: make upload2tkex
+  description: 快速发布命令，可根据项目实际情况进行修改

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,32 @@
     "tnode",
     "vnode",
     "wechat"
-  ]
+  ],
+  "terminal.integrated.profiles.linux": {
+    "bash": {
+      "path": "bash",
+      "icon": "terminal-bash"
+    },
+    "zsh": {
+      "path": "zsh"
+    },
+    "fish": {
+      "path": "fish"
+    },
+    "tmux": {
+      "path": "tmux",
+      "icon": "terminal-tmux"
+    },
+    "pwsh": {
+      "path": "pwsh",
+      "icon": "terminal-powershell"
+    },
+    "supercode-sh": {
+      "path": "/bin/zsh",
+      "args": [
+        "-l"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.linux": "supercode-sh"
 }

--- a/packages/components/chat/_example/chat-action.vue
+++ b/packages/components/chat/_example/chat-action.vue
@@ -3,15 +3,15 @@
     <t-chat-action
       :comment="comment"
       content="它叫 McMurdo Station ATM，是美国富国银行安装在南极洲最大科学中心麦克默多站的一台自动提款机。"
-      :operation-btn="['good', 'bad', 'replay', 'copy']"
-      @operation="handleOperation"
+      :action-bar="['good', 'bad', 'replay', 'copy']"
+      @actions="handleActions"
     />
   </div>
 </template>
 <script setup>
 import { ref } from 'vue';
 const comment = ref('');
-const handleOperation = (type, options) => {
+const handleActions = (type, options) => {
   console.log(type, options);
   comment.value = type;
 };

--- a/packages/components/chat/_example/chat-action.vue
+++ b/packages/components/chat/_example/chat-action.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="chat-action-content">
     <t-chat-action
-      :is-good="isGood"
-      :is-bad="isBad"
+      :comment="comment"
       content="它叫 McMurdo Station ATM，是美国富国银行安装在南极洲最大科学中心麦克默多站的一台自动提款机。"
       :operation-btn="['good', 'bad', 'replay', 'copy']"
       @operation="handleOperation"
@@ -11,16 +10,9 @@
 </template>
 <script setup>
 import { ref } from 'vue';
-const isGood = ref(false);
-const isBad = ref(false);
+const comment = ref('');
 const handleOperation = (type, options) => {
   console.log(type, options);
-  if (type === 'good') {
-    isGood.value = !isGood.value;
-    isBad.value = false;
-  } else if (type === 'bad') {
-    isBad.value = !isBad.value;
-    isGood.value = false;
-  }
+  comment.value = type;
 };
 </script>

--- a/packages/components/chat/chat-action-props.ts
+++ b/packages/components/chat/chat-action-props.ts
@@ -5,7 +5,7 @@
  * */
 
 import { TdChatActionProps } from '../chat/type';
-import { PropType } from 'vue';
+import { Prop, PropType } from 'vue';
 
 export default {
   /** 被复制的内容 */
@@ -15,10 +15,12 @@ export default {
   },
   /** 操作按钮是否可点击 */
   disabled: Boolean,
-  /** 是否点踩 */
-  isBad: Boolean,
-  /** 是否点赞 */
-  isGood: Boolean,
+  /** 评价类型， 可选值： 'good(点赞)'/'bad(点踩)', 默认值为空 */
+  comment: {
+    type: String as PropType<'good' | 'bad'>,
+    validator: (value: string) => ['good', 'bad'].includes(value),
+    default: '',
+  },
   /** 操作按钮配置项，可配置操作按钮选项和顺序 */
   operationBtn: {
     type: Array as PropType<TdChatActionProps['operationBtn']>,

--- a/packages/components/chat/chat-action-props.ts
+++ b/packages/components/chat/chat-action-props.ts
@@ -22,10 +22,10 @@ export default {
     default: '',
   },
   /** 操作按钮配置项，可配置操作按钮选项和顺序 */
-  operationBtn: {
-    type: Array as PropType<TdChatActionProps['operationBtn']>,
-    default: (): TdChatActionProps['operationBtn'] => ['replay', 'copy', 'good', 'bad'],
+  actionBar: {
+    type: Array as PropType<TdChatActionProps['actionBar']>,
+    default: (): TdChatActionProps['actionBar'] => ['replay', 'copy', 'good', 'bad'],
   },
   /** 点击点赞，点踩，复制，重新生成按钮时触发 */
-  onOperation: Function as PropType<TdChatActionProps['onOperation']>,
+  onActions: Function as PropType<TdChatActionProps['onActions']>,
 };

--- a/packages/components/chat/chat-action.md
+++ b/packages/components/chat/chat-action.md
@@ -8,14 +8,12 @@
 -- | -- | -- | -- | --
 content | String | - | 被复制的内容 | N
 disabled | Boolean | false | 操作按钮是否可点击 | N
-isBad | Boolean | false | 是否点踩 | N
-isGood | Boolean | false | 是否点赞 | N
 comment | String | - | 评价类型， 可选值： `'good(点赞)'/'bad(点踩)`， 默认为空| N
-operationBtn | Array | ["replay", "copy", "good", "bad"] | 操作按钮配置项，可配置操作按钮选项和顺序。TS 类型：`Array<'replay'\|'copy'\|'good'\|'bad'>` | N
-onOperation | Function |  | TS 类型：`(value:string, context: { e: MouseEvent }) => void`<br/>点击点赞，点踩，复制，重新生成按钮时触发 | N
+actionBar | Array | ["replay", "copy", "good", "bad"] | 操作按钮配置项，可配置操作按钮选项和顺序。TS 类型：`Array<'replay'\|'copy'\|'good'\|'bad'>` | N
+onActions | Function |  | TS 类型：`(value:string, context: { e: MouseEvent }) => void`<br/>点击点赞，点踩，复制，重新生成按钮时触发 | N
 
 ### ChatAction Events
 
 名称 | 参数 | 描述
 -- | -- | --
-operation | `(value:string, context: { e: MouseEvent })` | 点击点赞，点踩，复制，重新生成按钮时触发
+actions | `(value:string, context: { e: MouseEvent })` | 点击点赞，点踩，复制，重新生成按钮时触发

--- a/packages/components/chat/chat-action.md
+++ b/packages/components/chat/chat-action.md
@@ -10,6 +10,7 @@ content | String | - | 被复制的内容 | N
 disabled | Boolean | false | 操作按钮是否可点击 | N
 isBad | Boolean | false | 是否点踩 | N
 isGood | Boolean | false | 是否点赞 | N
+comment | String | - | 评价类型， 可选值： `'good(点赞)'/'bad(点踩)`， 默认为空| N
 operationBtn | Array | ["replay", "copy", "good", "bad"] | 操作按钮配置项，可配置操作按钮选项和顺序。TS 类型：`Array<'replay'\|'copy'\|'good'\|'bad'>` | N
 onOperation | Function |  | TS 类型：`(value:string, context: { e: MouseEvent }) => void`<br/>点击点赞，点踩，复制，重新生成按钮时触发 | N
 

--- a/packages/components/chat/chat-action.tsx
+++ b/packages/components/chat/chat-action.tsx
@@ -19,7 +19,7 @@ import { MessagePluginSingleton } from './utils';
 export default defineComponent({
   name: 'TChatAction',
   props,
-  emits: ['operation'],
+  emits: ['actions'],
   setup(props, { emit }) {
     const COMPONENT_NAME = usePrefixClass('chat');
     const renderTNodeJSX = useTNodeJSX();
@@ -47,11 +47,11 @@ export default defineComponent({
           copyAnswer();
         }
         // 如果通过default传入的chat-item 组件，如何获取index值todo
-        emit('operation', type, {
+        emit('actions', type, {
           e,
         });
       };
-      const replayButton = props.operationBtn.includes('replay') ? (
+      const replayButton = props.actionBar.includes('replay') ? (
         <Space>
           <div class={`${COMPONENT_NAME.value}__refresh`}>
             <Tooltip content={refreshTipText}>
@@ -68,7 +68,7 @@ export default defineComponent({
           </div>
         </Space>
       ) : null;
-      const copyButton = props.operationBtn.includes('copy') ? (
+      const copyButton = props.actionBar.includes('copy') ? (
         <Space>
           <Tooltip content={copyTipText}>
             <Button
@@ -84,7 +84,7 @@ export default defineComponent({
           </Tooltip>
         </Space>
       ) : null;
-      const goodButton = props.operationBtn.includes('good') ? (
+      const goodButton = props.actionBar.includes('good') ? (
         <Space>
           <Tooltip content={likeTipText}>
             <Button
@@ -99,7 +99,7 @@ export default defineComponent({
           </Tooltip>
         </Space>
       ) : null;
-      const badButton = props.operationBtn.includes('bad') ? (
+      const badButton = props.actionBar.includes('bad') ? (
         <Space>
           <Tooltip content={dislikeTipText}>
             <Button
@@ -123,7 +123,7 @@ export default defineComponent({
       };
       return (
         <div class={`${COMPONENT_NAME.value}__actions`}>
-          {props.operationBtn.map((btnKey) => {
+          {props.actionBar.map((btnKey) => {
             return buttonComponents[btnKey];
           })}
         </div>

--- a/packages/components/chat/chat-action.tsx
+++ b/packages/components/chat/chat-action.tsx
@@ -90,11 +90,11 @@ export default defineComponent({
             <Button
               theme="default"
               size="small"
-              class={props.isGood && `${COMPONENT_NAME.value}-button--active`}
+              class={props.comment === 'good' && `${COMPONENT_NAME.value}-button--active`}
               disabled={disabled}
               onClick={(e: MouseEvent) => handleClick(e, 'good')}
             >
-              {props.isGood ? <ThumbUpFilledIcon /> : <ThumbUpIcon />}
+              {props.comment === 'good' ? <ThumbUpFilledIcon /> : <ThumbUpIcon />}
             </Button>
           </Tooltip>
         </Space>
@@ -105,11 +105,11 @@ export default defineComponent({
             <Button
               theme="default"
               size="small"
-              class={props.isBad && `${COMPONENT_NAME.value}-button--active`}
+              class={props.comment === 'bad' && `${COMPONENT_NAME.value}-button--active`}
               disabled={disabled}
               onClick={(e: MouseEvent) => handleClick(e, 'bad')}
             >
-              {props.isBad ? <ThumbDownFilledIcon /> : <ThumbDownIcon />}
+              {props.comment === 'bad' ? <ThumbDownFilledIcon /> : <ThumbDownIcon />}
             </Button>
           </Tooltip>
         </Space>

--- a/packages/components/chat/type.ts
+++ b/packages/components/chat/type.ts
@@ -183,11 +183,11 @@ export interface TdChatActionProps {
    * 操作按钮配置项，可配置操作按钮选项和顺序
    * @default ["replay", "copy", "good", "bad"]
    */
-  operationBtn?: Array<'replay' | 'copy' | 'good' | 'bad'>;
+  actionBar?: Array<'replay' | 'copy' | 'good' | 'bad'>;
   /**
    * 点击点赞，点踩，复制，重新生成按钮时触发
    */
-  onOperation?: (value: string, context: { e: MouseEvent }) => void;
+  onActions?: (value: string, context: { e: MouseEvent }) => void;
 }
 
 export interface TdChatInputProps {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [✅ ] 新特性提交
- [✅] 文档改进
- [✅] 演示代码改进

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
内部需求

### 💡 需求背景和解决方案

<!--
1. 原chat-action组件控制点赞，点踩的参数比较冗余
2. 将chat-action 的isGood/isBad 参数合并为 comment 参数
-->

### 📝 更新日志

- [✅] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(chat-action): 将 isGood参数和isBad 参数合并为comment 参数
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✅] 文档已补充或无须补充
- [✅ ] 代码演示已提供或无须提供
- [✅] TypeScript 定义已补充或无须补充
- [✅] Changelog 已提供或无须提供
