### PR TITLE
test(Tabs): add a test for sub components without `onRemove` but `rem…

### DIFF
--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -137,5 +137,29 @@ describe('Tabs', () => {
       expect(onTabRemoveFn).toHaveBeenCalledWith({ value: 1, e: expect.any(Event), index: 0 });
       expect(onTabPanelRemoveFn).toHaveBeenCalledWith({ value: 1, e: expect.any(Event) });
     });
+    it('子组件没有 onRemove 但 removable 为 true 时', async () => {
+      const onTabRemoveFn = vi.fn();
+      const wrapper = mount({
+        render() {
+          return (
+            <Tabs theme={'card'} onRemove={onTabRemoveFn} value={2}>
+              <TabPanel value={1} label={'1'} removable={true}>
+                1
+              </TabPanel>
+              <TabPanel value={2} label={'2'} removable={true}>
+                2
+              </TabPanel>
+            </Tabs>
+          );
+        },
+      });
+      await nextTick();
+      const tabs = wrapper.findComponent(Tabs);
+      // 点击第一个标签的删除按钮
+      tabs.vm.$el.getElementsByClassName('remove-btn')[0].dispatchEvent(new Event('click'));
+
+      expect(onTabRemoveFn).toHaveBeenCalledTimes(1);
+      expect(onTabRemoveFn).toHaveBeenCalledWith({ value: 1, e: expect.any(Event), index: 0 });
+    });
   });
 });


### PR DESCRIPTION
…ovable=true`

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
