### PR TITLE
fix(select): remote search retains the data of the selected option

### DIFF
--- a/packages/components/select/_example/remote-search.vue
+++ b/packages/components/select/_example/remote-search.vue
@@ -1,5 +1,5 @@
 <template>
-  <t-select v-model="value" multiple remote filterable @search="remoteMethod">
+  <t-select v-model="modelValue" multiple remote filterable @search="remoteMethod">
     <t-option v-for="{ label, value } in options" :key="value" :value="value" :label="label"> </t-option>
   </t-select>
 </template>
@@ -31,11 +31,11 @@ const wholeOptions = [
 ];
 
 const options = ref([]);
-const value = ref(['test1', 'test3']);
+const modelValue = ref(['test1', 'test3']);
 
 // 回显初始值
 const initValue = () => {
-  if (value.value) {
+  if (modelValue.value) {
     setTimeout(() => {
       options.value = wholeOptions;
     }, 500);

--- a/packages/components/select/_example/remote-search.vue
+++ b/packages/components/select/_example/remote-search.vue
@@ -1,105 +1,54 @@
 <template>
-  <t-space direction="vertical" :style="{ width: '350px' }">
-    <t-select
-      v-model="value"
-      filterable
-      placeholder="请选择"
-      :loading="loading"
-      :options="options"
-      @search="remoteMethod"
-    />
-    <t-select
-      v-model="multipleValue"
-      filterable
-      placeholder="请选择"
-      :loading="multipleLoading"
-      :options="multipleOptions"
-      multiple
-      value-type="object"
-      reserve-keyword
-      @search="remoteMultipleMethod"
-      @change="onChange"
-    />
-  </t-space>
+  <t-select v-model="value" multiple remote filterable @search="remoteMethod">
+    <t-option v-for="{ label, value } in options" :key="value" :value="value" :label="label"> </t-option>
+  </t-select>
 </template>
-
 <script setup>
-import { ref, toRaw } from 'vue';
+import { ref, onMounted } from 'vue';
+
+// 模拟远程全部数据
+const wholeOptions = [
+  {
+    value: `test1`,
+    label: `腾讯_test1`,
+  },
+  {
+    value: `test2`,
+    label: `腾讯_test2`,
+  },
+  {
+    value: `test3`,
+    label: `腾讯_test3`,
+  },
+  {
+    value: `test4`,
+    label: `腾讯_test4`,
+  },
+  {
+    value: `test5`,
+    label: `腾讯_test5`,
+  },
+];
 
 const options = ref([]);
-const value = ref('');
-const loading = ref(false);
+const value = ref(['test1', 'test3']);
 
-const multipleOptions = ref([]);
-const multipleValue = ref([]);
-const multipleLoading = ref(false);
+// 回显初始值
+const initValue = () => {
+  if (value.value) {
+    setTimeout(() => {
+      options.value = wholeOptions;
+    }, 500);
+  }
+};
 
 const remoteMethod = (search) => {
-  console.log('search', search);
-  if (search) {
-    loading.value = true;
-    setTimeout(() => {
-      loading.value = false;
-      options.value = [
-        {
-          value: `腾讯_test1`,
-          label: `腾讯_test1`,
-        },
-        {
-          value: `腾讯_test2`,
-          label: `腾讯_test2`,
-        },
-        {
-          value: `腾讯_test3`,
-          label: `腾讯_test3`,
-        },
-      ].filter((item) => item.label.includes(search));
-    }, 500);
-  }
+  setTimeout(() => {
+    options.value = wholeOptions.slice(0, 3).filter((item) => item.label.includes(search));
+    console.log('options', options);
+  }, 500);
 };
-
-const remoteMultipleMethod = (search) => {
-  console.log('search', search);
-  if (search) {
-    multipleLoading.value = true;
-    setTimeout(() => {
-      multipleLoading.value = false;
-      const remoteOptions = [
-        {
-          value: `腾讯_test1`,
-          label: `腾讯_test1`,
-        },
-        {
-          value: `腾讯_test2`,
-          label: `腾讯_test2`,
-        },
-        {
-          value: `腾讯_test3`,
-          label: `腾讯_test3`,
-        },
-        {
-          value: `腾讯_test1_1`,
-          label: `腾讯_test1_1`,
-        },
-        {
-          value: `腾讯_test2_2`,
-          label: `腾讯_test2_2`,
-        },
-        {
-          value: `腾讯_test3_3`,
-          label: `腾讯_test3_3`,
-        },
-      ].filter((item) => item.label.includes(search));
-
-      const rawMultipleValue = multipleValue.value.map((item) => toRaw(item));
-      const mergedOptions = [...remoteOptions, ...rawMultipleValue];
-      multipleOptions.value = Array.from(new Map(mergedOptions.map((item) => [item.value, item])).values());
-    }, 500);
-  } else {
-    multipleOptions.value = multipleValue.value;
-  }
-};
-const onChange = (value) => {
-  console.log('mergedOptions', value);
-};
+onMounted(() => {
+  initValue();
+});
 </script>

--- a/packages/components/select/hooks/useSelectOptions.ts
+++ b/packages/components/select/hooks/useSelectOptions.ts
@@ -125,23 +125,20 @@ export const useSelectOptions = (
     });
   };
 
-  const getSearchDisPlayOptions = () => {
-    const everyTimeSelectedOptions = getSelectedOptions(optionsList.value, orgValue.value);
+  /**
+   * @description 获取搜索结果选项
+   * 这里通过记录所有时间选中的 options 来保证搜索结果中选中的选项不会被过滤掉
+   */
+  const getSearchDisplayOptions = () => {
+    const currentSelectedOptions = getSelectedOptions(optionsList.value, orgValue.value);
+    searchOptions.value = uniqBy([...currentSelectedOptions, ...searchOptions.value], keys.value.value);
+    const searchSelectedOptions = getSelectedOptions(searchOptions.value, orgValue.value);
 
-    searchOptions.value = uniqBy([...everyTimeSelectedOptions, ...searchOptions.value], keys.value.value);
-
-    const currentSelectedOptions = getSelectedOptions(searchOptions.value, orgValue.value);
-    // console.log('currentSelectedOptions', currentSelectedOptions);
-
-    const disPlayOptions = uniqBy([...optionsList.value, ...currentSelectedOptions], keys.value.value);
-    // console.log('disPlayOptions', disPlayOptions);
-    return disPlayOptions;
+    return uniqBy([...optionsList.value, ...searchSelectedOptions], keys.value.value);
   };
 
   const displayOptions = computed(() => {
-    if (props.onSearch && props.filterable) return getSearchDisPlayOptions();
-
-    // if (props.onSearch && props.filterable) return options.value; // 远程搜索时，不执行内部的过滤，不干预用户的自行处理，如输入首字母搜索中文的场景等
+    if (props.onSearch && props.filterable) return getSearchDisplayOptions();
 
     if (!inputValue.value || !(props.filterable || isFunction(props.filter))) return options.value;
 
@@ -183,6 +180,6 @@ export const useSelectOptions = (
     optionsCache,
     displayOptions,
     filterMethods,
-    getSearchDisPlayOptions,
+    getSearchDisplayOptions,
   };
 };

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -59,11 +59,8 @@ export default defineComponent({
       value: props.keys?.value || 'value',
       disabled: props.keys?.disabled || 'disabled',
     }));
-    const { optionsMap, optionsList, optionsCache, displayOptions, filterMethods } = useSelectOptions(
-      props,
-      keys,
-      innerInputValue,
-    );
+    const { optionsMap, optionsList, optionsCache, displayOptions, filterMethods, getSearchDisPlayOptions } =
+      useSelectOptions(props, keys, innerInputValue, orgValue);
 
     // 内部数据,格式化过的
     const innerValue = computed(() => {
@@ -470,11 +467,19 @@ export default defineComponent({
     };
 
     const renderValueDisplay = () => {
+      // console.log('renderValueDisplay', !props.multiple, !props.selectInputProps?.multiple);
       const renderTag = () => {
+        // 这里判断有问题？
         if (!props.multiple || !props.selectInputProps?.multiple) {
           return undefined;
         }
-        const currentSelectedOptions = getCurrentSelectedOptions(innerValue.value);
+
+        // console.log(getSearchDisPlayOptions());
+
+        const currentSelectedOptions =
+          props.onSearch && props.filterable ? getSearchDisPlayOptions() : getCurrentSelectedOptions(innerValue.value);
+
+        // console.log('currentSelectedOptions', currentSelectedOptions);
         return innerValue.value
           .slice(0, props.minCollapsedNum ? props.minCollapsedNum : innerValue.value.length)
           .map?.((v: string, key: number) => {

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -59,7 +59,7 @@ export default defineComponent({
       value: props.keys?.value || 'value',
       disabled: props.keys?.disabled || 'disabled',
     }));
-    const { optionsMap, optionsList, optionsCache, displayOptions, filterMethods, getSearchDisPlayOptions } =
+    const { optionsMap, optionsList, optionsCache, displayOptions, filterMethods, getSearchDisplayOptions } =
       useSelectOptions(props, keys, innerInputValue, orgValue);
 
     // 内部数据,格式化过的
@@ -467,19 +467,14 @@ export default defineComponent({
     };
 
     const renderValueDisplay = () => {
-      // console.log('renderValueDisplay', !props.multiple, !props.selectInputProps?.multiple);
       const renderTag = () => {
-        // 这里判断有问题？
-        if (!props.multiple || !props.selectInputProps?.multiple) {
+        if (!props.multiple || props.selectInputProps?.multiple === false) {
           return undefined;
         }
 
-        // console.log(getSearchDisPlayOptions());
-
         const currentSelectedOptions =
-          props.onSearch && props.filterable ? getSearchDisPlayOptions() : getCurrentSelectedOptions(innerValue.value);
+          props.onSearch && props.filterable ? getSearchDisplayOptions() : getCurrentSelectedOptions(innerValue.value);
 
-        // console.log('currentSelectedOptions', currentSelectedOptions);
         return innerValue.value
           .slice(0, props.minCollapsedNum ? props.minCollapsedNum : innerValue.value.length)
           .map?.((v: string, key: number) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

对于 https://github.com/Tencent/tdesign-vue-next/pull/5594 这个判断进行了修复，这里应该使用显示判断（`props.selectInputProps?.multiple==='false'`）用户传入了 `props.selectInputProps?.multiple` 否则就会导致这里的判断在用户不传入此参数的情况下产生错误
（这个 pr 的 changelog 可以保留）


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--

--> 

- fix(select): 远程搜索保留已选中 option 的数据

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
