### PR TITLE
fix(table): local sorting shows old data

### DIFF
--- a/packages/components/table/hooks/useSorter.tsx
+++ b/packages/components/table/hooks/useSorter.tsx
@@ -15,6 +15,8 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
   const sorterFuncMap = computed(() => getSorterFuncMap(props.columns));
   const innerSort = ref<SortInfo | SortInfo[]>();
 
+  let isSortingChange = false;
+
   const sortArray = computed<Array<SortInfo>>(() => {
     const sort = tSortInfo.value;
     if (!sort) return [];
@@ -48,13 +50,13 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
   function handleDataSort(sortInfo: SortInfo | Array<SortInfo>) {
     const sort = sortInfo;
     if (!Object.keys(sorterFuncMap.value).length) return;
-
     if (!originalData.value) {
       originalData.value = tData.value;
     }
     const isEmptyArraySort = !sort || (sort instanceof Array && !sort.length);
     const isEmptyObjectSort = !(sort instanceof Array) && !sort?.sortBy;
     if (isEmptyArraySort || isEmptyObjectSort) {
+      isSortingChange = true;
       setTData(originalData.value, { trigger: 'sort' });
       return originalData.value;
     }
@@ -76,6 +78,7 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
     });
     // Data 变化返回的是数据引用，为避免死循环，特此检测排序数据前后是否相同，如果相同则不再触发事件
     if (JSON.stringify(newData) === JSON.stringify(tData.value)) return;
+    isSortingChange = true;
     setTData(newData, { trigger: 'sort' });
     return newData;
   }
@@ -169,10 +172,7 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
    */
   watch(
     () => [tSortInfo, props.data],
-    (val) => {
-      if (props.data.length === 0) {
-        originalData.value = props.data;
-      }
+    () => {
       if (!tSortInfo.value || !Object.keys(tSortInfo.value).length || !tData.value.length) return;
       // isSortInfoSame 的两个参数顺序不可变
       if (!isSortInfoSame(tSortInfo.value, innerSort.value)) {
@@ -180,6 +180,20 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
       }
     },
     { immediate: true },
+  );
+
+  /**
+   * 外部 data 发生变化时，需要同步更新 originalData，避免取消排序时还原成已经过时的旧数据。
+   */
+  watch(
+    () => props.data,
+    (val) => {
+      if (isSortingChange) {
+        isSortingChange = false;
+        return;
+      }
+      originalData.value = val;
+    },
   );
 
   return {

--- a/packages/components/table/hooks/useSorter.tsx
+++ b/packages/components/table/hooks/useSorter.tsx
@@ -48,6 +48,7 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
   function handleDataSort(sortInfo: SortInfo | Array<SortInfo>) {
     const sort = sortInfo;
     if (!Object.keys(sorterFuncMap.value).length) return;
+
     if (!originalData.value) {
       originalData.value = tData.value;
     }
@@ -168,7 +169,10 @@ export default function useSorter(props: TdPrimaryTableProps, { slots }: SetupCo
    */
   watch(
     () => [tSortInfo, props.data],
-    () => {
+    (val) => {
+      if (props.data.length === 0) {
+        originalData.value = props.data;
+      }
       if (!tSortInfo.value || !Object.keys(tSortInfo.value).length || !tData.value.length) return;
       // isSortInfoSame 的两个参数顺序不可变
       if (!isSortInfoSame(tSortInfo.value, innerSort.value)) {

--- a/packages/tdesign-vue-next/.changelog/pr-6537.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6537.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6537
+contributor: LavenderDuskGlow
+---
+
+- fix(Table): 修复排序后本地数据变化，重新调整排序方式仍然显示旧数据的问题 @LavenderDuskGlow ([#6537](https://github.com/Tencent/tdesign-vue-next/pull/6537))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #6527 

### 💡 需求背景和解决方案
在useSorter,ts 170行 当props.data发生改变的时候将 props.data 赋值给 originalData

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Table): 修复排序后本地数据变化，重新调整排序方式仍然显示旧数据的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

