### PR TITLE
feat(card): props增加header/body/content的class和style支持

### DIFF
--- a/packages/components/card/card.tsx
+++ b/packages/components/card/card.tsx
@@ -28,9 +28,9 @@ export default defineComponent({
 
     const headerCls = computed(() => {
       const defaultClass = [`${COMPONENT_NAME.value}__header`];
-      return props.headerBordered
-        ? defaultClass.concat(`${COMPONENT_NAME.value}__title--bordered`)
-        : [`${COMPONENT_NAME.value}__header`];
+      if (props.headerBordered) defaultClass.push(`${COMPONENT_NAME.value}__title--bordered`);
+      if (props.headerClass) defaultClass.push(props.headerClass);
+      return defaultClass;
     });
 
     const headerWrapperCls = usePrefixClass('card__header-wrapper');
@@ -40,7 +40,16 @@ export default defineComponent({
     const headerDescriptionCls = usePrefixClass('card__description');
     const actionsCls = usePrefixClass('card__actions');
 
-    const bodyCls = usePrefixClass('card__body');
+    const bodyCls = computed(() => {
+      const defaultClass = [usePrefixClass('card__body').value];
+      if (props.bodyClass) defaultClass.push(props.bodyClass);
+      return defaultClass;
+    });
+    const contentCls = computed(() => {
+      const defaultClass = [usePrefixClass('card__content').value];
+      if (props.contentClass) defaultClass.push(props.contentClass);
+      return defaultClass;
+    });
     const coverCls = usePrefixClass('card__cover');
     const footerCls = usePrefixClass('card__footer');
     const footerWrapperCls = usePrefixClass('card__footer-wrapper');
@@ -78,9 +87,15 @@ export default defineComponent({
 
     // 头部区域渲染逻辑
     const renderHeader = () => {
-      if (showHeader.value) return <div class={headerCls.value}>{renderTNodeJSX('header')}</div>;
+      if (showHeader.value) {
+        return (
+          <div class={headerCls.value} style={props.headerStyle as any}>
+            {renderTNodeJSX('header')}
+          </div>
+        );
+      }
       return (
-        <div class={headerCls.value}>
+        <div class={headerCls.value} style={props.headerStyle as any}>
           <div class={headerWrapperCls.value}>
             {showAvatar.value && <div class={headerAvatarCls.value}>{renderTNodeJSX('avatar')}</div>}
             <div>
@@ -107,7 +122,11 @@ export default defineComponent({
           {isHeaderRender.value ? renderHeader() : null}
           {showCover.value ? renderCover() : null}
           {showContent.value && (
-            <div class={bodyCls.value}>{renderTNodeJSX('default') || renderTNodeJSX('content')}</div>
+            <div class={bodyCls.value} style={props.bodyStyle as any}>
+              <div class={contentCls.value} style={props.contentStyle as any}>
+                {renderTNodeJSX('default') || renderTNodeJSX('content')}
+              </div>
+            </div>
           )}
           {isFooterRender.value && (
             <div class={footerCls.value}>

--- a/packages/components/card/props.ts
+++ b/packages/components/card/props.ts
@@ -21,6 +21,22 @@ export default {
     type: Boolean,
     default: true,
   },
+  /** 卡片内容区域自定义类名 */
+  bodyClass: {
+    type: String as PropType<TdCardProps['bodyClass']>,
+  },
+  /** body区域自定义样式 */
+  bodyStyle: {
+    type: Object as PropType<TdCardProps['bodyStyle']>,
+  },
+  /** content区域自定义类名 */
+  contentClass: {
+    type: String as PropType<TdCardProps['contentClass']>,
+  },
+  /** content区域自定义样式 */
+  contentStyle: {
+    type: Object as PropType<TdCardProps['contentStyle']>,
+  },
   /** 卡片内容 */
   content: {
     type: [String, Function] as PropType<TdCardProps['content']>,
@@ -44,6 +60,14 @@ export default {
   /** 卡片顶部内容，优先级高于其他所有元素 */
   header: {
     type: [String, Function] as PropType<TdCardProps['header']>,
+  },
+  /** 卡片顶部区域自定义类名 */
+  headerClass: {
+    type: String as PropType<TdCardProps['headerClass']>,
+  },
+  /** 卡片顶部区域自定义样式 */
+  headerStyle: {
+    type: Object as PropType<TdCardProps['headerStyle']>,
   },
   /** 头部是否带分割线，仅在有header时有效 */
   headerBordered: Boolean,

--- a/packages/components/card/type.ts
+++ b/packages/components/card/type.ts
@@ -22,6 +22,22 @@ export interface TdCardProps {
    */
   bordered?: boolean;
   /**
+   * 卡片内容区域自定义类名
+   */
+  bodyClass?: string;
+  /**
+   * 卡片内容区域自定义样式
+   */
+  bodyStyle?: Record<string, any>;
+  /**
+   * content区域自定义类名
+   */
+  contentClass?: string;
+  /**
+   * content区域自定义样式
+   */
+  contentStyle?: Record<string, any>;
+  /**
    * 卡片内容
    */
   content?: string | TNode;
@@ -45,6 +61,14 @@ export interface TdCardProps {
    * 卡片顶部内容，优先级高于其他所有元素
    */
   header?: string | TNode;
+  /**
+   * 卡片顶部区域自定义类名
+   */
+  headerClass?: string;
+  /**
+   * 卡片顶部区域自定义样式
+   */
+  headerStyle?: Record<string, any>;
   /**
    * 头部是否带分割线，仅在有header时有效
    * @default false


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ - ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/5836


### 💡 需求背景和解决方案
方案：把内部属性暴露包装一下暴露出来。
API: 
bodyClass
bodyStyle
contentClass
contentStyle
headerClass
headerStyle
尾缀为Class的传入字符串，尾缀为Style的传入为Record<string, any>

### 📝 更新日志

card组件支持通过props方式自定义header/content/body样式

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ - ] 文档已补充或无须补充
- [ - ] 代码演示已提供或无须提供
- [ - ] TypeScript 定义已补充或无须补充
- [ - ] Changelog 已提供或无须提供
