### PR TITLE
fix(date-range-picker): prevent unnecessary onChange triggers for unchanged values

### DIFF
--- a/packages/components/date-picker/DateRangePicker.tsx
+++ b/packages/components/date-picker/DateRangePicker.tsx
@@ -369,10 +369,14 @@ export default defineComponent({
             defaultTime: props.defaultTime,
           }) as DateValue[];
           const isSame =
-            Array.isArray(value.value) &&
-            value.value.length === 2 &&
-            formattedValue[0] === value.value[0] &&
-            formattedValue[1] === value.value[1];
+            Array.isArray(formattedValue) &&
+            formattedValue.length === 2 &&
+            formattedValue[0] != null &&
+            formattedValue[1] != null &&
+            value.value[0] != null &&
+            value.value[1] != null &&
+            dayjs(formattedValue[0] as any).valueOf() === dayjs(value.value[0] as any).valueOf() &&
+            dayjs(formattedValue[1] as any).valueOf() === dayjs(value.value[1] as any).valueOf();
           //判断传入的值和当前值是否相同，不同再触发 onChange，避免不必要的事件触发
           props?.onConfirm?.({
             date: nextValue.map((v) => dayjs(v).toDate()),

--- a/packages/components/date-picker/DateRangePicker.tsx
+++ b/packages/components/date-picker/DateRangePicker.tsx
@@ -373,29 +373,19 @@ export default defineComponent({
             value.value.length === 2 &&
             formattedValue[0] === value.value[0] &&
             formattedValue[1] === value.value[1];
-          //判断传入的值和当前值是否相同，不同再触发 onChange和 onConfirm事件，避免不必要的事件触发
-
+          //判断传入的值和当前值是否相同，不同再触发 onChange，避免不必要的事件触发
           props?.onConfirm?.({
             date: nextValue.map((v) => dayjs(v).toDate()),
             e: e || null,
             partial: activeIndex.value ? 'end' : 'start',
           });
-
           if (!isSame) {
-            onChange?.(
-              formatDate(nextValue, {
-                format: formatRef.value.format,
-                targetFormat: formatRef.value.valueType,
-                autoSwap: true,
-                defaultTime: props.defaultTime,
-              }) as DateValue[],
-              {
-                dayjsValue: nextValue.map((v, i) =>
-                  parseToDayjs(v, formatRef.value.format, undefined, undefined, props.defaultTime?.[i]),
-                ),
-                trigger: 'confirm',
-              },
-            );
+            onChange?.(formattedValue, {
+              dayjsValue: nextValue.map((v, i) =>
+                parseToDayjs(v, formatRef.value.format, undefined, undefined, props.defaultTime?.[i]),
+              ),
+              trigger: 'confirm',
+            });
           }
         }
       }

--- a/packages/components/date-picker/DateRangePicker.tsx
+++ b/packages/components/date-picker/DateRangePicker.tsx
@@ -362,25 +362,41 @@ export default defineComponent({
           cacheValue.value = nextValue;
           inputValue.value = nextValue;
         } else {
+          const formattedValue = formatDate(nextValue, {
+            format: formatRef.value.format,
+            targetFormat: formatRef.value.valueType,
+            autoSwap: true,
+            defaultTime: props.defaultTime,
+          }) as DateValue[];
+          const isSame =
+            Array.isArray(value.value) &&
+            value.value.length === 2 &&
+            formattedValue[0] === value.value[0] &&
+            formattedValue[1] === value.value[1];
+          //判断传入的值和当前值是否相同，不同再触发 onChange和 onConfirm事件，避免不必要的事件触发
+
           props?.onConfirm?.({
             date: nextValue.map((v) => dayjs(v).toDate()),
             e: e || null,
             partial: activeIndex.value ? 'end' : 'start',
           });
-          onChange?.(
-            formatDate(nextValue, {
-              format: formatRef.value.format,
-              targetFormat: formatRef.value.valueType,
-              autoSwap: true,
-              defaultTime: props.defaultTime,
-            }) as DateValue[],
-            {
-              dayjsValue: nextValue.map((v, i) =>
-                parseToDayjs(v, formatRef.value.format, undefined, undefined, props.defaultTime?.[i]),
-              ),
-              trigger: 'confirm',
-            },
-          );
+
+          if (!isSame) {
+            onChange?.(
+              formatDate(nextValue, {
+                format: formatRef.value.format,
+                targetFormat: formatRef.value.valueType,
+                autoSwap: true,
+                defaultTime: props.defaultTime,
+              }) as DateValue[],
+              {
+                dayjsValue: nextValue.map((v, i) =>
+                  parseToDayjs(v, formatRef.value.format, undefined, undefined, props.defaultTime?.[i]),
+                ),
+                trigger: 'confirm',
+              },
+            );
+          }
         }
       }
     };

--- a/packages/components/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-picker.test.tsx
@@ -759,4 +759,153 @@ describe('DatePicker', () => {
     const html = wrapper.element.innerHTML;
     expect(html).toContain('01:02:03');
   });
+
+  it('DateRangePicker: should not trigger onChange but trigger onConfirm when confirming unchanged value', async () => {
+    const onChange = vi.fn();
+    const onConfirm = vi.fn();
+    const attachClass = 'drp-confirm-unchanged-attach';
+    const value = ['2020-12-10 08:00:00', '2020-12-20 18:00:00'];
+
+    const wrapper = mount({
+      render() {
+        return (
+          <div class={attachClass}>
+            <DateRangePicker
+              value={value}
+              format="YYYY-MM-DD HH:mm:ss"
+              enableTimePicker={true}
+              onChange={onChange}
+              onConfirm={onConfirm}
+              popupProps={{ attach: `.${attachClass}` }}
+            />
+          </div>
+        );
+      },
+    });
+
+    const trigger = wrapper.find('.t-input');
+    await trigger.trigger('mousedown');
+    await trigger.trigger('mouseup');
+    await trigger.trigger('click');
+    await nextTick();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const findConfirmBtn = () =>
+      (wrapper.element.querySelector('.t-date-picker__footer button') as HTMLElement | null) ||
+      (Array.from(document.querySelectorAll('button.t-button') as NodeListOf<HTMLElement>).find((b) =>
+        b.textContent?.trim().includes('确定'),
+      ) as HTMLElement | null);
+
+    const btn = findConfirmBtn();
+    expect(btn).toBeTruthy();
+    btn?.click();
+    await nextTick();
+
+    // onConfirm always fires when user clicks confirm; onChange only fires when value actually changes
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('DateRangePicker: should not trigger onChange when confirming unchanged value with valueType=Date', async () => {
+    const onChange = vi.fn();
+    const attachClass = 'drp-confirm-unchanged-date-attach';
+    const value = [new Date('2020-12-10 08:00:00'), new Date('2020-12-20 18:00:00')];
+
+    const wrapper = mount({
+      render() {
+        return (
+          <div class={attachClass}>
+            <DateRangePicker
+              value={value}
+              valueType="Date"
+              enableTimePicker={true}
+              onChange={onChange}
+              popupProps={{ attach: `.${attachClass}` }}
+            />
+          </div>
+        );
+      },
+    });
+
+    const trigger = wrapper.find('.t-input');
+    await trigger.trigger('mousedown');
+    await trigger.trigger('mouseup');
+    await trigger.trigger('click');
+    await nextTick();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const findConfirmBtn = () =>
+      (wrapper.element.querySelector('.t-date-picker__footer button') as HTMLElement | null) ||
+      (Array.from(document.querySelectorAll('button.t-button') as NodeListOf<HTMLElement>).find((b) =>
+        b.textContent?.trim().includes('确定'),
+      ) as HTMLElement | null);
+
+    const btn = findConfirmBtn();
+    expect(btn).toBeTruthy();
+    btn?.click();
+    await nextTick();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('DateRangePicker: should trigger onChange/onConfirm when confirming changed value', async () => {
+    const onChange = vi.fn();
+    const onConfirm = vi.fn();
+    const attachClass = 'drp-confirm-changed-attach';
+    const value = ['2020-12-10 08:00:00', '2020-12-20 18:00:00'];
+
+    const wrapper = mount({
+      render() {
+        return (
+          <div class={attachClass}>
+            <DateRangePicker
+              value={value}
+              format="YYYY-MM-DD HH:mm:ss"
+              enableTimePicker={true}
+              onChange={onChange}
+              onConfirm={onConfirm}
+              popupProps={{ attach: `.${attachClass}` }}
+            />
+          </div>
+        );
+      },
+    });
+
+    const trigger = wrapper.find('.t-input');
+    await trigger.trigger('mousedown');
+    await trigger.trigger('mouseup');
+    await trigger.trigger('click');
+    await nextTick();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // activeIndex defaults to 0 (start), click a different start date
+    const findCells = () => {
+      const cs = Array.from(wrapper.element.querySelectorAll('td.t-date-picker__cell')) as HTMLElement[];
+      return cs.length > 0 ? cs : (Array.from(document.querySelectorAll('td.t-date-picker__cell')) as HTMLElement[]);
+    };
+    const cells = findCells();
+    const newStartCell = cells.find((c) => c.textContent?.trim() === '15' && !c.className.includes('--additional'));
+    expect(newStartCell).toBeTruthy();
+    newStartCell?.click();
+
+    const findConfirmBtn = () =>
+      (wrapper.element.querySelector('.t-date-picker__footer button') as HTMLElement | null) ||
+      (Array.from(document.querySelectorAll('button.t-button') as NodeListOf<HTMLElement>).find((b) =>
+        b.textContent?.trim().includes('确定'),
+      ) as HTMLElement | null);
+
+    let btn: HTMLElement | null = null;
+    for (let i = 0; i < 10; i++) {
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 0));
+      btn = findConfirmBtn();
+      if (btn) break;
+    }
+    expect(btn).toBeTruthy();
+    btn?.click();
+    await nextTick();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/tdesign-vue-next/.changelog/pr-6551.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6551.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6551
+contributor: JefferyHcool
+---
+
+- fix(date-range-picker): 避免在值未变化时除非 onChange 回调的问题 @JefferyHcool ([#6551](https://github.com/Tencent/tdesign-vue-next/pull/6551))

--- a/packages/tdesign-vue-next/.changelog/pr-6551.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6551.md
@@ -3,4 +3,4 @@ pr_number: 6551
 contributor: JefferyHcool
 ---
 
-- fix(date-range-picker): 避免在值未变化时除非 onChange 回调的问题 @JefferyHcool ([#6551](https://github.com/Tencent/tdesign-vue-next/pull/6551))
+- fix(date-range-picker): 避免在值未变化时触发 `onChange` 回调的问题 @JefferyHcool ([#6551](https://github.com/Tencent/tdesign-vue-next/pull/6551))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- https://github.com/Tencent/tdesign-vue-next/issues/6538

### 💡 需求背景和解决方案

当 `DateRangePicker` 传入默认值（value）时：

- 打开面板  
- 不做任何选择  
- 点击“确定”  

仍然会触发 `onChange`。

这不符合用户预期，因为值实际上并没有发生变化。
#### 问题原因

在 `confirmValueChange` 中，无论值是否发生变化，都会直接触发：
```ts
onChange?.(...)
```

#### 解决方案
在触发 onChange 前增加判断：
```ts
const isSame =
  value.value.length === 2 &&
  nextValue[0] === value.value[0] &&
  nextValue[1] === value.value[1];

if (!isSame) {
  onChange?.(...)
}
```


### 📝 更新日志
#### tdesign-vue-next

- fix(date-range-picker): 避免在值未变化时触发 `onChange` 回调的问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
