### PR TITLE
fix(Cascader): fix label margin area trigger change event

### DIFF
--- a/packages/components/checkbox/checkbox.tsx
+++ b/packages/components/checkbox/checkbox.tsx
@@ -135,7 +135,7 @@ export default defineComponent({
     const renderContent = useContent();
 
     const handleLabelClick = (e: MouseEvent) => {
-      // 在tree等组件中使用  阻止label触发checked 与expand冲突
+      // 在 Tree、Cascader 等组件中使用  阻止 label触发 checked 与非叶子节点的 expand 冲突
       if (props.stopLabelTrigger) e.preventDefault();
     };
 
@@ -151,6 +151,7 @@ export default defineComponent({
           tabindex={isDisabled.value ? undefined : '0'}
           onFocus={onCheckboxFocus}
           onBlur={onCheckboxBlur}
+          onClick={handleLabelClick}
           title={titleAttr}
         >
           {!showCheckbox.value
@@ -169,8 +170,12 @@ export default defineComponent({
                   onChange={handleChange}
                   key="input"
                 ></input>,
-                <span class={`${COMPONENT_NAME.value}__input`} key="input-span"></span>,
-                <span class={`${COMPONENT_NAME.value}__label`} key="label" onClick={handleLabelClick}>
+                <span
+                  class={`${COMPONENT_NAME.value}__input`}
+                  key="input-span"
+                  onClick={props.stopLabelTrigger && handleChange} // stopLabelTrigger 情况下，仍需保证真正的 input 触发 change
+                />,
+                <span class={`${COMPONENT_NAME.value}__label`} key="label">
                   {renderContent('default', 'label')}
                 </span>,
               ]}

--- a/packages/tdesign-vue-next/.changelog/pr-5748.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5748.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5748
+contributor: uyarn
+---
+
+- fix(Cascader): 优化点击 Cascader 非叶子节点选项的部分区域错误触发选中的问题 @uyarn ([#5748](https://github.com/Tencent/tdesign-vue-next/pull/5748))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/issues/5739
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 💡 需求背景和解决方案
- https://github.com/Tencent/tdesign-common/pull/2123 
- 优化margin实现暴露的问题，但实际此前的实现就有缺陷，点击任意margin 都可能存在此问题，调整 stoplabelTrigger至外层节点确保不触发；配合真实Input 直接触发change 保证功能正常运行
### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Cascader): 优化点击 Cascader 非叶子节点选项的部分区域错误触发选中的问题


#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
