### PR TITLE
perf(site): add grid component online demo styles

### DIFF
--- a/packages/tdesign-vue-next/site/src/components/codeSandbox/content.ts
+++ b/packages/tdesign-vue-next/site/src/components/codeSandbox/content.ts
@@ -49,6 +49,22 @@ export const styleContent = `
     font-weight: 500;
     font-size: 20px;
   }
+
+  /* grid 组件示例展示 */
+  .tdesign-demo-item--grid .t-col > div {
+    min-height: 40px;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    background: #366ef4;
+    color: #fff;
+    text-align: center;
+    line-height: 40px;
+  }
+
+  .tdesign-demo-item--grid .t-col:nth-of-type(2n) > div {
+    background: #8eabff;
+  }
+
 `;
 
 export const packageJSONContent = (name: string) => {

--- a/packages/tdesign-vue-next/site/src/components/stackblitz/content.ts
+++ b/packages/tdesign-vue-next/site/src/components/stackblitz/content.ts
@@ -52,6 +52,21 @@ export const styleContent = `
     font-weight: 500;
     font-size: 20px;
   }
+
+  /* grid 组件示例展示 */
+  .tdesign-demo-item--grid .t-col > div {
+    min-height: 40px;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    background: #366ef4;
+    color: #fff;
+    text-align: center;
+    line-height: 40px;
+  }
+
+  .tdesign-demo-item--grid .t-col:nth-of-type(2n) > div {
+    background: #8eabff;
+  }
 `;
 
 export const stackblitzRc = `


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

grid 组件的在线 demo 未带上与官网示例所需的特定样式

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
