### PR TITLE
fix(calendar): fix the months can be selected are out of range when set the range in the same year

### DIFF
--- a/packages/components/calendar/calendar.tsx
+++ b/packages/components/calendar/calendar.tsx
@@ -68,13 +68,19 @@ export default defineComponent({
     function checkMonthAndYearSelectedDisabled(year: number, month: number): boolean {
       let disabled = false;
       if (rangeFromTo.value && rangeFromTo.value.from && rangeFromTo.value.to) {
+        // 读取起止年份
         const beginYear = dayjs(rangeFromTo.value.from).year();
         const endYear = dayjs(rangeFromTo.value.to).year();
-        if (year === beginYear) {
-          const beginMon = parseInt(dayjs(rangeFromTo.value.from).format('M'), 10);
+        // 读取起止月份
+        const beginMon = parseInt(dayjs(rangeFromTo.value.from).format('M'), 10);
+        const endMon = parseInt(dayjs(rangeFromTo.value.to).format('M'), 10);
+
+        if (beginYear === endYear) {
+          // 同一年内，禁用开始月份至结束月份之外的月份选项
+          disabled = month < beginMon || month > endMon;
+        } else if (year === beginYear) {
           disabled = month < beginMon;
         } else if (year === endYear) {
-          const endMon = parseInt(dayjs(rangeFromTo.value.to).format('M'), 10);
           disabled = month > endMon;
         }
       }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

* [[Calendar] 年份相同，月份不同的日期范围显示有误 #6044](https://github.com/Tencent/tdesign-vue-next/issues/6044)

### 💡 需求背景和解决方案

#### 代码缺陷

组件源码中的月份禁用选项生成依据仅为先起始年份后终止年份的单侧判断

```tsx
// packages\components\calendar\calendar.tsx 73-79
if (year === beginYear) {
  const beginMon = parseInt(dayjs(rangeFromTo.value.from).format('M'), 10);
  disabled = month < beginMon;
} else if (year === endYear) {
  const endMon = parseInt(dayjs(rangeFromTo.value.to).format('M'), 10);
  disabled = month > endMon;
}
```

只有在切换年份时才会触发月份的禁用选项更新。当起止年份相同时（假定为2025年），若年份选中`2025年`，以上逻辑仅会判断当前选中项与起始年份相同然后禁用起始月份之前的月份选项，而忽略对终止月份之后的月份选项的禁用

#### 解决方案

```tsx
// packages\components\calendar\calendar.tsx 71-85
// 读取起止年份
const beginYear = dayjs(rangeFromTo.value.from).year();
const endYear = dayjs(rangeFromTo.value.to).year();
// 读取起止月份
const beginMon = parseInt(dayjs(rangeFromTo.value.from).format('M'), 10);
const endMon = parseInt(dayjs(rangeFromTo.value.to).format('M'), 10);

if (beginYear === endYear) {
  // 同一年内，禁用开始月份至结束月份之外的月份选项
  disabled = month < beginMon || month > endMon;
} else if (year === beginYear) {
  disabled = month < beginMon;
} else if (year === endYear) {
  disabled = month > endMon;
}
```

将可复用的月份处理逻辑提前，然后在单侧判断之前增加一个分支逻辑判断起止年份是否相同，相同的话将禁用的月份选项设定为在起止月份之外的即可

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(calendar): 修复了当设定日历的range值为同一年内时，终止月份之后的月份选项没有正常禁用的问题

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
