### PR TITLE
fix(date-picker): fix incorrect week highlight when switching years i…

### DIFF
--- a/packages/components/date-picker/components/base/Table.tsx
+++ b/packages/components/date-picker/components/base/Table.tsx
@@ -71,10 +71,11 @@ export default defineComponent({
         };
       }
 
+      const valueDayjs = parseToDayjs(value, props.format).locale(dayjsLocale);
+      const targetDayjs = parseToDayjs(targetValue, props.format).locale(dayjsLocale);
       return {
         [`${COMPONENT_NAME.value}-${props.mode}-row--active`]:
-          parseToDayjs(value, props.format).locale(dayjsLocale).week() ===
-          parseToDayjs(targetValue, props.format).locale(dayjsLocale).week(),
+          valueDayjs.year() === targetDayjs.year() && valueDayjs.week() === targetDayjs.week(),
       };
     };
 


### PR DESCRIPTION
### ✨ Commit Message

fix(date-picker): fix incorrect week highlight when switching years in single-week mode

Fixes a bug where, in single-week selection mode, the same week number remained highlighted after switching to a different year.
This occurred because the highlight logic did not account for the year when comparing the selected value.
Now, the highlight appears only when both the year and week number match.

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
如果有相关 issue，可填写链接，例如：
Fixes #1234
-->

### 💡 需求背景和解决方案

在 `DatePicker` 的单周选择模式中，切换年份时依旧会高亮原先选中的周数，哪怕年份不同，这会导致用户误解。
本 PR 修复了该问题，确保只有在“年份 + 周数”完全匹配时才高亮。
![20250729194222_rec_](https://github.com/user-attachments/assets/62aece1a-ec09-4250-8b03-30f7ac5e6547)
这是修复后的效果
![20250729194415_rec_](https://github.com/user-attachments/assets/05834495-dce6-47b8-8e8c-2c17270ef8d7)

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(date-picker): 修复单周模式下切换年份时高亮仍显示的问题

#### @tdesign-vue-next/chat

<!-- 暂无相关改动 -->

#### @tdesign-vue-next/auto-import-resolver

<!-- 暂无相关改动 -->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并**勾选全部选项** ⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
