### PR TITLE
fix(ColorPicker): remove unused visibility state and related logic

### DIFF
--- a/packages/components/color-picker/color-picker.tsx
+++ b/packages/components/color-picker/color-picker.tsx
@@ -1,7 +1,7 @@
 import { defineComponent, ref, toRefs } from 'vue';
 import { useDefaultValue, useTNodeDefault, useVModel } from '@tdesign/shared-hooks';
 
-import { Popup as TPopup } from '../popup';
+import { type PopupProps, Popup as TPopup } from '../popup';
 import ColorPanel from './components/panel';
 import DefaultTrigger from './components/trigger';
 import { useBaseClassName } from './hooks';
@@ -47,10 +47,10 @@ export default defineComponent({
 
     return () => {
       const popProps = {
-        placement: 'bottom-left',
-        trigger: 'click',
+        placement: 'bottom-left' as const,
+        trigger: 'click' as const,
         overlayClassName: [baseClassName.value],
-        ...((props.popupProps as any) || {}),
+        ...((props.popupProps as PopupProps) || {}),
       };
       return (
         <TPopup {...popProps} content={renderPopupContent}>

--- a/packages/components/color-picker/color-picker.tsx
+++ b/packages/components/color-picker/color-picker.tsx
@@ -1,11 +1,11 @@
 import { defineComponent, ref, toRefs } from 'vue';
-import { useVModel, useDefaultValue, useTNodeDefault } from '@tdesign/shared-hooks';
+import { useDefaultValue, useTNodeDefault, useVModel } from '@tdesign/shared-hooks';
 
-import props from './props';
 import { Popup as TPopup } from '../popup';
 import ColorPanel from './components/panel';
 import DefaultTrigger from './components/trigger';
 import { useBaseClassName } from './hooks';
+import props from './props';
 
 export default defineComponent({
   name: 'TColorPicker',
@@ -13,8 +13,6 @@ export default defineComponent({
   setup(props) {
     const baseClassName = useBaseClassName();
     const renderTNodeJSXDefault = useTNodeDefault();
-    const visible = ref(false);
-    const setVisible = (value: boolean) => (visible.value = value);
 
     const { value: inputValue, modelValue, recentColors } = toRefs(props);
     const [innerValue, setInnerValue] = useVModel(inputValue, modelValue, props.defaultValue, props.onChange);
@@ -50,28 +48,13 @@ export default defineComponent({
     return () => {
       const popProps = {
         placement: 'bottom-left',
-        ...((props.popupProps as any) || {}),
         trigger: 'click',
-        attach: 'body',
         overlayClassName: [baseClassName.value],
-        visible: visible.value,
-        overlayInnerStyle: {
-          padding: 0,
-        },
-        onVisibleChange: (
-          visible: boolean,
-          context: {
-            trigger: string;
-          },
-        ) => {
-          if (context.trigger === 'document') {
-            setVisible(false);
-          }
-        },
+        ...((props.popupProps as any) || {}),
       };
       return (
         <TPopup {...popProps} content={renderPopupContent}>
-          <div class={`${baseClassName.value}__trigger`} onClick={() => setVisible(!visible.value)} ref={refTrigger}>
+          <div class={`${baseClassName.value}__trigger`} ref={refTrigger}>
             {renderTNodeJSXDefault(
               'default',
               <DefaultTrigger

--- a/packages/components/color-picker/components/panel/header.tsx
+++ b/packages/components/color-picker/components/panel/header.tsx
@@ -1,11 +1,11 @@
 import { defineComponent, PropType, ref, watch } from 'vue';
 
-import props from '../../color-picker-panel-props';
 import { COLOR_MODES } from '@tdesign/common-js/color-picker/constants';
-import { RadioGroup as TRadioGroup, RadioButton as TRadioButton } from '../../../radio';
-import { TdColorModes } from '../../types';
-import { useBaseClassName } from '../../hooks';
 import { useConfig } from '@tdesign/shared-hooks';
+import { RadioButton as TRadioButton, RadioGroup as TRadioGroup } from '../../../radio';
+import props from '../../color-picker-panel-props';
+import { useBaseClassName } from '../../hooks';
+import type { TdColorModes } from '../../types';
 
 export default defineComponent({
   name: 'PanelHeader',
@@ -14,9 +14,6 @@ export default defineComponent({
     mode: {
       type: String as PropType<TdColorModes>,
       default: 'color',
-    },
-    togglePopup: {
-      type: Function,
     },
     onModeChange: {
       type: Function,

--- a/packages/components/color-picker/components/panel/index.tsx
+++ b/packages/components/color-picker/components/panel/index.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref, toRefs, watch, computed } from 'vue';
+import { computed, defineComponent, ref, toRefs, watch } from 'vue';
 import { cloneDeep, isNull, isUndefined } from 'lodash-es';
 import {
   Color,
@@ -10,26 +10,23 @@ import {
   initColorFormat,
   TD_COLOR_USED_COLORS_MAX_SIZE,
 } from '@tdesign/common-js/color-picker/index';
-import { useConfig, useVModel, useDefaultValue, useCommonClassName } from '@tdesign/shared-hooks';
+import { useCommonClassName, useConfig, useDefaultValue, useVModel } from '@tdesign/shared-hooks';
 import props from '../../color-picker-panel-props';
+import { useBaseClassName } from '../../hooks';
+import type { ColorPickerChangeTrigger, TdColorPickerProps } from '../../type';
+import type { TdColorModes } from '../../types';
+import FormatPanel from '../format';
+import AlphaSlider from './alpha';
 import PanelHeader from './header';
+import HueSlider from './hue';
 import LinearGradient from './linear-gradient';
 import SaturationPanel from './saturation';
-import HueSlider from './hue';
-import AlphaSlider from './alpha';
-import FormatPanel from '../format';
 import SwatchesPanel from './swatches';
-import type { TdColorPickerProps, ColorPickerChangeTrigger } from '../../type';
-import type { TdColorModes } from '../../types';
-import { useBaseClassName } from '../../hooks';
 
 export default defineComponent({
   name: 'ColorPanel',
   props: {
     ...props,
-    togglePopup: {
-      type: Function,
-    },
   },
   setup(props) {
     const baseClassName = useBaseClassName();

--- a/packages/tdesign-vue-next/.changelog/pr-5839.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5839.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5839
+contributor: RylanBot
+---
+
+- fix(ColorPicker): 修复 `popupProps.onVisibleChange` 回调函数不执行 @RylanBot ([#5839](https://github.com/Tencent/tdesign-vue-next/pull/5839))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue-next/issues/5837

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

-  `...((props.popupProps as any) || {})` 应该放在最后面，否则无法被用户自定义的属性覆盖
- 实际上这个组件也不需要让 `visible` 受控...让 `Popup` 内部自己控制即可 

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(ColorPicker): 修复 `popupProps.onVisibleChange` 回调函数不执行

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
