### PR TITLE
fix(notification): 修复 NotifyPlugin.close 错误触发 onCloseBtnClick 的问题

### DIFF
--- a/packages/components/notification/_example/plugin.vue
+++ b/packages/components/notification/_example/plugin.vue
@@ -4,8 +4,6 @@
       <p>插件调用</p>
       <!-- this.$notify 和 this.$notification 都支持，两者等价 -->
       <t-space>
-        <t-button @click="openNotify"> 打开通知 </t-button>
-        <t-button @click="closeNotify"> 关闭通知 </t-button>
         <t-button
           variant="outline"
           @click="
@@ -115,24 +113,5 @@ const iconRender = () => {
       }}
     />
   );
-};
-
-let notifyInstance = null;
-
-const openNotify = () => {
-  notifyInstance = NotifyPlugin.info({
-    title: '标题',
-    content: '用户表示普通操作信息提示',
-    closeBtn: true,
-    onCloseBtnClick: () => {
-      console.log('[NotifyPlugin] onCloseBtnClick 被触发（点击关闭按钮）');
-    },
-  });
-};
-
-const closeNotify = () => {
-  if (notifyInstance) {
-    NotifyPlugin.close(notifyInstance);
-  }
 };
 </script>

--- a/packages/components/notification/_example/plugin.vue
+++ b/packages/components/notification/_example/plugin.vue
@@ -4,6 +4,8 @@
       <p>插件调用</p>
       <!-- this.$notify 和 this.$notification 都支持，两者等价 -->
       <t-space>
+        <t-button @click="openNotify"> 打开通知 </t-button>
+        <t-button @click="closeNotify"> 关闭通知 </t-button>
         <t-button
           variant="outline"
           @click="
@@ -113,5 +115,24 @@ const iconRender = () => {
       }}
     />
   );
+};
+
+let notifyInstance = null;
+
+const openNotify = () => {
+  notifyInstance = NotifyPlugin.info({
+    title: '标题',
+    content: '用户表示普通操作信息提示',
+    closeBtn: true,
+    onCloseBtnClick: () => {
+      console.log('[NotifyPlugin] onCloseBtnClick 被触发（点击关闭按钮）');
+    },
+  });
+};
+
+const closeNotify = () => {
+  if (notifyInstance) {
+    NotifyPlugin.close(notifyInstance);
+  }
 };
 </script>

--- a/packages/components/notification/notification-list.tsx
+++ b/packages/components/notification/notification-list.tsx
@@ -73,6 +73,12 @@ export default defineComponent({
           }
           return remove(index);
         },
+        onClose: () => {
+          if (item.onClose) {
+            item.onClose();
+          }
+          return remove(index);
+        },
       };
     };
 

--- a/packages/components/notification/notification.en-US.md
+++ b/packages/components/notification/notification.en-US.md
@@ -14,6 +14,7 @@ footer | String / Slot / Function | - | Typescript：`string \| TNode`。[see mo
 icon | Boolean / Slot / Function | true | Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 theme | String | info | options: info/success/warning/error。Typescript：`NotificationThemeList` `type NotificationThemeList = 'info' \| 'success' \| 'warning' \| 'error'`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/notification/type.ts) | N
 title | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
+onClose | Function |  | Typescript：：`() => void`<br/> the callback event of NotificationPlugin.close | N
 onCloseBtnClick | Function |  | Typescript：`(context: { e: MouseEvent }) => void`<br/> | N
 onDurationEnd | Function |  | Typescript：`() => void`<br/> | N
 
@@ -21,6 +22,7 @@ onDurationEnd | Function |  | Typescript：`() => void`<br/> | N
 
 name | params | description
 -- | -- | --
+close |  \- | the callback event of NotificationPlugin.close
 close-btn-click | `(context: { e: MouseEvent })` | \-
 duration-end | \- | \-
 

--- a/packages/components/notification/notification.md
+++ b/packages/components/notification/notification.md
@@ -27,6 +27,7 @@ footer | String / Slot / Function | - | 用于自定义底部内容。TS 类型�
 icon | Boolean / Slot / Function | true | 用于自定义消息通知前面的图标，优先级大于 theme 设定的图标。值为 false 则不显示图标，值为 true 显示 theme 设定图标。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
 theme | String | info | 消息类型。可选项：info/success/warning/error。TS 类型：`NotificationThemeList` `type NotificationThemeList = 'info' \| 'success' \| 'warning' \| 'error'`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/notification/type.ts) | N
 title | String / Slot / Function | - | 标题。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
+onClose | Function |  | TS 类型：`() => void`<br/>调用 NotificationPlugin.close 的事件回调 | N
 onCloseBtnClick | Function |  | TS 类型：`(context: { e: MouseEvent }) => void`<br/>点击关闭按钮时触发 | N
 onDurationEnd | Function |  | TS 类型：`() => void`<br/>计时结束时触发 | N
 
@@ -34,6 +35,7 @@ onDurationEnd | Function |  | TS 类型：`() => void`<br/>计时结束时触发
 
 名称 | 参数 | 描述
 -- | -- | --
+close |  \- | 调用 NotificationPlugin.close 的事件回调
 close-btn-click | `(context: { e: MouseEvent })` | 点击关闭按钮时触发
 duration-end | \- | 计时结束时触发
 

--- a/packages/components/notification/notification.tsx
+++ b/packages/components/notification/notification.tsx
@@ -30,10 +30,17 @@ export default defineComponent({
     const timer = ref(null);
     const notificationRef = ref(null);
 
-    const close = (e?: MouseEvent) => {
+    const handleCloseBtnClick = (e?: MouseEvent) => {
       const dom = notificationRef.value as HTMLElement;
       fadeOut(dom, props.placement, () => {
         props.onCloseBtnClick?.({ e });
+      });
+    };
+
+    const close = () => {
+      const dom = notificationRef.value as HTMLElement;
+      fadeOut(dom, props.placement, () => {
+        props.onClose?.();
       });
     };
 
@@ -59,7 +66,7 @@ export default defineComponent({
     const renderClose = () => {
       const defaultClose = <CloseIcon />;
       return (
-        <span class={`${classPrefix.value}-message__close`} onClick={close}>
+        <span class={`${classPrefix.value}-message__close`} onClick={handleCloseBtnClick}>
           {renderTNode('closeBtn', defaultClose)}
         </span>
       );

--- a/packages/components/notification/props.ts
+++ b/packages/components/notification/props.ts
@@ -52,4 +52,6 @@ export default {
   onCloseBtnClick: Function as PropType<TdNotificationProps['onCloseBtnClick']>,
   /** 计时结束时触发 */
   onDurationEnd: Function as PropType<TdNotificationProps['onDurationEnd']>,
+  /** 调用 NotificationPlugin.close 时触发 */
+  onClose: Function as PropType<TdNotificationProps['onClose']>,
 };

--- a/packages/components/notification/type.ts
+++ b/packages/components/notification/type.ts
@@ -50,6 +50,10 @@ export interface TdNotificationProps {
    * 计时结束时触发
    */
   onDurationEnd?: () => void;
+  /**
+   * 调用 NotificationPlugin.close  时触发
+   */
+  onClose?: () => void;
 }
 
 export interface NotificationOptions extends TdNotificationProps {

--- a/packages/tdesign-vue-next/.changelog/pr-5958.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5958.md
@@ -1,0 +1,7 @@
+---
+pr_number: 5958
+contributor: baozjj
+---
+
+- feat(Notification): 新增`onClose` 事件，用于处理调用  `NotifyPlugin.close()`  的相关回调场景 @baozjj ([#5958](https://github.com/Tencent/tdesign-vue-next/pull/5958))
+- fix(Notification): 修复调用 `NotifyPlugin.close()` 错误触发 `onCloseBtnClick` 回调的问题 @baozjj ([#5958](https://github.com/Tencent/tdesign-vue-next/pull/5958))

--- a/packages/tdesign-vue-next/.changelog/pr-5958.md
+++ b/packages/tdesign-vue-next/.changelog/pr-5958.md
@@ -3,5 +3,5 @@ pr_number: 5958
 contributor: baozjj
 ---
 
-- feat(Notification): 新增`onClose` 事件，用于处理调用  `NotifyPlugin.close()`  的相关回调场景 @baozjj ([#5958](https://github.com/Tencent/tdesign-vue-next/pull/5958))
+- feat(Notification): 新增 `onClose` 事件，用于处理调用 `NotifyPlugin.close()` 的相关回调场景 @baozjj ([#5958](https://github.com/Tencent/tdesign-vue-next/pull/5958))
 - fix(Notification): 修复调用 `NotifyPlugin.close()` 错误触发 `onCloseBtnClick` 回调的问题 @baozjj ([#5958](https://github.com/Tencent/tdesign-vue-next/pull/5958))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
修复了 `NotifyPlugin.close()` 会错误触发 `onCloseBtnClick` 事件的问题。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
**问题背景：**
`onCloseBtnClick` 事件本应仅在用户手动点击关闭按钮时触发。但在之前的实现中，通过代码调用 `NotifyPlugin.close()` 方法同样会错误地触发该事件。这会导致开发者在 `onCloseBtnClick` 回调中编写的、仅针对用户行为的逻辑被意外执行，从而引发潜在的 Bug。

**解决方案：**
新增 `onClose` 事件，将程序化关闭和用户手动关闭的逻辑进行解耦。
 **`Notification`**: 新增 `onClose` prop，并重构内部关闭逻辑，区分了用户点击 (`handleCloseBtnClick`) 和程序化调用 (`close`)，确保只有前者触发 `onCloseBtnClick` 事件。

**备注：**
‘packages/components/notification/_example/plugin.vue’是为了演示这个场景，后续需要删除

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

- feat(Notification): 新增`onClose` 事件，用于处理调用  `NotifyPlugin.close()`  的相关回调场景
-  fix(Notification): 修复调用 `NotifyPlugin.close()` 错误触发 `onCloseBtnClick` 回调的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供