### PR TITLE
fix(message): reuse message instance to fix overlapped messages and closeAll not working

### DIFF
--- a/packages/components/message/plugin.tsx
+++ b/packages/components/message/plugin.tsx
@@ -66,7 +66,7 @@ const MessageFunction = (props: MessageOptions, context?: AppContext): Promise<M
   }
   const p = instanceMap.get(attachDom)[placement] as ComponentPublicInstance;
   let mgKey: number;
-  if (!p || !attachDom.contains(p.$el)) {
+  if (!p || !attachDom.contains(p.component?.proxy?.$el)) {
     const wrapper = document.createElement('div');
 
     const instance = createVNode(MessageList, {
@@ -137,6 +137,7 @@ const extraApi: ExtraApi = {
       instanceMap.forEach((attach) => {
         Object.keys(attach).forEach((placement) => {
           const instance = attach[placement];
+          debugger;
           instance.component.exposed.removeAll();
         });
       });

--- a/packages/components/message/plugin.tsx
+++ b/packages/components/message/plugin.tsx
@@ -137,7 +137,6 @@ const extraApi: ExtraApi = {
       instanceMap.forEach((attach) => {
         Object.keys(attach).forEach((placement) => {
           const instance = attach[placement];
-          debugger;
           instance.component.exposed.removeAll();
         });
       });


### PR DESCRIPTION
Fix a regression introduced by switching from `createApp` to `createVNode`.  
Previously, instance existence was checked using `$el`, which is undefined on a VNode.  
This caused multiple `MessageList` instances to be created for the same `placement` (e.g. `'top'`).  
As a result, messages appeared overlapped instead of stacking vertically, and `closeAll` could not clear all messages as expected.  

Now, by using `component.proxy.$el` to check whether the instance is already mounted, the logic ensures only one instance is created per `placement`.  
This guarantees consistent stacking behavior and correct behavior of `closeAll`.

Closes #5559

---

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Closes #5559  
问题来源：切换为 `createVNode` 后，message 组件实例判断逻辑失效，导致多个 message 实例叠加。

### 💡 需求背景和解决方案

- **问题**：https://github.com/Tencent/tdesign-vue-next/pull/5559 在 `plugin.tsx` 中将消息组件由 `createApp` 改为 `createVNode` 创建后，原本用于判断是否已经存在实例的逻辑 `$el` 失效，导致同一位置（如 `top`）重复创建多个 `MessageList` 实例。
- **表现**：
  - 多个 message 重叠显示，而非正常垂直堆叠。
  - 调用 `closeAll` 时无法关闭所有消息。
- **解决方案**：
  - 修复判断条件为：使用 `p.component?.proxy?.$el` 或 `p.component?.vnode?.el` 判断 DOM 是否挂载。
  - 保证相同 `attach` + `placement` 只创建一个 `MessageList` 实例。
  - 所有消息添加到同一实例中。

### 📝 更新日志

- [ ] 本条 PR 需要纳入 Changelog

#### tdesign-vue-next

- `fix(message)`: 修复因 `createVNode` 替代 `createApp` 导致 message 实例重复创建的问题，确保消息正确堆叠，`closeAll` 正常工作。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
