### PR TITLE
feat(Pagination): Use Tooltip to replace title in navigation buttons

### DIFF
--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -2,6 +2,7 @@
 import { mount } from '@vue/test-utils';
 import { vi } from 'vitest';
 import { Select, Pagination } from '@tdesign/components';
+import TPaginationMini from '../pagination-mini';
 
 const defaultPaginationProps = {
   total: 100,
@@ -369,5 +370,46 @@ describe('Pagination', () => {
       });
       expect(wrapper.find('[data-testid="total-content"]').text()).toEqual('TOTAL');
     });
+  });
+});
+
+describe('TPaginationMini with Tooltip', () => {
+  it('should render Tooltip with correct content when tips enabled', () => {
+    const wrapper = mount(TPaginationMini, {
+      props: {
+        tips: { prev: '上一页', current: '当前页', next: '下一页' },
+        showCurrent: true,
+      },
+    });
+
+    const tooltips = wrapper.findAllComponents({ name: 'TTooltip' });
+    expect(tooltips).toHaveLength(3);
+    expect(tooltips[0].props('content')).toBe('上一页');
+    expect(tooltips[1].props('content')).toBe('当前页');
+    expect(tooltips[2].props('content')).toBe('下一页');
+  });
+
+  it('should not render Tooltip when tips is false', () => {
+    const wrapper = mount(TPaginationMini, {
+      props: {
+        tips: false,
+        showCurrent: true,
+      },
+    });
+
+    const tooltips = wrapper.findAllComponents({ name: 'TTooltip' });
+    expect(tooltips.length).toBe(0);
+  });
+
+  it('should pass showArrow=false to Tooltip', () => {
+    const wrapper = mount(TPaginationMini, {
+      props: {
+        tips: { prev: '上一页' },
+      },
+    });
+
+    const tooltip = wrapper.findComponent({ name: 'TTooltip' });
+    expect(tooltip.exists()).toBe(true);
+    expect(tooltip.props('showArrow')).toBe(false);
   });
 });

--- a/packages/components/pagination/pagination-mini.tsx
+++ b/packages/components/pagination/pagination-mini.tsx
@@ -12,6 +12,7 @@ import props from './pagination-mini-props';
 import { useGlobalIcon, usePrefixClass } from '@tdesign/shared-hooks';
 
 import TButton from '../button';
+import TTooltip from '../tooltip';
 
 export default defineComponent({
   name: 'TPaginationMini',
@@ -46,6 +47,15 @@ export default defineComponent({
       return { prev: false, current: false, next: false };
     });
 
+    const renderWithTooltip = (content: string | undefined, node: JSX.Element) => {
+      if (!content) return node;
+      return (
+        <TTooltip content={content} showArrow={false}>
+          {node}
+        </TTooltip>
+      );
+    };
+
     return () => {
       const jumperClass = [
         COMPONENT_NAME.value,
@@ -56,40 +66,45 @@ export default defineComponent({
 
       return (
         <div class={jumperClass}>
-          <TButton
-            title={titleConfig.value.prev}
-            variant={props.variant}
-            size={props.size}
-            shape="square"
-            onClick={(e) => props.onChange?.({ e, trigger: 'prev' })}
-            icon={props.layout === 'horizontal' ? () => <ChevronLeftIcon /> : () => <ChevronUpIcon />}
-            class={`${COMPONENT_NAME.value}__prev`}
-            disabled={disabledConfig.value.prev}
-          />
-
-          {props.showCurrent && (
+          {renderWithTooltip(
+            titleConfig.value.prev,
             <TButton
-              title={titleConfig.value.current}
               variant={props.variant}
               size={props.size}
               shape="square"
-              onClick={(e) => props.onChange?.({ e, trigger: 'current' })}
-              icon={() => <RoundIcon />}
-              class={`${COMPONENT_NAME.value}__current`}
-              disabled={disabledConfig.value.current}
-            />
+              onClick={(e) => props.onChange?.({ e, trigger: 'prev' })}
+              icon={props.layout === 'horizontal' ? () => <ChevronLeftIcon /> : () => <ChevronUpIcon />}
+              class={`${COMPONENT_NAME.value}__prev`}
+              disabled={disabledConfig.value.prev}
+            />,
           )}
 
-          <TButton
-            title={titleConfig.value.next}
-            variant={props.variant}
-            size={props.size}
-            shape="square"
-            onClick={(e) => props.onChange?.({ e, trigger: 'next' })}
-            icon={props.layout === 'horizontal' ? () => <ChevronRightIcon /> : () => <ChevronDownIcon />}
-            class={`${COMPONENT_NAME.value}__next`}
-            disabled={disabledConfig.value.next}
-          />
+          {props.showCurrent &&
+            renderWithTooltip(
+              titleConfig.value.current,
+              <TButton
+                variant={props.variant}
+                size={props.size}
+                shape="square"
+                onClick={(e) => props.onChange?.({ e, trigger: 'current' })}
+                icon={() => <RoundIcon />}
+                class={`${COMPONENT_NAME.value}__current`}
+                disabled={disabledConfig.value.current}
+              />,
+            )}
+
+          {renderWithTooltip(
+            titleConfig.value.next,
+            <TButton
+              variant={props.variant}
+              size={props.size}
+              shape="square"
+              onClick={(e) => props.onChange?.({ e, trigger: 'next' })}
+              icon={props.layout === 'horizontal' ? () => <ChevronRightIcon /> : () => <ChevronDownIcon />}
+              class={`${COMPONENT_NAME.value}__next`}
+              disabled={disabledConfig.value.next}
+            />,
+          )}
         </div>
       );
     };

--- a/packages/tdesign-vue-next/.changelog/pr-5670.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5670.md
@@ -1,0 +1,7 @@
+---
+pr_number: 5670
+contributor: baozjj
+---
+
+- feat(pagination): 使用 `Tooltip` 显示提示文案 @baozjj ([#5670](https://github.com/Tencent/tdesign-vue-next/pull/5670))
+- test(pagination): add unit tests for tooltip behavior @baozjj ([#5670](https://github.com/Tencent/tdesign-vue-next/pull/5670))

--- a/packages/tdesign-vue-next/.changelog/pr-5670.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5670.md
@@ -3,5 +3,4 @@ pr_number: 5670
 contributor: baozjj
 ---
 
-- feat(pagination): 使用 `Tooltip` 显示提示文案 @baozjj ([#5670](https://github.com/Tencent/tdesign-vue-next/pull/5670))
-- test(pagination): add unit tests for tooltip behavior @baozjj ([#5670](https://github.com/Tencent/tdesign-vue-next/pull/5670))
+- feat(Pagination): 优化 `PaginationMini`  的显示提示文案展示 @baozjj ([#5670](https://github.com/Tencent/tdesign-vue-next/pull/5670))


### PR DESCRIPTION
…ini navigation buttons

Replace native browser title attributes with TDesign Tooltip component to improve visual consistency and user experience. Configured `showArrow=false` in TTooltip to match the original native title behavior. Added unit tests to verify tooltip rendering and configuration behavior.

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在 TPaginationMini 组件中，上一页 / 当前 / 下一页按钮原使用原生 `title` 提示，样式与 TDesign 视觉体系不统一，且其样式不可控，在不同浏览器和系统下表现不一致，可能影响整体视觉统一性。TDesign 本身有提供 Tooltip 组件，所以我在想是否可以用它来替代原生 title。

本 PR 使用 TDesign 提供的 `<TTooltip>` 组件替代 `title` 属性，提升提示体验与一致性：

- 配置 `showArrow=false`，以复现原生 title 的纯文本提示体验；
- 同时补充对应的单元测试，覆盖显示逻辑与 props 配置行为。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- feat(Pagination): 优化 `PaginationMini`  的显示提示文案展示

#### @tdesign-vue-next/chat

<!-- 暂无涉及 -->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
