### PR TITLE
fix(table): firefox not support minWidth

### DIFF
--- a/packages/components/table/base-table.tsx
+++ b/packages/components/table/base-table.tsx
@@ -370,6 +370,13 @@ export default defineComponent({
             };
             if (col.minWidth) {
               style.minWidth = formatCSSUnit(col.minWidth);
+
+              // 不支持 minWidth 的浏览器需设置 width
+              // 判断是否为火狐浏览器
+              const isNotSupportMinWidth = Boolean(navigator.userAgent.toLowerCase().includes('firefox'));
+              if (isNotSupportMinWidth) {
+                style.width = style.minWidth;
+              }
             }
             // 没有设置任何宽度的场景下，需要保留表格正常显示的最小宽度，否则会出现因宽度过小的抖动问题
             if (!style.width && !col.minWidth && props.tableLayout === 'fixed') {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/4997

### 💡 需求背景和解决方案

火狐浏览器兼容性，TableCol 的 minWidth 属性无效。在不支持minWidth的浏览器中，自动将minWidth属性改为width。

<img width="661" height="485" alt="image" src="https://github.com/user-attachments/assets/766844a0-2a85-4f39-8526-e881ecd7f405" />


### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(table): firefox not support minWidth

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [] Changelog 已提供或无须提供
