### PR TITLE
docs(alert): add  a button to redisplay alert component when it is closed in usage demo

### DIFF
--- a/packages/components/alert/_usage/index.vue
+++ b/packages/components/alert/_usage/index.vue
@@ -1,7 +1,13 @@
 <!-- 该脚本为自动生成，如有需要请在 /script/generate-usage/index.js 中调整 -->
 <template>
   <base-usage :code="usageCode" :config-list="configList" :panel-list="panelList" @panel-change="onPanelChange">
-    <template #alert="{ configProps }"><t-alert message="这是一条信息" v-bind="configProps" /></template>
+    <template #alert="{ configProps }">
+      <t-alert v-if="visible" message="这是一条信息" v-bind="configProps" @close="visible = false" />
+
+      <t-button v-if="!visible" size="small" theme="default" variant="outline" @click="showAlert">
+        显示 Alert
+      </t-button>
+    </template>
   </base-usage>
 </template>
 
@@ -18,5 +24,10 @@ const usageCode = ref(`<template>${usageCodeMap[panelList[0].value].trim()}</tem
 
 function onPanelChange(panel) {
   usageCode.value = `<template>${usageCodeMap[panel].trim()}</template>`;
+}
+
+const visible = ref(true);
+function showAlert() {
+  visible.value = true;
 }
 </script>

--- a/packages/tdesign-vue-next/.changelog/pr-5646.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5646.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5646
+contributor: baozjj
+---
+
+- docs(alert): 优化 Alert 演示交互，在关闭后显示“显示 Alert”按钮以恢复显示 @baozjj ([#5646](https://github.com/Tencent/tdesign-vue-next/pull/5646))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无。此改进由贡献者主动发现并提出。

### 💡 需求背景和解决方案

当前 Alert 组件演示中，开启 `close` 属性后，用户关闭 Alert 之后无法在页面上重新显示它。如果想查看其他配置效果，只能刷新页面，使用体验不够友好。 

本次改动在 Alert 被关闭时新增一个“显示 Alert”按钮，用户点击后可以无需刷新页面，直接恢复 Alert 显示，提升演示交互体验。 

该改动仅影响演示示例文件，不涉及组件本身逻辑。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- docs(alert): 优化 Alert 演示交互，在关闭后显示“显示 Alert”按钮以恢复显示

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
