### PR TITLE
fix(ColorPicker): prevent `onChange` prop from being passed as an array

### DIFF
--- a/packages/components/color-picker/color-picker.tsx
+++ b/packages/components/color-picker/color-picker.tsx
@@ -36,11 +36,13 @@ export default defineComponent({
 
       return (
         <ColorPanel
-          {...props}
+          {...{
+            ...props,
+            onChange: setInnerValue,
+            onRecentColorsChange: setInnerRecentColors,
+          }}
           value={innerValue.value}
           recentColors={innerRecentColors.value}
-          onChange={setInnerValue}
-          onRecentColorsChange={setInnerRecentColors}
         />
       );
     };

--- a/packages/tdesign-vue-next/.changelog/pr-5545.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5545.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5545
+contributor: RylanBot
+---
+
+- fix(ColorPicker): 修复 `onChange` 和  `onRecentChange`  回调失效 @RylanBot ([#5545](https://github.com/Tencent/tdesign-vue-next/pull/5545))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- https://github.com/Tencent/tdesign-vue-next/pull/5428 中将 `delete` 移除了，本以为后者会覆盖前者，但实际导致传递了一个数组进来

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(ColorPicker): 修复 `onChange` 和  `onRecentChange`  回调失效

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
