### PR TITLE
fix(chat-sender-attachments): fix chat sender attachment  example

### DIFF
--- a/packages/pro-components/chat/chat-sender/_example/chat-sender-attachments.vue
+++ b/packages/pro-components/chat/chat-sender/_example/chat-sender-attachments.vue
@@ -59,6 +59,7 @@ const filesList = ref<TdAttachmentItem[]>([
   {
     key: '3',
     name: 'image-file.png',
+    url: 'https://tdesign.gtimg.com/site/avatar.jpg',
     size: 333333,
   },
   {


### PR DESCRIPTION
…oid invalid loading

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#6478 
### 💡 需求背景和解决方案
在官网提供的 `example` 中 ，`chat-sender` 的附件例子中
对于图片附件并没有为图片附件提供`url` 所以当其他附件删除之后会去拉去图片
#### 修复之前
![ChatSender 对话输入 - TDesign — 4月1日 22 07](https://github.com/user-attachments/assets/2c0b3fc8-0e89-4750-a76d-385b2c5c8696)
#### 修复之后
![output](https://github.com/user-attachments/assets/0f39a39b-f746-46f0-accf-31ce4f25f1c0)


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
fix(chat-sender): 修复官网中 `chatSender` 组件的附件演示问题
- [ ] 本条 PR 不需要纳入 Changelog

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->
fix(chat-sender): 修复 `example` 中图片附件删除无图片加载问题。
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
