### PR TITLE
fix(space): fix missing px unit in align demo padding

### DIFF
--- a/packages/components/space/_example/align.vue
+++ b/packages/components/space/_example/align.vue
@@ -25,7 +25,7 @@
 
 <style scoped>
 .space-border {
-  padding: 12;
+  padding: 12px;
   border: 1px dashed var(--td-component-stroke);
 }
 .space-block {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

Space 组件的 align demo（`packages/components/space/_example/align.vue`）中，`.space-border` 的 `padding` 缺少 `px` 单位：

修改前（无效声明，浏览器会忽略）：`padding: 12;`
修改后：`padding: 12px;`

CSS 中除 `0` 以外的长度值必须带单位，否则声明无效，导致 demo 展示时边框内没有内间距。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(space): 修复 align demo 中 padding 缺少 px 单位的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
