### PR TITLE
docs: fix Vue CDN script URL in getting-started guide

### DIFF
--- a/packages/tdesign-vue-next/site/docs/getting-started.en-US.md
+++ b/packages/tdesign-vue-next/site/docs/getting-started.en-US.md
@@ -15,7 +15,7 @@ npm i tdesign-vue-next
 
 ```html
 <!-- vue 3 -->
-<script src="https://unpkg.com/vue@next"></script>
+<script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/tdesign-vue-next/dist/tdesign.min.css" />
 <script src="https://unpkg.com/tdesign-vue-next/dist/tdesign.min.js"></script>
 ...

--- a/packages/tdesign-vue-next/site/docs/getting-started.md
+++ b/packages/tdesign-vue-next/site/docs/getting-started.md
@@ -19,7 +19,7 @@ npm i tdesign-vue-next
 
 ```html
 <!-- vue 3 -->
-<script src="https://unpkg.com/vue@next"></script>
+<script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/tdesign-vue-next/dist/tdesign.min.css" />
 <script src="https://unpkg.com/tdesign-vue-next/dist/tdesign.min.js"></script>
 ...


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

* [ ] 日常 bug 修复
* [ ] 新特性提交
* [x] 文档改进
* [ ] 演示代码改进
* [ ] 组件样式/交互改进
* [ ] CI/CD 改进
* [ ] 重构
* [ ] 代码风格优化
* [ ] 测试用例
* [ ] 分支合并
* [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在 `getting-started.en-US.md`与`getting-started.md` 的 CDN 示例中使用了：

`https://unpkg.com/vue@next`

该地址不会加载 Vue 3 的 global 构建版本，可能导致示例无法正常运行。

本 PR 将其更新为：

`https://unpkg.com/vue@3/dist/vue.global.js`

以确保示例能够在浏览器环境中正确加载 Vue 3。

修改文件：

`packages/tdesign-vue-next/site/docs/getting-started.en-US.md`
`packages/tdesign-vue-next/site/docs/getting-started.md`

### 📝 更新日志

* [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

无运行时代码修改，仅修正文档示例。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

* [x] 文档已补充或无须补充
* [x] 代码演示已提供或无须提供
* [x] TypeScript 定义已补充或无须补充
* [x] Changelog 已提供或无须提供
