### PR TITLE
fix(TagInput): `suffix` is not fixed on the right side in `break-line` mode

### DIFF
--- a/packages/components/tag-input/tag-input.tsx
+++ b/packages/components/tag-input/tag-input.tsx
@@ -57,7 +57,6 @@ export default defineComponent({
     const isFocused = ref(false);
     const suffixWidthRef = ref<number>(0);
     const suffixIconWidthRef = ref<number>(0);
-    const isBreakLine = computed(() => excessTagsDisplayType.value === 'break-line');
 
     // 这里不需要响应式，因此直接传递参数
     const { getDragProps } = useDragSorter({
@@ -79,6 +78,8 @@ export default defineComponent({
           getDragProps,
         }),
       );
+
+    const isBreakLine = computed(() => excessTagsDisplayType.value === 'break-line');
 
     const classes = computed(() => {
       const isEmpty = !(isArray(tagValue.value) && tagValue.value.length);

--- a/packages/components/tag-input/tag-input.tsx
+++ b/packages/components/tag-input/tag-input.tsx
@@ -23,6 +23,7 @@ const useComponentClassName = () => {
     NAME_CLASS: usePrefixClass('tag-input'),
     CLEAR_CLASS: usePrefixClass('tag-input__suffix-clear'),
     BREAK_LINE_CLASS: usePrefixClass('tag-input--break-line'),
+    WITH_SUFFIX_ICON_CLASS: usePrefixClass('tag-input__with-suffix-icon'),
   };
 };
 
@@ -31,7 +32,7 @@ export default defineComponent({
   props,
   setup(props: TdTagInputProps, { slots }) {
     const renderTNodeJSX = useTNodeJSX();
-    const { NAME_CLASS, CLEAR_CLASS, BREAK_LINE_CLASS } = useComponentClassName();
+    const { NAME_CLASS, CLEAR_CLASS, BREAK_LINE_CLASS, WITH_SUFFIX_ICON_CLASS } = useComponentClassName();
     const { CloseCircleFilledIcon } = useGlobalIcon({ CloseCircleFilledIcon: TdCloseCircleFilledIcon });
 
     const isDisabled = useDisabled() as ComputedRef<boolean>;
@@ -54,6 +55,9 @@ export default defineComponent({
     const isComposition = ref(false);
     const { classPrefix } = useConfig();
     const isFocused = ref(false);
+    const suffixWidthRef = ref<number>(0);
+    const suffixIconWidthRef = ref<number>(0);
+    const isBreakLine = computed(() => excessTagsDisplayType.value === 'break-line');
 
     // 这里不需要响应式，因此直接传递参数
     const { getDragProps } = useDragSorter({
@@ -81,7 +85,7 @@ export default defineComponent({
       return [
         NAME_CLASS.value,
         {
-          [BREAK_LINE_CLASS.value]: excessTagsDisplayType.value === 'break-line',
+          [BREAK_LINE_CLASS.value]: isBreakLine.value,
           [`${classPrefix.value}-is-empty`]: isEmpty,
           [`${classPrefix.value}-tag-input--with-tag`]: !isEmpty,
           [`${classPrefix.value}-tag-input--drag-sort`]: props.dragSort && !isReadonly.value && !isDisabled.value,
@@ -172,6 +176,52 @@ export default defineComponent({
       },
     );
 
+    const updateSuffixWidth = (selector: string, cssVar: string, widthRef: typeof suffixWidthRef) => {
+      const wrapperEl = tagInputRef.value?.$el as HTMLElement;
+      if (!wrapperEl) return;
+
+      const inputEl = wrapperEl.querySelector(`.${classPrefix.value}-input`) as HTMLElement;
+      if (!inputEl) return;
+
+      const targetEl = wrapperEl.querySelector(selector);
+      const width = targetEl ? targetEl.getBoundingClientRect().width : 0;
+      if (width !== widthRef.value) {
+        widthRef.value = width;
+        if (width) {
+          inputEl.style.setProperty(cssVar, `${Math.ceil(width + 8)}px`);
+        } else {
+          inputEl.style.removeProperty(cssVar);
+        }
+      }
+    };
+
+    const handleSuffixWidthUpdate = () => {
+      nextTick(() => {
+        if (!isBreakLine.value) return;
+
+        if (suffix.value) {
+          updateSuffixWidth(
+            `.${classPrefix.value}-input__suffix:not(.${classPrefix.value}-input__suffix-icon)`,
+            `--${classPrefix.value}-tag-input-suffix-width`,
+            suffixWidthRef,
+          );
+        }
+
+        updateSuffixWidth(
+          `.${classPrefix.value}-input__suffix-icon`,
+          `--${classPrefix.value}-tag-input-suffix-icon-width`,
+          suffixIconWidthRef,
+        );
+      });
+    };
+
+    watch(
+      () => [excessTagsDisplayType.value, suffix.value, showClearIcon.value, classPrefix.value, isBreakLine.value],
+      () => {
+        handleSuffixWidthUpdate();
+      },
+    );
+
     return () => {
       const suffixIconNode = showClearIcon.value ? (
         <CloseCircleFilledIcon class={CLEAR_CLASS.value} onClick={onClearClick} />
@@ -179,10 +229,11 @@ export default defineComponent({
         renderTNodeJSX('suffixIcon')
       );
       const prefixIconNode = renderTNodeJSX('prefixIcon');
-      const suffixClass = `${classPrefix.value}-tag-input__with-suffix-icon`;
+      const suffixClass = WITH_SUFFIX_ICON_CLASS.value;
       if (suffixIconNode && !classes.value.includes(suffixClass)) {
         classes.value.push(suffixClass);
       }
+
       // 自定义 Tag 节点
       const displayNode = renderTNodeJSX('valueDisplay', {
         params: {

--- a/packages/tdesign-vue-next/.changelog/pr-6585.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6585.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6585
+contributor: RylanBot
+---
+
+- fix(TagInput): 修复 `excessTagsDisplayType="break-line"` 时，`suffix` 没有固定在右侧的问题 @RylanBot ([#6585](https://github.com/Tencent/tdesign-vue-next/pull/6585))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- https://github.com/Tencent/tdesign-react/pull/4178
- https://github.com/Tencent/tdesign-common/pull/2469

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(TagInput): 修复 `excessTagsDisplayType="break-line"` 时，`suffix` 没有固定在右侧的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
