### PR TITLE
fix(chat-input): clear shift flag after blur

### DIFF
--- a/packages/pro-components/chat/chat-input.tsx
+++ b/packages/pro-components/chat/chat-input.tsx
@@ -51,6 +51,7 @@ export default defineComponent({
       setInnerValue(value, context);
     };
     const blurFn = (value: string, context: { e: FocusEvent }) => {
+      shiftDownFlag = false;
       emit('blur', value, context);
     };
     const focusFn = (value: string, context: { e: FocusEvent }) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5709

### 💡 需求背景和解决方案

在输入框失焦时清除 shift 标识

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
fix(chat-input): 修复使用含 shift 的快捷键导致输入框失焦后，shift 标识未取消的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
