### PR TITLE
fix(enhanced-table): update watch dependencies to use reactive values

### DIFF
--- a/packages/components/table/hooks/useTreeData.tsx
+++ b/packages/components/table/hooks/useTreeData.tsx
@@ -97,7 +97,7 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
   });
 
   watch(
-    () => [columns, props.tree?.treeNodeColumnIndex],
+    () => [columns.value, props.tree?.treeNodeColumnIndex],
     () => {
       treeNodeCol.value = getTreeNodeColumnCol();
     },

--- a/packages/tdesign-vue-next/.changelog/pr-6578.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6578.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6578
+contributor: JefferyHcool
+---
+
+- fix(EnhancedTable): 修复树状表格的列配置在 `computed/ref` 场景下无响应式的问题 @JefferyHcool ([#6578](https://github.com/Tencent/tdesign-vue-next/pull/6578))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/6573
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
#### 问题背景
在使用`enhanceTable`  树结构的时候，如果动态的改变 `column`的 width 属性，column的宽度实际是没有被修改的。
#### 问题原因
在 `useTreeData`的监听中  `columns` 是通过 toRefs(props) 得到的 Ref 对象。
在 watch 的 getter 函数 () => [columns, ...] 中，Vue 不会自动解包 ref，每次返回的都是同一个 ref  对象引用，引用地址不变，所以 watch 从未触发过。 

#### 修复前
![befor](https://github.com/user-attachments/assets/507490f7-69b4-451e-a0e5-790c243819d5)
#### 修复后
![after](https://github.com/user-attachments/assets/974b5c62-4c6c-429f-8352-65705dd05391)

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(EnhancedTable): 修复树状表格的列配置在 `computed/ref` 场景下无响应式的问题




### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
