### PR TITLE
fix(ColorPicker): reduce multiple color conversions to minimize errors

### DIFF
--- a/packages/components/color-picker/components/panel/index.tsx
+++ b/packages/components/color-picker/components/panel/index.tsx
@@ -107,7 +107,10 @@ export default defineComponent({
         const newMode = getModeByColor(newColor);
         mode.value = newMode;
         color.value.isGradient = newMode === 'linear-gradient';
-        color.value.update(newColor);
+        const currentColor = color.value.getFormattedColor(props.format, props.enableAlpha);
+        if (currentColor !== newColor) {
+          color.value.update(newColor);
+        }
       },
     );
 

--- a/packages/components/color-picker/components/panel/slider.tsx
+++ b/packages/components/color-picker/components/panel/slider.tsx
@@ -42,9 +42,10 @@ export default defineComponent({
         return;
       }
       const left = Math.round((props.value / props.maxValue) * 100);
+      const color = props.type === 'hue' ? `hsl(${props.color.hue}, 100%, 50%)` : props.color.rgba;
       return {
         left: `${left}%`,
-        color: props.color.rgb,
+        color,
       };
     });
 

--- a/packages/tdesign-vue-next/.changelog/pr-5814.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5814.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5814
+contributor: RylanBot
+---
+
+- fix(ColorPicker): 减少颜色跨色彩空间的多次转换，降低误差 @RylanBot ([#5814](https://github.com/Tencent/tdesign-vue-next/pull/5814))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

色相(Hue)滑动条上的点频繁跳跃：
- 该点由 `color.hsv` 的 `h` 控制
- RGB -> HSV -> RGB，色彩在转换过程中存在小数点误差，多次累计后偏差越来越大

https://github.com/user-attachments/assets/5db5f794-483d-4a3b-be8e-22fee1a09379

---

此外，优化了一下滑动条上的点的颜色显示，三个点的颜色代表意义是不同的，不应该统一设为最终的显示数值

<img width="40%" src="https://github.com/user-attachments/assets/795e261e-3435-4934-877a-a87a70c0ff8d" />

<img width="40%" src="https://github.com/user-attachments/assets/32dc13ef-12f2-4f48-8c3e-45d22c618200" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(ColorPicker): 减少颜色跨色彩空间的多次转换，降低误差

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
