### PR TITLE
fix(select): selected option can be removed when form is disabled

### DIFF
--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -504,7 +504,7 @@ export default defineComponent({
             return (
               <Tag
                 key={key}
-                closable={!option?.disabled && !props.disabled && !props.readonly}
+                closable={!option?.disabled && !isDisabled.value && !isReadonly.value}
                 size={props.size}
                 {...props.tagProps}
                 onClose={({ e }: { e: MouseEvent }) => {

--- a/packages/tdesign-vue-next/.changelog/pr-5775.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5775.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5775
+contributor: An0510
+---
+
+- fix(Select): 修复 Form 设置为 disabled 或 readonly 时，多选选项仍可删除的错误 @An0510 ([#5775](https://github.com/Tencent/tdesign-vue-next/pull/5775))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/5762

### 💡 需求背景和解决方案
具体问题：要解决的问题是Form表单设置disabled/readonly时，多选select选中项还显示删除按钮，点击还能删除选中项
解决方案：多选Select的选中项的删除按钮判断显隐时考虑Form设置的disabled/readonly，使用hook返回的字段判断

### 📝 更新日志
修复了Form设置为disabled或readonly时，其中的多选Select组件在disabled/readonly时标签存在删除按钮且可以删除标签的问题。
- [ ] 本条 PR 不需要纳入 Changelog


#### tdesign-vue-next

- fix(Select): 修复 Form 设置为 disabled 或 readonly 时，多选选项仍可删除的错误


#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
--> 

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
