### PR TITLE
fix(transfer): support object-type values with deep equality comparison

### DIFF
--- a/packages/components/transfer/transfer.tsx
+++ b/packages/components/transfer/transfer.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, computed, toRefs } from 'vue';
-import { pick, isFunction } from 'lodash-es';
+import { pick, isFunction, isEqual } from 'lodash-es';
 
 import TransferList from './components/transfer-list';
 import TransferOperations from './components/transfer-operations';
@@ -113,11 +113,11 @@ export default defineComponent({
       const selfCheckedValue = toDirection === TARGET ? checkedValue.value[SOURCE] : checkedValue.value[TARGET];
       // target->source
       if (toDirection === SOURCE) {
-        newTargetValue = oldTargetValue.filter((v) => !selfCheckedValue.includes(v));
+        newTargetValue = oldTargetValue.filter((v) => !selfCheckedValue.some((cv) => isEqual(cv, v)));
       } else if (props.targetSort === 'original') {
         // 按照原始顺序
         const remainValue = transferData.value.reduce((acc, data) => {
-          if (oldTargetValue.includes(data.value) && data.disabled) {
+          if (oldTargetValue.some((v) => isEqual(v, data.value)) && data.disabled) {
             return acc.concat(data.value);
           }
           return acc;

--- a/packages/components/transfer/utils/index.ts
+++ b/packages/components/transfer/utils/index.ts
@@ -1,5 +1,5 @@
 import { ComponentPublicInstance } from 'vue';
-import { isArray, cloneDeep, isUndefined } from 'lodash-es';
+import { isArray, cloneDeep, isUndefined, isEqual } from 'lodash-es';
 
 import { TransferListOptionBase, TransferItemOption, TdTransferProps, TransferValue, DataOption } from '../types';
 
@@ -10,6 +10,12 @@ export const TRANSFER_NAME = 'TTransfer';
 
 export const SOURCE = 'source';
 export const TARGET = 'target';
+
+// Check if a value exists in an array using deep equality,
+// so that object-type values work correctly with the Transfer component.
+function valueInArray(val: TransferValue, arr: Array<TransferValue>): boolean {
+  return arr.some((item) => isEqual(item, val));
+}
 
 interface TreeNode {
   children?: Array<TreeNode>;
@@ -54,7 +60,7 @@ function getDataValues(
     if (data) {
       for (let i = 0; i < data.length; i++) {
         const item = data[i];
-        const isInclude = filterValues.includes(item.value) && !item.disabled;
+        const isInclude = valueInArray(item.value, filterValues) && !item.disabled;
         if (!include && isInclude) {
           continue; // 排除模式下子元素一律排除
         }
@@ -76,9 +82,9 @@ function getDataValues(
   return data
     .filter((item) => {
       if (!item) return false;
-      const isInclude = filterValues.includes(item.value);
+      const isInclude = valueInArray(item.value, filterValues);
       return (
-        ((include && isInclude) || (!include && !isInclude)) && (!item.disabled || remainValue.includes(item.value))
+        ((include && isInclude) || (!include && !isInclude)) && (!item.disabled || valueInArray(item.value, remainValue))
       );
     })
     .map((item) => item.value);
@@ -115,7 +121,7 @@ function getTransferData(
 }
 
 function isAllNodeValid(data: TransferItemOption, filterValues: Array<TransferValue>, needMatch: boolean): boolean {
-  if (filterValues.includes(data.value)) {
+  if (valueInArray(data.value, filterValues)) {
     return needMatch;
   }
   return false;
@@ -124,7 +130,7 @@ function isAllNodeValid(data: TransferItemOption, filterValues: Array<TransferVa
 function isTreeNodeValid(data: TransferItemOption, filterValues: Array<TransferValue>, needMatch: boolean): boolean {
   if (!data) return !needMatch;
 
-  if (filterValues.includes(data.value)) {
+  if (valueInArray(data.value, filterValues)) {
     return needMatch;
   }
 
@@ -175,11 +181,11 @@ function filterTransferData(
   if (!isTreeMode) {
     if (needMatch) {
       // 正向过滤。要保持filterValues顺序
-      return filterValues?.map((value) => data.find((item) => item.value === value)).filter((item) => !!item);
+      return filterValues?.map((value) => data.find((item) => isEqual(item.value, value))).filter((item) => !!item);
     }
     // 反向过滤
     return data.filter((item) => {
-      const isMatch = filterValues.includes(item.value);
+      const isMatch = valueInArray(item.value, filterValues);
       return !isMatch;
     });
   }

--- a/packages/components/transfer/utils/index.ts
+++ b/packages/components/transfer/utils/index.ts
@@ -84,7 +84,8 @@ function getDataValues(
       if (!item) return false;
       const isInclude = valueInArray(item.value, filterValues);
       return (
-        ((include && isInclude) || (!include && !isInclude)) && (!item.disabled || valueInArray(item.value, remainValue))
+        ((include && isInclude) || (!include && !isInclude)) &&
+        (!item.disabled || valueInArray(item.value, remainValue))
       );
     })
     .map((item) => item.value);

--- a/packages/tdesign-vue-next/.changelog/pr-6587.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6587.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6587
+contributor: hobostay
+---
+
+- fix(Transfer): 修复选项内容为对象时选中异常的问题 @hobostay ([#6587](https://github.com/Tencent/tdesign-vue-next/pull/6587))


### PR DESCRIPTION
## Summary

Fixes #6542

### Problem

The Transfer (穿梭框) component does not work correctly when `value` is an object. Users cannot transfer items back and forth multiple times.

### Root Cause

The component uses `Array.includes()` and `===` for value comparison throughout its codebase. These use **reference equality**, which fails for objects because:

1. **`JSON.parse(JSON.stringify())` in `transferTo()`** (`transfer.tsx:111`) creates new object references, breaking reference equality with the original values
2. **Vue reactivity** may create Proxy wrappers around object values, further breaking `===` comparisons

This causes `filterValues.includes(item.value)` to return `false` even when the objects have identical content, preventing proper filtering and transfer operations.

### Fix

Replace all value comparisons with lodash `isEqual` deep equality:

**`utils/index.ts`** — 7 replacements:
- `filterValues.includes(item.value)` → `valueInArray(item.value, filterValues)` (5 instances)
- `remainValue.includes(item.value)` → `valueInArray(item.value, remainValue)` (1 instance)
- `item.value === value` → `isEqual(item.value, value)` (1 instance)

Added a `valueInArray()` helper that uses `isEqual` for deep comparison.

**`transfer.tsx`** — 2 replacements:
- `selfCheckedValue.includes(v)` → `selfCheckedValue.some((cv) => isEqual(cv, v))`
- `oldTargetValue.includes(data.value)` → `oldTargetValue.some((v) => isEqual(v, data.value))`

### Test Case

```vue
<script setup>
const data = [
  { label: 'a', value: { key1: 'key1', key2: 'key2' } },
  { label: 'b', value: { key1: 'key11', key2: 'key22' } },
];
</script>
<template>
  <t-transfer :data="data" />
</template>
```

Before fix: Can transfer once, but transferring back fails.
After fix: Object values can be transferred back and forth correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Transfer): 修复选项内容为对象时选中异常的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
