### PR TITLE
fix(select): fix keys alias restore onChange params

### DIFF
--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -203,6 +203,7 @@ describe('Select', () => {
         expect(value.value).toBe([]);
       });
     });
+    // TODO: rename describe name
     describe('onChange #5779', () => {
       it('should trigger onChange with correct data', async () => {
         const onChangeFn = vi.fn();

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { ref } from 'vue';
+import { ref, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { vi, describe, it, expect } from 'vitest';
 import { Select, OptionGroup, Option } from '@tdesign/components/select';
@@ -202,6 +202,73 @@ describe('Select', () => {
         expect(fn).toBeCalled();
         expect(value.value).toBe([]);
       });
+    });
+    describe('onChange', () => {
+      it('should trigger onChange with correct data', async () => {
+        const onChangeFn = vi.fn();
+        const value = ref('');
+        const wrapper = mount({
+          render() {
+            return <Select v-model={value.value} onChange={onChangeFn} options={options} />;
+          },
+        });
+
+        const input = wrapper.find('.t-input');
+        await input.trigger('click');
+        await wrapper.setProps({ popupProps: { visible: true } });
+
+        const panelNode = document.querySelector('.t-select__list');
+        // 点击普通选项（跳过第一个全选特殊项）
+        const secondOption = panelNode.querySelectorAll('.t-select-option')[1];
+        secondOption.click();
+
+        // 等待Vue响应式更新
+        await nextTick();
+
+        // 验证onChange回调参数
+        expect(onChangeFn).toHaveBeenCalled();
+        expect(onChangeFn.mock.calls[0][0]).toEqual(options[1].value); // 验证选中的值
+        expect(onChangeFn.mock.calls[0][1]?.option).toEqual(expect.objectContaining(options[1])); // 验证选中的选项对象
+
+        panelNode.parentNode.removeChild(panelNode);
+      });
+    });
+  });
+
+  describe('keys', () => {
+    const contentOptions = [
+      { name: '架构云', content: '1' },
+      { name: '大数据', content: '2' },
+      { name: '区块链', content: '3' },
+    ];
+
+    const keys = {
+      label: 'name',
+      value: 'content',
+    };
+    it('content in option #5779', async () => {
+      const value = ref('');
+      const wrapper = mount({
+        render() {
+          return <Select v-model={value.value} options={contentOptions} keys={keys}></Select>;
+        },
+      });
+      const input = wrapper.find('.t-input');
+      await input.trigger('mouseenter');
+
+      await wrapper.setProps({ popupProps: { visible: true } });
+      const panelNode = document.querySelector('.t-select__list');
+
+      // 验证第一个选项的name
+      const firstOption = panelNode.querySelectorAll('.t-select-option')?.[0];
+      expect(firstOption.textContent).toContain('架构云');
+
+      firstOption.click();
+
+      // 验证选中的值是否为1
+      expect(value.value).toBe('1');
+
+      panelNode.parentNode.removeChild(panelNode);
     });
   });
 });

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -203,7 +203,7 @@ describe('Select', () => {
         expect(value.value).toBe([]);
       });
     });
-    describe('onChange', () => {
+    describe('onChange #5779', () => {
       it('should trigger onChange with correct data', async () => {
         const onChangeFn = vi.fn();
         const value = ref('');

--- a/packages/components/select/_example/multiple.vue
+++ b/packages/components/select/_example/multiple.vue
@@ -6,10 +6,9 @@
       :options="options1"
       placeholder="请选择云解决方案"
       multiple
-      :keys="{ label: 'customLabel', value: 'customValue' }"
+      filterable
       @focus="onFocus"
       @blur="onBlur"
-      @change="onchange"
     />
 
     <!-- 方式二：使用 t-option 输出下拉选项。options 和 t-option 两种实现方式二选一即可 -->
@@ -33,16 +32,16 @@
 import { ref } from 'vue';
 
 const options1 = [
-  { customLabel: '全选', checkAll: true },
-  { customLabel: '架构云', customValue: '1' },
-  { customLabel: '大数据', customValue: '2' },
-  { customLabel: '区块链', customValue: '3' },
-  { customLabel: '物联网', customValue: '4', disabled: true },
-  { customLabel: '人工智能', customValue: '5' },
+  { label: '全选', checkAll: true },
+  { label: '架构云', value: '1' },
+  { label: '大数据', value: '2' },
+  { label: '区块链', value: '3' },
+  { label: '物联网', value: '4', disabled: true },
+  { label: '人工智能', value: '5' },
   // 可以使用渲染函数自定义下拉选项内容和样式
   {
-    customLabel: '计算场景',
-    customValue: '6',
+    label: '计算场景',
+    value: '6',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     content: (h) => <span>计算场景（高性能计算）</span>,
   },
@@ -66,9 +65,5 @@ const onFocus = (ctx) => {
 
 const onBlur = (ctx) => {
   console.log('blur:', ctx);
-};
-
-const onchange = (value, options) => {
-  console.log('change:', value, options);
 };
 </script>

--- a/packages/components/select/_example/multiple.vue
+++ b/packages/components/select/_example/multiple.vue
@@ -6,9 +6,10 @@
       :options="options1"
       placeholder="请选择云解决方案"
       multiple
-      filterable
+      :keys="{ label: 'customLabel', value: 'customValue' }"
       @focus="onFocus"
       @blur="onBlur"
+      @change="onchange"
     />
 
     <!-- 方式二：使用 t-option 输出下拉选项。options 和 t-option 两种实现方式二选一即可 -->
@@ -32,16 +33,16 @@
 import { ref } from 'vue';
 
 const options1 = [
-  { label: '全选', checkAll: true },
-  { label: '架构云', value: '1' },
-  { label: '大数据', value: '2' },
-  { label: '区块链', value: '3' },
-  { label: '物联网', value: '4', disabled: true },
-  { label: '人工智能', value: '5' },
+  { customLabel: '全选', checkAll: true },
+  { customLabel: '架构云', customValue: '1' },
+  { customLabel: '大数据', customValue: '2' },
+  { customLabel: '区块链', customValue: '3' },
+  { customLabel: '物联网', customValue: '4', disabled: true },
+  { customLabel: '人工智能', customValue: '5' },
   // 可以使用渲染函数自定义下拉选项内容和样式
   {
-    label: '计算场景',
-    value: '6',
+    customLabel: '计算场景',
+    customValue: '6',
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     content: (h) => <span>计算场景（高性能计算）</span>,
   },
@@ -65,5 +66,9 @@ const onFocus = (ctx) => {
 
 const onBlur = (ctx) => {
   console.log('blur:', ctx);
+};
+
+const onchange = (value, options) => {
+  console.log('change:', value, options);
 };
 </script>

--- a/packages/components/select/components/select-panel.tsx
+++ b/packages/components/select/components/select-panel.tsx
@@ -73,7 +73,10 @@ export default defineComponent({
                 </OptionGroup>
               );
             }
-            const option = [keys?.['value'], keys.value?.['label'], keys.value?.['disabled']].includes('content')
+
+            // 如果keys中有content，则移除 content 渲染
+            const keysValue = keys.value;
+            const option = [keysValue?.['value'], keysValue?.['label'], keysValue?.['disabled']].includes('content')
               ? omit(item, 'index', '$index', 'className', 'tagName', 'content')
               : omit(item, 'index', '$index', 'className', 'tagName');
 

--- a/packages/components/select/components/select-panel.tsx
+++ b/packages/components/select/components/select-panel.tsx
@@ -5,28 +5,29 @@ import { Styles } from '../../common';
 import { SelectOption, SelectOptionGroup, TdOptionProps } from '../type';
 import Option from '../option';
 import OptionGroup from '../option-group';
-import TdSelectProps from '../props';
+import tdSelectProps from '../props';
 
 import { useConfig, useTNodeJSX, usePrefixClass, useTNodeDefault } from '@tdesign/shared-hooks';
 
 import { usePanelVirtualScroll } from '../hooks';
 import { selectInjectKey } from '../consts';
+import type { TdSelectProps } from '../type';
 
 export default defineComponent({
   name: 'TSelectPanel',
   props: {
-    inputValue: TdSelectProps.inputValue,
-    panelTopContent: TdSelectProps.panelTopContent,
-    panelBottomContent: TdSelectProps.panelBottomContent,
-    empty: TdSelectProps.empty,
-    creatable: TdSelectProps.creatable,
-    loading: TdSelectProps.loading,
-    loadingText: TdSelectProps.loadingText,
-    multiple: TdSelectProps.multiple,
-    filterable: TdSelectProps.filterable,
-    filter: TdSelectProps.filter,
-    scroll: TdSelectProps.scroll,
-    size: TdSelectProps.size,
+    inputValue: tdSelectProps.inputValue,
+    panelTopContent: tdSelectProps.panelTopContent,
+    panelBottomContent: tdSelectProps.panelBottomContent,
+    empty: tdSelectProps.empty,
+    creatable: tdSelectProps.creatable,
+    loading: tdSelectProps.loading,
+    loadingText: tdSelectProps.loadingText,
+    multiple: tdSelectProps.multiple,
+    filterable: tdSelectProps.filterable,
+    filter: tdSelectProps.filter,
+    scroll: tdSelectProps.scroll,
+    keys: tdSelectProps.keys,
   },
   setup(props, { expose }) {
     const COMPONENT_NAME = usePrefixClass('select');
@@ -35,6 +36,7 @@ export default defineComponent({
     const { t, globalConfig } = useConfig('select');
     const tSelect = inject(selectInjectKey);
     const innerRef = ref<HTMLElement>(null);
+    const keys = computed(() => props.keys as TdSelectProps['keys']);
 
     const popupContentRef = computed(() => tSelect.value.popupContentRef.value);
     const showCreateOption = computed(() => props.creatable && props.filterable && props.inputValue);
@@ -71,9 +73,13 @@ export default defineComponent({
                 </OptionGroup>
               );
             }
+            const option = [keys?.['value'], keys.value?.['label'], keys.value?.['disabled']].includes('content')
+              ? omit(item, 'index', '$index', 'className', 'tagName', 'content')
+              : omit(item, 'index', '$index', 'className', 'tagName');
+
             return (
               <Option
-                {...omit(item, 'index', '$index', 'className', 'tagName')}
+                {...option}
                 {...(isVirtual.value
                   ? {
                       rowIndex: item.$index,

--- a/packages/components/select/components/select-panel.tsx
+++ b/packages/components/select/components/select-panel.tsx
@@ -74,13 +74,12 @@ export default defineComponent({
               );
             }
 
-            // 如果 keys 中刚好有 content，则移除 content 渲染 https://github.com/Tencent/tdesign-vue-next/issues/5088
             const defaultOmit = ['index', '$index', 'className', 'tagName'];
 
             const { value, label, disabled } = keys.value || {};
-            const option = [value, label, disabled].includes('content')
-              ? omit(item, defaultOmit.concat('content'))
-              : omit(item, defaultOmit);
+            // 如果 keys 中刚好有 content，则移除 content 渲染 https://github.com/Tencent/tdesign-vue-next/issues/5088
+            const shouldOmitContent = [value, label, disabled].includes('content');
+            const option = omit(item, defaultOmit.concat(shouldOmitContent ? 'content' : []));
 
             return (
               <Option

--- a/packages/components/select/components/select-panel.tsx
+++ b/packages/components/select/components/select-panel.tsx
@@ -5,29 +5,29 @@ import { Styles } from '../../common';
 import { SelectOption, SelectOptionGroup, TdOptionProps } from '../type';
 import Option from '../option';
 import OptionGroup from '../option-group';
-import tdSelectProps from '../props';
+import TdSelectProps from '../props';
 
 import { useConfig, useTNodeJSX, usePrefixClass, useTNodeDefault } from '@tdesign/shared-hooks';
 
 import { usePanelVirtualScroll } from '../hooks';
 import { selectInjectKey } from '../consts';
-import type { TdSelectProps } from '../type';
+import type { TdSelectProps as SelectProps } from '../type';
 
 export default defineComponent({
   name: 'TSelectPanel',
   props: {
-    inputValue: tdSelectProps.inputValue,
-    panelTopContent: tdSelectProps.panelTopContent,
-    panelBottomContent: tdSelectProps.panelBottomContent,
-    empty: tdSelectProps.empty,
-    creatable: tdSelectProps.creatable,
-    loading: tdSelectProps.loading,
-    loadingText: tdSelectProps.loadingText,
-    multiple: tdSelectProps.multiple,
-    filterable: tdSelectProps.filterable,
-    filter: tdSelectProps.filter,
-    scroll: tdSelectProps.scroll,
-    keys: tdSelectProps.keys,
+    inputValue: TdSelectProps.inputValue,
+    panelTopContent: TdSelectProps.panelTopContent,
+    panelBottomContent: TdSelectProps.panelBottomContent,
+    empty: TdSelectProps.empty,
+    creatable: TdSelectProps.creatable,
+    loading: TdSelectProps.loading,
+    loadingText: TdSelectProps.loadingText,
+    multiple: TdSelectProps.multiple,
+    filterable: TdSelectProps.filterable,
+    filter: TdSelectProps.filter,
+    scroll: TdSelectProps.scroll,
+    keys: TdSelectProps.keys,
   },
   setup(props, { expose }) {
     const COMPONENT_NAME = usePrefixClass('select');
@@ -36,7 +36,7 @@ export default defineComponent({
     const { t, globalConfig } = useConfig('select');
     const tSelect = inject(selectInjectKey);
     const innerRef = ref<HTMLElement>(null);
-    const keys = computed(() => props.keys as TdSelectProps['keys']);
+    const keys = computed(() => props.keys as SelectProps['keys']);
 
     const popupContentRef = computed(() => tSelect.value.popupContentRef.value);
     const showCreateOption = computed(() => props.creatable && props.filterable && props.inputValue);
@@ -74,11 +74,13 @@ export default defineComponent({
               );
             }
 
-            // 如果keys中有content，则移除 content 渲染
-            const keysValue = keys.value;
-            const option = [keysValue?.['value'], keysValue?.['label'], keysValue?.['disabled']].includes('content')
-              ? omit(item, 'index', '$index', 'className', 'tagName', 'content')
-              : omit(item, 'index', '$index', 'className', 'tagName');
+            // 如果 keys 中刚好有 content，则移除 content 渲染 https://github.com/Tencent/tdesign-vue-next/issues/5088
+            const defaultOmit = ['index', '$index', 'className', 'tagName'];
+
+            const { value, label, disabled } = keys.value || {};
+            const option = [value, label, disabled].includes('content')
+              ? omit(item, defaultOmit.concat('content'))
+              : omit(item, defaultOmit);
 
             return (
               <Option

--- a/packages/components/select/hooks/useSelectOptions.ts
+++ b/packages/components/select/hooks/useSelectOptions.ts
@@ -1,5 +1,5 @@
 import { computed, Slots, Ref, ref } from 'vue';
-import { get, omit, isArray, isFunction, uniqBy } from 'lodash-es';
+import { get, isArray, isFunction, uniqBy } from 'lodash-es';
 
 import { useChildComponentSlots } from '@tdesign/shared-hooks';
 import { TdSelectProps, TdOptionProps, SelectOptionGroup, SelectValue, SelectOption } from '../type';
@@ -26,9 +26,8 @@ export const useSelectOptions = (
       props.options?.map((option) => {
         const getFormatOption = (option: TdOptionProps) => {
           const { value, label, disabled } = keys.value;
-          const restOption = omit(option, [value, label, disabled]) as Partial<TdOptionProps>;
           const res = {
-            ...restOption,
+            ...option,
             index: dynamicIndex,
             label: get(option, label),
             value: get(option, value),

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -636,6 +636,7 @@ export default defineComponent({
                     'panelBottomContent',
                     'filter',
                     'scroll',
+                    'keys',
                   ])}
                   inputValue={innerInputValue.value}
                   v-slots={slots}

--- a/packages/tdesign-vue-next-chat/.changelog/pr-5779.md
+++ b/packages/tdesign-vue-next-chat/.changelog/pr-5779.md
@@ -3,5 +3,4 @@ pr_number: 5779
 contributor: RSS1102
 ---
 
-- fix(select): 解决 keys 别名出现 `content` 冲突的问题 @RSS1102 ([#5779](https://github.com/Tencent/tdesign-vue-next/pull/5779))
-- fix(select): 恢复 onChange 的 `conte.option` 参数数据 @RSS1102 ([#5779](https://github.com/Tencent/tdesign-vue-next/pull/5779))
+- fix(Select): 修复 onChange 回调参数中涉及 keys 别名丢失的问题 @RSS1102 ([#5779](https://github.com/Tencent/tdesign-vue-next/pull/5779))

--- a/packages/tdesign-vue-next-chat/.changelog/pr-5779.md
+++ b/packages/tdesign-vue-next-chat/.changelog/pr-5779.md
@@ -1,0 +1,7 @@
+---
+pr_number: 5779
+contributor: RSS1102
+---
+
+- fix(select): 解决 keys 别名出现 `content` 冲突的问题 @RSS1102 ([#5779](https://github.com/Tencent/tdesign-vue-next/pull/5779))
+- fix(select): 恢复 onChange 的 `conte.option` 参数数据 @RSS1102 ([#5779](https://github.com/Tencent/tdesign-vue-next/pull/5779))


### PR DESCRIPTION
…meter content in option data

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

Related https://github.com/Tencent/tdesign-vue-next/pull/5199

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

- fix(select): 解决 keys 别名出现 `content` 冲突的问题
- fix(select): 恢复 onChange 的 `conte.option` 参数数据

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
