### PR TITLE
fix(input-number): correct min value handling on empty input

### DIFF
--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -508,6 +508,30 @@ describe('InputNumber', () => {
       expect(fn).toBeCalled();
     });
 
+    it(':onBlur with allowInputOverLimit false and undefined value should not set to min', async () => {
+      const value = ref(undefined);
+      const fn = vi.fn();
+      const wrapper = mount(() => (
+        <InputNumber v-model={value.value} min={10} max={100} allowInputOverLimit={false} onBlur={fn} />
+      ));
+      const input = wrapper.find('.t-input input');
+      await input.trigger('blur');
+      expect(value.value).toBe(undefined);
+      expect(fn).toHaveBeenCalledWith(undefined, expect.any(Object));
+    });
+
+    it(':onBlur with allowInputOverLimit false and null value should set to min', async () => {
+      const value = ref(null);
+      const fn = vi.fn();
+      const wrapper = mount(() => (
+        <InputNumber v-model={value.value} min={5} max={50} allowInputOverLimit={false} onBlur={fn} />
+      ));
+      const input = wrapper.find('.t-input input');
+      await input.trigger('blur');
+      expect(value.value).toBe(null);
+      expect(fn).toHaveBeenCalledWith(null, expect.any(Object));
+    });
+
     it(':onChange', async () => {
       const data = ref<InputNumberValue>('');
       const value = ref<InputNumberValue>('');

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -508,30 +508,6 @@ describe('InputNumber', () => {
       expect(fn).toBeCalled();
     });
 
-    it(':onBlur with allowInputOverLimit false and undefined value should set to min', async () => {
-      const value = ref(undefined);
-      const fn = vi.fn();
-      const wrapper = mount(() => (
-        <InputNumber v-model={value.value} min={10} max={100} allowInputOverLimit={false} onBlur={fn} />
-      ));
-      const input = wrapper.find('.t-input input');
-      await input.trigger('blur');
-      expect(value.value).toBe(10);
-      expect(fn).toHaveBeenCalledWith(10, expect.any(Object));
-    });
-
-    it(':onBlur with allowInputOverLimit false and null value should set to min', async () => {
-      const value = ref(null);
-      const fn = vi.fn();
-      const wrapper = mount(() => (
-        <InputNumber v-model={value.value} min={5} max={50} allowInputOverLimit={false} onBlur={fn} />
-      ));
-      const input = wrapper.find('.t-input input');
-      await input.trigger('blur');
-      expect(value.value).toBe(5);
-      expect(fn).toHaveBeenCalledWith(5, expect.any(Object));
-    });
-
     it(':onChange', async () => {
       const data = ref<InputNumberValue>('');
       const value = ref<InputNumberValue>('');

--- a/packages/components/input-number/__tests__/useInputNumber.test.tsx
+++ b/packages/components/input-number/__tests__/useInputNumber.test.tsx
@@ -394,6 +394,78 @@ describe('useInputNumber', () => {
     });
   });
 
+  describe('blur with min value and empty input', () => {
+    it('should not auto-fill min value when input is cleared', async () => {
+      const onBlur = vi.fn();
+      const onChange = vi.fn();
+      const TestComponent = createTestComponent({ defaultValue: 5, min: 1, max: 100, onBlur, onChange });
+      const wrapper = mount(TestComponent);
+      const hook = wrapper.vm.hook;
+
+      // 清空输入
+      hook.onInnerInputChange('', { e: new Event('input') as InputEvent });
+      await nextTick();
+
+      expect(hook.tValue.value).toBeUndefined();
+
+      // blur 时不应自动填充为 min
+      hook.listeners.onBlur('', { e: new FocusEvent('blur') });
+      await nextTick();
+
+      expect(hook.tValue.value).toBeUndefined();
+      expect(onBlur).toHaveBeenCalledWith(undefined, { e: expect.any(FocusEvent) });
+    });
+
+    it('should correct value to min when input is below minimum', async () => {
+      const onBlur = vi.fn();
+      const TestComponent = createTestComponent({ defaultValue: 5, min: 10, max: 100, onBlur });
+      const wrapper = mount(TestComponent);
+      const hook = wrapper.vm.hook;
+
+      // 输入一个低于 min 的值
+      hook.onInnerInputChange('3', { e: new Event('input') as InputEvent });
+      await nextTick();
+
+      // blur 时应矫正为 min
+      hook.listeners.onBlur('3', { e: new FocusEvent('blur') });
+      await nextTick();
+
+      expect(hook.tValue.value).toBe(10);
+      expect(onBlur).toHaveBeenCalledWith(10, { e: expect.any(FocusEvent) });
+    });
+
+    it('should correct value to max when input exceeds maximum', async () => {
+      const onBlur = vi.fn();
+      const TestComponent = createTestComponent({ defaultValue: 5, min: 0, max: 10, onBlur });
+      const wrapper = mount(TestComponent);
+      const hook = wrapper.vm.hook;
+
+      // 输入一个超过 max 的值
+      hook.onInnerInputChange('50', { e: new Event('input') as InputEvent });
+      await nextTick();
+
+      // blur 时应矫正为 max
+      hook.listeners.onBlur('50', { e: new FocusEvent('blur') });
+      await nextTick();
+
+      expect(hook.tValue.value).toBe(10);
+      expect(onBlur).toHaveBeenCalledWith(10, { e: expect.any(FocusEvent) });
+    });
+
+    it('should keep valid value unchanged on blur', async () => {
+      const onBlur = vi.fn();
+      const TestComponent = createTestComponent({ defaultValue: 5, min: 0, max: 100, onBlur });
+      const wrapper = mount(TestComponent);
+      const hook = wrapper.vm.hook;
+
+      hook.listeners.onBlur('5', { e: new FocusEvent('blur') });
+      await nextTick();
+
+      expect(hook.tValue.value).toBe(5);
+      expect(onBlur).toHaveBeenCalledWith(5, { e: expect.any(FocusEvent) });
+    });
+  });
+
   describe('readonly state', () => {
     it('should respect readonly state', () => {
       const TestComponent = createTestComponent();

--- a/packages/components/input-number/hooks/useInputNumber.tsx
+++ b/packages/components/input-number/hooks/useInputNumber.tsx
@@ -215,9 +215,11 @@ export default function useInputNumber(props: TdInputNumberProps) {
         //  空值不处理，只在非法输入时修正
         if (isValidNumber(tValue.value) && tValue.value < min) {
           setTValue(min, { type: 'blur', e: ctx.e });
+          props.onBlur?.(min, ctx);
+        } else {
+          props.onBlur?.(tValue.value, ctx);
         }
 
-        props.onBlur?.(min, ctx);
         return;
       }
       // 当值不为 undefined 时，进行范围检查
@@ -226,8 +228,10 @@ export default function useInputNumber(props: TdInputNumberProps) {
         if (r === 'below-minimum') {
           if (isValidNumber(tValue.value) && tValue.value < min) {
             setTValue(min, { type: 'blur', e: ctx.e });
+            props.onBlur?.(min, ctx);
+          } else {
+            props.onBlur?.(tValue.value, ctx);
           }
-          props.onBlur?.(min, ctx);
           return;
         }
         if (r === 'exceed-maximum') {

--- a/packages/components/input-number/hooks/useInputNumber.tsx
+++ b/packages/components/input-number/hooks/useInputNumber.tsx
@@ -204,13 +204,19 @@ export default function useInputNumber(props: TdInputNumberProps) {
       setTValue(newNumber, { type: 'input', e });
     }
   };
-
+  const isValidNumber = (val: any) => {
+    return typeof val === 'number' && !Number.isNaN(val);
+  };
   const handleBlur = (value: string, ctx: { e: FocusEvent }) => {
     const { largeNumber, max, min, decimalPlaces } = props;
     if (!props.allowInputOverLimit) {
       // 当值为 undefined 或 null 且最小值不为默认值 -Infinity 时，设置为最小值
       if ([undefined, null].includes(tValue.value) && min !== -Infinity) {
-        setTValue(min, { type: 'blur', e: ctx.e });
+        //  空值不处理，只在非法输入时修正
+        if (isValidNumber(tValue.value) && tValue.value < min) {
+          setTValue(min, { type: 'blur', e: ctx.e });
+        }
+
         props.onBlur?.(min, ctx);
         return;
       }
@@ -218,7 +224,9 @@ export default function useInputNumber(props: TdInputNumberProps) {
       if (tValue.value !== undefined) {
         const r = getMaxOrMinValidateResult({ value: tValue.value, largeNumber, max, min });
         if (r === 'below-minimum') {
-          setTValue(min, { type: 'blur', e: ctx.e });
+          if (isValidNumber(tValue.value) && tValue.value < min) {
+            setTValue(min, { type: 'blur', e: ctx.e });
+          }
           props.onBlur?.(min, ctx);
           return;
         }

--- a/packages/tdesign-vue-next/.changelog/pr-6582.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6582.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6582
+contributor: JefferyHcool
+---
+
+- fix(input-number): 修复失焦时空值被错误回填为最小值的问题 @JefferyHcool ([#6582](https://github.com/Tencent/tdesign-vue-next/pull/6582))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue-next/issues/6580
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
在 InputNumber 组件中，当输入值为空（'' | null | undefined）时：
- 用户未输入任何内容，仅触发 blur
- 输入框被自动回填为 min
- 行为不符合用户预期（用户未进行修改却改变了值）

##### 修复前：
![fix-b](https://github.com/user-attachments/assets/452a5df5-fc59-406f-aa17-54c609262319)
##### 修复后:
![fix-a](https://github.com/user-attachments/assets/cdcd8c7c-e798-46b3-9db1-077e4eb7eddf)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(input-number): 修复失焦时空值被错误回填为最小值的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
