### PR TITLE
fix(message): support closeBtn="" to render default close icon

### DIFF
--- a/packages/components/message/__tests__/message.test.tsx
+++ b/packages/components/message/__tests__/message.test.tsx
@@ -66,4 +66,52 @@ describe('Message', () => {
       expect(onDurationEnd).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Message closeBtn prop', () => {
+    it('renders default close icon when closeBtn is empty string', () => {
+      const wrapper = mount(Message, {
+        props: { closeBtn: '' },
+      });
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(true);
+    });
+
+    it('renders default close icon when closeBtn is true', () => {
+      const wrapper = mount(Message, {
+        props: { closeBtn: true },
+      });
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(true);
+    });
+
+    it('does not render close button when closeBtn is false', () => {
+      const wrapper = mount(Message, {
+        props: { closeBtn: false },
+      });
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(false);
+    });
+
+    it('renders custom closeBtn string', () => {
+      const customText = '关闭';
+      const wrapper = mount(Message, {
+        props: { closeBtn: customText },
+      });
+      expect(wrapper.find('.t-message__close').text()).toBe(customText);
+    });
+
+    it('renders custom closeBtn function vnode', () => {
+      const customVNode = () => <button class="custom-close">X</button>;
+      const wrapper = mount(Message, {
+        props: { closeBtn: customVNode },
+      });
+      expect(wrapper.find('button.custom-close').exists()).toBe(true);
+    });
+
+    it('renders default close icon if closeBtn not passed but slot exists', () => {
+      const wrapper = mount(Message, {
+        slots: {
+          closeBtn: '<button class="slot-close">Close</button>',
+        },
+      });
+      expect(wrapper.find('button.slot-close').exists()).toBe(true);
+    });
+  });
 });

--- a/packages/components/message/message.tsx
+++ b/packages/components/message/message.tsx
@@ -47,7 +47,7 @@ export default defineComponent({
         COMPONENT_NAME.value,
         status,
         {
-          [`${classPrefix.value}-is-closable`]: props.closeBtn || slots.closeBtn,
+          [`${classPrefix.value}-is-closable`]: props.closeBtn || props.closeBtn === '' || slots.closeBtn,
         },
       ];
     });

--- a/packages/shared/hooks/tnode/index.ts
+++ b/packages/shared/hooks/tnode/index.ts
@@ -76,7 +76,6 @@ export const useTNodeJSX = () => {
     const isSlotFirst = getSlotFirst(options);
     // 插槽
     const renderSlot = instance.slots[camelCase(name)] || instance.slots[kebabCase(name)];
-
     if (isSlotFirst && renderSlot) {
       // 1. 如果显示设置了 slot 优先，并且存在 slot，那么优先使用 slot
       return handleSlots(instance, name, renderParams);
@@ -85,7 +84,8 @@ export const useTNodeJSX = () => {
       // 2.1 处理主动传入的 prop
       if (isPropExplicitlySet(instance, name)) {
         // 2.1.1 如果有传，那么优先使用 prop 的值
-        const propsNode = instance.props[camelCase(name)] || instance.props[kebabCase(name)];
+        const propsNode = instance.props[camelCase(name)] ?? instance.props[kebabCase(name)];
+
         // 如果该属性的类型有多种且包含 Boolean 和 Slot 的情况下，处理 boolean casting true 的场景
         // https://vuejs.org/guide/components/props.html#boolean-casting
         const types = instance.type.props[name]?.type;


### PR DESCRIPTION
Fixes an inconsistency between Alert and Message components. In Vue, when passing a boolean prop without a value (e.g., `<Comp closeBtn />`), it is treated as `closeBtn=""`, which is considered truthy. This behavior works in Alert, but not in Message due to use of `||` when reading props.  
Empty string was treated as falsy and caused the logic to fail. Now replaced `||` with `??` in `useTNodeJSX` to preserve `""`.  
Also updated the `-is-closable` class logic in Message to correctly reflect `closeBtn=""`. Open to further suggestions on improving the class condition.

Notably, the following code snippet in `useTNodeJSX` 89-96:
```ts
// If the prop type is a union including Boolean and Function, handle boolean casting as per Vue rules
// https://vuejs.org/guide/components/props.html#boolean-casting
if (types?.length > 1) {
  if (types.includes(Boolean) && types.includes(Function)) {
    if (propsNode === '' && !renderSlot) return defaultNode;
  }
}
```
reflects an intention to align with Vue's boolean casting behavior.
However, due to the use of || when reading the prop value:

```ts
const propsNode = instance.props[camelCase(name)] || instance.props[kebabCase(name)];
```

the empty string '' is treated as falsy and this intended behavior is not achieved.
Replacing || with ?? fixes this and brings useTNodeJSX in line with Vue's rules.

BREAKING CHANGE: Changed behavior in `useTNodeJSX` when prop is passed as an empty string. Previously, empty string values (e.g., `closeBtn=""`) were treated as falsy. Now they are preserved and considered as explicitly set, which may affect rendering in some components.

<!--
首先，感谢你的贡献！😄  
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。  
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue


1. 该问题由 Alert 和 Message 组件 `closeBtn` 行为不一致引起。
2. Vue 中布尔 prop 传入无值时应被视为真值。
3. Message 组件未正确处理该情况，导致关闭按钮无法显示。


### 💡 需求背景和解决方案

1. Vue 规则说明：在模板中 `<Comp closeBtn />` 等价于 `closeBtn=""`，其应视为真值。
2. Message 组件中 `useTNodeJSX` 函数中，读取 prop 时使用 `||` 导致 `""` 被视为假值，无法触发关闭按钮渲染。
3. 解决方案是将 `||` 改为 `??`，保持空字符串的显式性。
4. 另外修正 Message 组件关闭按钮 CSS class 逻辑，确保 `closeBtn=""` 时添加可关闭样式。
5. 保持与 Alert 组件行为一致，避免用户混淆。

- 修复 Message 组件 `closeBtn=""` 时关闭按钮不显示的问题
- 优化 `useTNodeJSX` 中 props 读取逻辑，正确处理空字符串值
- 调整 Message 组件关闭按钮样式判断，兼容空字符串值
- 统一 Alert 与 Message 组件的 `closeBtn` 语义行为
- 添加相关单元测试覆盖

### 📝 更新日志

#### tdesign-vue-next
- fix(message): 修复 closeBtn 为空字符串时关闭按钮不显示问题

#### @tdesign-vue-next/chat

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
