### PR TITLE
fix(ChatSender): fix stopDisabled is effected by internal loading 

### DIFF
--- a/packages/pro-components/chat/_example/chat-sender-slot.vue
+++ b/packages/pro-components/chat/_example/chat-sender-slot.vue
@@ -3,10 +3,10 @@
     ref="chatSenderRef"
     v-model="inputValue"
     class="chat-sender"
-    :stop-disabled="loading"
     :textarea-props="{
       placeholder: '请输入消息...',
     }"
+    :loading="loading"
     @send="inputEnter"
   >
     <template #suffix>

--- a/packages/pro-components/chat/_example/chat-sender.vue
+++ b/packages/pro-components/chat/_example/chat-sender.vue
@@ -1,12 +1,13 @@
 <template>
   <t-chat-sender
     v-model="query"
-    :stop-disabled="loading"
     :textarea-props="{
       placeholder: '请输入消息...',
     }"
+    :loading="loading"
     @send="inputEnter"
     @file-select="fileSelect"
+    @stop="onStop"
   >
     <!-- 自定义操作区域的内容，默认支持图片上传、附件上传和发送按钮 -->
     <template #suffix="{ renderPresets }">
@@ -40,5 +41,8 @@ const inputEnter = function () {
 };
 const fileSelect = (file: File) => {
   console.log(file);
+};
+const onStop = function () {
+  loading.value = false;
 };
 </script>

--- a/packages/pro-components/chat/_example/reasoning-drag.vue
+++ b/packages/pro-components/chat/_example/reasoning-drag.vue
@@ -40,7 +40,7 @@
         <template #footer>
           <t-chat-sender
             v-model="inputValue"
-            :stop-disabled="isStreamLoad"
+            :loading="isStreamLoad"
             :textarea-props="{
               placeholder: '请输入消息...',
             }"

--- a/packages/pro-components/chat/_example/reasoning-drawer.vue
+++ b/packages/pro-components/chat/_example/reasoning-drawer.vue
@@ -33,7 +33,7 @@
       <template #footer>
         <t-chat-sender
           v-model="inputValue"
-          :stop-disabled="isStreamLoad"
+          :loading="isStreamLoad"
           :textarea-props="{
             placeholder: '请输入消息...',
           }"

--- a/packages/pro-components/chat/_example/reasoning.vue
+++ b/packages/pro-components/chat/_example/reasoning.vue
@@ -31,7 +31,7 @@
       <template #footer>
         <t-chat-sender
           v-model="inputValue"
-          :stop-disabled="isStreamLoad"
+          :loading="isStreamLoad"
           :textarea-props="{
             placeholder: '请输入消息...',
           }"

--- a/packages/pro-components/chat/chat-sender-props.ts
+++ b/packages/pro-components/chat/chat-sender-props.ts
@@ -19,8 +19,16 @@ export default {
   prefix: {
     type: [String, Function] as PropType<TdChatSenderProps['prefix']>,
   },
-  /** 中止按钮是否可点击。等流式数据全部返回结束置为false，注意跟textLoading的控制时机不是同一个 */
-  stopDisabled: Boolean,
+  /** 是否加载中 */
+  stopDisabled: {
+    type: Boolean as PropType<TdChatSenderProps['stopDisabled']>,
+    default: false,
+  },
+  /** 是否加载中 */
+  loading: {
+    type: Boolean as PropType<TdChatSenderProps['loading']>,
+    default: false,
+  },
   /** 输入框右下角区域扩展 */
   suffix: {
     type: [String, Function] as PropType<TdChatSenderProps['suffix']>,

--- a/packages/pro-components/chat/chat-sender.tsx
+++ b/packages/pro-components/chat/chat-sender.tsx
@@ -23,8 +23,7 @@ export default defineComponent({
     const [textValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
 
     const focusFlag = ref(false);
-    const loading = ref(false);
-    const showStopBtn = computed(() => props.stopDisabled && loading.value);
+    const showStopBtn = computed(() => props.loading || props.stopDisabled);
     const disabled = computed(() => props.disabled || false);
     const uploadImageRef = ref(null);
     const uploadFileRef = ref(null);
@@ -34,13 +33,11 @@ export default defineComponent({
     const sendClick = (e: MouseEvent | KeyboardEvent) => {
       if (textValue.value && !disabled.value) {
         emit('send', textValue.value, { e });
-        loading.value = true;
       }
     };
     // 点击了停止按钮
     const handleStop = (e: MouseEvent) => {
       e.stopPropagation(); // 阻止事件冒泡
-      loading.value = false;
       emit('stop', textValue.value, {
         e,
       });

--- a/packages/pro-components/chat/chat-sender.tsx
+++ b/packages/pro-components/chat/chat-sender.tsx
@@ -3,7 +3,7 @@ import { SendFilledIcon, FileAttachmentIcon, ImageIcon } from 'tdesign-icons-vue
 import { Button, Textarea, Tooltip } from 'tdesign-vue-next';
 import { useConfig } from 'tdesign-vue-next/es/config-provider/hooks';
 
-import { usePrefixClass, useTNodeJSX, useContent, useVModel } from '@tdesign/hooks';
+import { usePrefixClass, useTNodeJSX, useVModel } from '@tdesign/hooks';
 import props from './chat-sender-props';
 
 import type { TdChatSenderProps, UploadActionType, UploadActionConfig } from './type';

--- a/packages/pro-components/chat/chat-sender.tsx
+++ b/packages/pro-components/chat/chat-sender.tsx
@@ -28,7 +28,6 @@ export default defineComponent({
     const uploadImageRef = ref(null);
     const uploadFileRef = ref(null);
     const renderTNodeJSX = useTNodeJSX();
-    const renderContent = useContent();
     // 点击了发送按钮
     const sendClick = (e: MouseEvent | KeyboardEvent) => {
       if (textValue.value && !disabled.value) {
@@ -218,14 +217,14 @@ export default defineComponent({
     };
     return () => (
       <div class={`${COMPONENT_NAME.value}-sender`}>
-        <div class={`${COMPONENT_NAME.value}-sender__header`}>{renderContent('default', 'header')}</div>
+        <div class={`${COMPONENT_NAME.value}-sender__header`}>{renderTNodeJSX('header')}</div>
         <div
           class={[
             `${COMPONENT_NAME.value}-sender__textarea`,
             focusFlag.value ? `${COMPONENT_NAME.value}-sender__textarea--focus` : '',
           ]}
         >
-          <div class={`${COMPONENT_NAME.value}-sender__inner-header`}>{renderContent('default', 'inner-header')}</div>
+          <div class={`${COMPONENT_NAME.value}-sender__inner-header`}>{renderTNodeJSX('inner-header')}</div>
           <Textarea
             ref={senderTextarea}
             value={textValue.value}
@@ -246,7 +245,7 @@ export default defineComponent({
             onCompositionend={compositionendFn}
           />
           <div class={`${COMPONENT_NAME.value}-sender__footer`}>
-            <div class={`${COMPONENT_NAME.value}-sender__mode`}>{renderContent('default', 'prefix')}</div>
+            <div class={`${COMPONENT_NAME.value}-sender__mode`}>{renderTNodeJSX('prefix')}</div>
             <div class={`${COMPONENT_NAME.value}-sender__button`}>
               {/* 发送按钮 */}
               <div class={`${COMPONENT_NAME.value}-sender__button__sendbtn`}>{renderSuffixIcon()}</div>

--- a/packages/pro-components/chat/type.ts
+++ b/packages/pro-components/chat/type.ts
@@ -273,10 +273,15 @@ export interface TdChatSenderProps {
    */
   prefix?: string | TNode;
   /**
-   * 中止按钮是否可点击。等流式数据全部返回结束置为false，注意跟textLoading的控制时机不是同一个
-   * @default false
+   * 请更为使用 `loading`
+   * @deprecated
    */
   stopDisabled?: boolean;
+  /**
+   * 是否加载中
+   * @default false
+   */
+  loading: boolean;
   /**
    * 输入框右下角区域扩展
    */

--- a/packages/tdesign-vue-next-chat/.changelog/pr-5595.md
+++ b/packages/tdesign-vue-next-chat/.changelog/pr-5595.md
@@ -1,0 +1,8 @@
+---
+pr_number: 5595
+contributor: zydemail
+---
+
+- feat(ChatSender):  新增`loading` API，用于控制按钮状态,  `stopDisabled` 将在未来版本废弃，请尽快使用`loading`替换⚠️ @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
+- fix(ChatSender): 修复`stopDisabled` 直接修改值不立即生效的问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
+- fix(ChatSender): 修复`header`、`innerHeader` 等插槽的传参问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))

--- a/packages/tdesign-vue-next-chat/.changelog/pr-5595.md
+++ b/packages/tdesign-vue-next-chat/.changelog/pr-5595.md
@@ -3,6 +3,6 @@ pr_number: 5595
 contributor: zydemail
 ---
 
-- feat(ChatSender):  新增`loading` API，用于控制按钮状态,  `stopDisabled` 将在未来版本废弃，请尽快使用`loading`替换⚠️ @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
-- fix(ChatSender): 修复`stopDisabled` 直接修改值不立即生效的问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
-- fix(ChatSender): 修复`header`、`innerHeader` 等插槽的传参问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
+- feat(ChatSender):  新增 `loading` API，用于控制按钮状态,  `stopDisabled` 将在未来版本废弃，请尽快使用 `loading` 替换⚠️ @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
+- fix(ChatSender): 修复 `stopDisabled` 直接修改值不立即生效的问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))
+- fix(ChatSender): 修复 `header`、`innerHeader` 等插槽的传参问题 @zydemail ([#5595](https://github.com/Tencent/tdesign-vue-next/pull/5595))


### PR DESCRIPTION
[ChatSender] 修复stopDisabled直接修改值不生效，需要调用发送事件才生效 #5258

closed #5258

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/5258 
### 💡 需求背景和解决方案
-  通过stopDisabled或者loading传入值来改变按钮状态
-  stopDisabled待废弃，请使用loading替代
### 📝 更新日志

#### @tdesign-vue-next/chat
- feat(ChatSender):  新增`loading` API，用于控制按钮状态,  `stopDisabled` 将在未来版本废弃，请尽快使用`loading`替换⚠️
- fix(ChatSender): 修复`stopDisabled` 直接修改值不立即生效的问题
- fix(ChatSender): 修复`header`、`innerHeader` 等插槽的传参问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
