### PR TITLE
test(descriptions): Improved the test cases for the descriptions component

### DIFF
--- a/packages/components/descriptions/__tests__/descriptions.test.tsx
+++ b/packages/components/descriptions/__tests__/descriptions.test.tsx
@@ -205,11 +205,158 @@ describe('Descriptions', () => {
 
       const tbody = wrapper.find('tbody');
       const firstTr = tbody.findAll('tr')[0];
-      // 检查 第 1 个 td 是否为空
+      // 检查 第 0 个 td 是否为空
       expect(firstTr.findAll('td')[0].text()).toBe('');
 
       // 检查 第 4 个 td 是否为空
       expect(firstTr.findAll('td')[3].text()).toBe('');
+    });
+
+    it(':items:span', () => {
+      const items = [
+        { label: 1, content: 'TDesign', span: 1 },
+        { label: 2, content: 'TDesign', span: 2 },
+      ];
+      const wrapper = mount({
+        render() {
+          return <Descriptions items={items} />;
+        },
+      });
+
+      const tbody = wrapper.find('tbody');
+      const firstTr = tbody.findAll('tr')[0];
+      // 检查 是否有 2 个 td 元素
+      expect(firstTr.findAll('td')).toHaveLength(2);
+
+      // 检查 第 1 个 td元素 colspan 属性是否正确
+      expect(firstTr.findAll('td')[0].element.getAttribute('colspan')).toBe('1');
+    });
+
+    it(':items:span:null:undefined', () => {
+      const items = [
+        { label: 1, content: 'TDesign', span: undefined },
+        { label: 2, content: 'TDesign', span: null },
+        { label: 3, content: 'TDesign', span: 2 },
+      ];
+      const wrapper = mount({
+        render() {
+          return <Descriptions items={items} />;
+        },
+      });
+
+      const tbody = wrapper.find('tbody');
+      const lastTr = tbody.findAll('tr')[1];
+      // 检查 是否有 6 个 td 元素
+      expect(tbody.findAll('td')).toHaveLength(6);
+
+      // 检查 第 2 个 td元素 是否正确显示内容
+      expect(lastTr.findAll('td')[1].text()).toBe('TDesign');
+      // 检查 第 2 个 td元素 colspan 属性是否正确
+      expect(lastTr.findAll('td')[1].element.getAttribute('colspan')).toBe('3');
+    });
+
+    it(':items:span:span>column', () => {
+      const items = [
+        { label: 1, content: 'TDesign', span: 2 },
+        { label: 2, content: 'TDesign', span: 2 },
+      ];
+      const wrapper = mount({
+        render() {
+          return <Descriptions items={items} column={1} />;
+        },
+      });
+
+      const tbody = wrapper.find('tbody');
+      const firstTr = tbody.findAll('tr')[0];
+      // 检查 是否有 2 个 td 元素
+      expect(firstTr.findAll('td')).toHaveLength(2);
+
+      // 检查 第 1 个 td元素 colspan 属性是否正确设置
+      expect(firstTr.findAll('td')[0].element.getAttribute('colspan')).toBe('1');
+    });
+
+    it(':items:span:span<column', () => {
+      const items = [
+        { label: 1, content: 'TDesign', span: 2 },
+        { label: 2, content: 'TDesign', span: 2 },
+      ];
+      const wrapper = mount({
+        render() {
+          return <Descriptions items={items} column={5} />;
+        },
+      });
+
+      const tbody = wrapper.find('tbody');
+      const firstTr = tbody.findAll('tr')[0];
+      // 检查 是否有 4 个 td 元素
+      expect(firstTr.findAll('td')).toHaveLength(4);
+
+      // 检查 第 1 个 td元素 colspan 属性是否正确设置
+      expect(firstTr.findAll('td')[0].element.getAttribute('colspan')).toBe('1');
+    });
+
+    it(':itemLayout:validator', () => {
+      const layoutList = ['horizontal', 'vertical'];
+      layoutList.forEach((layout) => {
+        mount({
+          render() {
+            return <Descriptions itemLayout={layout} />;
+          },
+        });
+
+        // 验证 validator：手动调用 validator 函数
+        const itemLayoutProp = Descriptions.props.itemLayout;
+        expect(itemLayoutProp.validator(layout)).toBe(true);
+        expect(itemLayoutProp.validator('')).toBe(true);
+      });
+    });
+
+    it(':layout:validator', () => {
+      const layoutList = ['horizontal', 'vertical'];
+      layoutList.forEach((layout) => {
+        mount({
+          render() {
+            return <Descriptions layout={layout} />;
+          },
+        });
+
+        // 验证 validator 逻辑
+        const layoutProp = Descriptions.props.layout;
+        expect(layoutProp.validator(layout)).toBe(true);
+        expect(layoutProp.validator(undefined)).toBe(true);
+      });
+    });
+
+    it(':size:validator', () => {
+      const sizeList = ['small', 'medium', 'large'];
+      sizeList.forEach((size) => {
+        mount({
+          render() {
+            return <Descriptions size={size} />;
+          },
+        });
+
+        // 验证 validator 逻辑
+        const sizeProp = Descriptions.props.size;
+        expect(sizeProp.validator(size)).toBe(true);
+        expect(sizeProp.validator(null)).toBe(true);
+      });
+    });
+
+    it(':tableLayout:validator', () => {
+      const tableLayoutList = ['fixed', 'auto'];
+      tableLayoutList.forEach((layout) => {
+        mount({
+          render() {
+            return <Descriptions tableLayout={layout} />;
+          },
+        });
+
+        // 验证 validator
+        const tableLayoutProp = Descriptions.props.tableLayout;
+        expect(tableLayoutProp.validator(layout)).toBe(true);
+        expect(tableLayoutProp.validator(null)).toBe(true);
+      });
     });
   });
 

--- a/packages/components/descriptions/__tests__/descriptions.test.tsx
+++ b/packages/components/descriptions/__tests__/descriptions.test.tsx
@@ -205,7 +205,7 @@ describe('Descriptions', () => {
 
       const tbody = wrapper.find('tbody');
       const firstTr = tbody.findAll('tr')[0];
-      // 检查 第 0 个 td 是否为空
+      // 检查 第 1 个 td 是否为空
       expect(firstTr.findAll('td')[0].text()).toBe('');
 
       // 检查 第 4 个 td 是否为空

--- a/packages/components/descriptions/descriptions.tsx
+++ b/packages/components/descriptions/descriptions.tsx
@@ -56,7 +56,7 @@ export default defineComponent({
         items = props.items.map((item) => ({
           label: renderCustomNode(item.label),
           content: renderCustomNode(item.content),
-          span: item.span || 1,
+          span: item.span,
         }));
         itemsType.value = ItemsType.props;
       } else {

--- a/packages/components/descriptions/descriptions.tsx
+++ b/packages/components/descriptions/descriptions.tsx
@@ -56,7 +56,7 @@ export default defineComponent({
         items = props.items.map((item) => ({
           label: renderCustomNode(item.label),
           content: renderCustomNode(item.content),
-          span: item.span,
+          span: item.span || 1,
         }));
         itemsType.value = ItemsType.props;
       } else {


### PR DESCRIPTION
在编写测试用例的时候发现个问题 就是自定义items的时候 span属性在两个地方都有默认值操作 一次是我更改的地方 第二次是86行那里 为了测试用例能够覆盖到 我把59行的默认值行为取消了 大家可以商讨一下这个默认值设置的位置 🚀
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#5631

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
