### PR TITLE
test(card): improve card test coverage

### DIFF
--- a/packages/components/card/__tests__/card.test.tsx
+++ b/packages/components/card/__tests__/card.test.tsx
@@ -1,6 +1,6 @@
-import { mount } from '@vue/test-utils';
-import { it, expect } from 'vitest';
 import Card from '@tdesign/components/card';
+import { mount } from '@vue/test-utils';
+import { expect, it } from 'vitest';
 
 // every component needs four parts: props/events/slots/functions.
 describe('Card', () => {
@@ -114,6 +114,11 @@ describe('Card', () => {
       expect(cover.element.getAttribute('src')).toBe(src);
     });
 
+    it(':cover:slot', () => {
+      const wrapper = mount(() => <Card v-slots={{ cover: <span class="custom-node" /> }} />);
+      expect(wrapper.find('.custom-node').exists()).toBeTruthy();
+    });
+
     it(':actions', () => {
       const wrapper = mount(() => <Card actions="actions">卡片内容</Card>);
       const actions = wrapper.find('.t-card__actions');
@@ -128,6 +133,11 @@ describe('Card', () => {
       expect(loading.exists()).toBeTruthy();
       expect(svg.exists()).toBeTruthy();
       expect(svg.classes()).toContain('t-icon-loading');
+    });
+
+    it(':loading:slot', () => {
+      const wrapper = mount(() => <Card v-slots={{ loading: <span class="custom-node" /> }} />);
+      expect(wrapper.find('.custom-node').exists()).toBeTruthy();
     });
 
     it(':loadingProps', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5631

### 覆盖率变更

<img width="227" height="52" alt="Clipboard_Screenshot_1753781503" src="https://github.com/user-attachments/assets/1786988c-6ebd-4dd5-b1f2-ff51848f2c78" />


提升 Card 组件 Branches 覆盖率 98.63% Branches 72/73

<img width="709" height="119" alt="Clipboard_Screenshot_1753781353" src="https://github.com/user-attachments/assets/d6d4d0a7-9abb-4e16-84e5-59cb4793829f" />


覆盖率应该是 100%
怀疑计算覆盖率工具有点问题

<img width="863" height="207" alt="Clipboard_Screenshot_1753781413" src="https://github.com/user-attachments/assets/c215907b-6dad-410a-bd69-63f9a0dbbf8b" />


