### PR TITLE
fix: 表格内内容编辑切换页时数据丢失问题

### DIFF
--- a/packages/components/table/components/editable-cell.tsx
+++ b/packages/components/table/components/editable-cell.tsx
@@ -1,5 +1,5 @@
 import { computed, defineComponent, onMounted, PropType, ref, SetupContext, toRefs, watch } from 'vue';
-import { get, set, isFunction, cloneDeep, isObject } from 'lodash-es';
+import { get, set, isFunction, isObject } from 'lodash-es';
 import { Edit1Icon as TdEdit1Icon } from 'tdesign-icons-vue-next';
 import {
   TableRowData,
@@ -121,7 +121,7 @@ export default defineComponent({
       const [firstKey, ...restKeys] = colKey.split('.') || [];
       const newRow = { ...row.value };
       if (restKeys.length) {
-        newRow[firstKey] = cloneDeep(row.value[firstKey]);
+        newRow[firstKey] = row.value[firstKey];
         set(newRow[firstKey], restKeys.join('.'), editValue.value);
       } else {
         set(newRow, colKey, editValue.value);

--- a/packages/components/table/hooks/useEditableRow.ts
+++ b/packages/components/table/hooks/useEditableRow.ts
@@ -1,5 +1,5 @@
 import { ref, computed, watch, toRefs } from 'vue';
-import { get, set, cloneDeep, isFunction } from 'lodash-es';
+import { get, set, isFunction } from 'lodash-es';
 
 import { PrimaryTableProps } from '../types';
 import { getEditableKeysMap } from '@tdesign/common-js/table/utils';
@@ -142,7 +142,7 @@ export default function useRowEdit(props: PrimaryTableProps) {
   /** 更新编辑态单元格数据 */
   const onUpdateEditedCell = (rowValue: any, lastRowData: TableRowData, data: { [key: string]: any }) => {
     if (!editedFormData.value[rowValue]) {
-      editedFormData.value[rowValue] = cloneDeep(lastRowData);
+      editedFormData.value[rowValue] = lastRowData;
     }
     Object.entries(data).forEach(([key, val]) => {
       set(editedFormData.value[rowValue], key, val);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [✓] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 表格内内容编辑切换页时数据会丢失
2. 复现地址：https://stackblitz.com/edit/pgds6ust-urj1exbv?file=package.json,src%2Fdemo.vue
-->

### 💡 需求背景和解决方案

<!--
1. 去除深拷贝引用
-->

### 📝 更新日志

- [✓] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(table): 修复表格内内容编辑切换页时数据会丢失问题
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [✓] 文档已补充或无须补充
- [✓ 代码演示已提供或无须提供
- [✓] TypeScript 定义已补充或无须补充
- [✓] Changelog 已提供或无须提供
