### PR TITLE
fix(input): prevent onEnter event during IME composition

### DIFF
--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -394,6 +394,32 @@ describe('Input Component', () => {
     expect(onEnterFn1.mock.calls[0][1].e.type).toBe('keydown');
   });
 
+  it('events.enter should not trigger during IME composition', async () => {
+    const onEnterFn = vi.fn();
+    const wrapper = mount(<Input value="text" onEnter={onEnterFn}></Input>);
+    const input = wrapper.find('input');
+
+    // 模拟中文输入法开始
+    input.trigger('compositionstart');
+    await wrapper.vm.$nextTick();
+
+    // 在输入法激活状态下按回车键，不应该触发 onEnter 事件
+    input.trigger('keydown.enter');
+    await wrapper.vm.$nextTick();
+    expect(onEnterFn).not.toHaveBeenCalled();
+
+    // 模拟中文输入法结束
+    input.trigger('compositionend');
+    await wrapper.vm.$nextTick();
+
+    // 输入法结束后按回车键，应该正常触发 onEnter 事件
+    input.trigger('keydown.enter');
+    await wrapper.vm.$nextTick();
+    expect(onEnterFn).toHaveBeenCalled(1);
+    expect(onEnterFn.mock.calls[0][0]).toBe('text');
+    expect(onEnterFn.mock.calls[0][1].e.type).toBe('keydown');
+  });
+
   it('events.focus works fine', async () => {
     const onFocusFn = vi.fn();
     const wrapper = mount(<Input onFocus={onFocusFn}></Input>);

--- a/packages/components/input/hooks/useInputEventHandler.ts
+++ b/packages/components/input/hooks/useInputEventHandler.ts
@@ -2,13 +2,16 @@ import { Ref } from 'vue';
 import { TdInputProps } from './../type';
 import { getOutputValue } from './useInput';
 
-export function useInputEventHandler(props: TdInputProps, isHover: Ref<Boolean>) {
+export function useInputEventHandler(props: TdInputProps, isHover: Ref<Boolean>, isComposition?: Ref<boolean>) {
   const handleKeydown = (e: KeyboardEvent) => {
     if (props.disabled) return;
     const { code } = e;
     const tmpValue = getOutputValue((e.currentTarget as HTMLInputElement).value, props.type);
     if (/enter/i.test(code) || /enter/i.test(e.key)) {
-      props.onEnter?.(tmpValue, { e });
+      // 修复中文输入法回车键冲突：在中文输入法激活时不触发onEnter事件
+      if (!isComposition?.value) {
+        props.onEnter?.(tmpValue, { e });
+      }
     } else {
       props.onKeydown?.(tmpValue, { e });
     }

--- a/packages/components/input/input.tsx
+++ b/packages/components/input/input.tsx
@@ -70,7 +70,7 @@ export default defineComponent({
 
     const { inputPreRef } = useInputWidth(props, inputRef, innerValue);
 
-    const inputEventHandler = useInputEventHandler(props, isHover);
+    const inputEventHandler = useInputEventHandler(props, isHover, isComposition);
 
     const tPlaceholder = computed(() => props.placeholder ?? globalConfig.value.placeholder);
     const inputAttrs = computed(() => {

--- a/packages/tdesign-vue-next/.changelog/pr-5862.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5862.md
@@ -1,0 +1,6 @@
+---
+pr_number: 5862
+contributor: dhj-l
+---
+
+- fix(Input): 修复中文输入法激活时不触发 `onEnter` 事件的问题 @dhj-l ([#5862](https://github.com/Tencent/tdesign-vue-next/pull/5862))


### PR DESCRIPTION
在 `useInputEventHandler` 中添加 `isComposition` 检查以防止回车键事件
在中文输入法输入过程中
将 `useInput` 中的 `isComposition` 状态传递给 `useInputEventHandler`
- 添加测试用例以验证输入法组合行为
修复了表格筛选组件的问题，即按回车键会同时触发两个操作
输入法提交和过滤确认

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- #5860

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

- fix(Input): 修复中文输入法激活时不触发 `onEnter` 事件的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
