### PR TITLE
fix(timeline): align custom dot icons without props

### DIFF
--- a/packages/components/timeline/__tests__/timeline.test.tsx
+++ b/packages/components/timeline/__tests__/timeline.test.tsx
@@ -494,5 +494,12 @@ describe('TimelineItem', () => {
       expect(customNode.classes()).toContain('t-timeline-item__dot-content');
       expect(customNode.classes()).toContain('my-custom-class');
     });
+
+    it(':dot element adds dot-content class when dot has no props', () => {
+      const wrapper = mount(<TimelineItem dot={() => <span>Custom Dot</span>}></TimelineItem>);
+      const customNode = wrapper.find('.t-timeline-item__dot-content');
+      expect(customNode.exists()).toBeTruthy();
+      expect(customNode.text()).toBe('Custom Dot');
+    });
   });
 });

--- a/packages/components/timeline/timeline-item.tsx
+++ b/packages/components/timeline/timeline-item.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, inject } from 'vue';
+import { defineComponent, inject, isVNode } from 'vue';
 import { omit } from 'lodash-es';
 import props from './timeline-item-props';
 import { useContent, useTNodeJSX, usePrefixClass } from '@tdesign/shared-hooks';
@@ -56,8 +56,9 @@ export default defineComponent({
       const dotElement = renderTNodeJSX('dot');
 
       const dotContentClass = `${COMPONENT_NAME.value}__dot-content`;
-      if (dotElement?.props) {
-        const classes = dotElement?.props?.class;
+      if (isVNode(dotElement)) {
+        dotElement.props = dotElement.props || {};
+        const classes = dotElement.props.class;
         dotElement.props.class = classes ? [dotContentClass, classes].join(' ') : dotContentClass;
       }
 

--- a/packages/tdesign-vue-next/.changelog/pr-6613.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6613.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6613
+contributor: nagisa77
+---
+
+- fix(Timeline): 修复部分场景下icon未对齐的问题 @nagisa77 ([#6613](https://github.com/Tencent/tdesign-vue-next/pull/6613))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- tdesign issue（问题反馈入口）：https://github.com/Tencent/tdesign/issues/775  
- 实际修复仓库：`tdesign-vue-next`

badcase代码
```vue
<template>
  <t-space direction="vertical">
    <t-space align="center">
      <h3>时间轴方向</h3>
      <t-radio-group v-model="layout" variant="default-filled">
        <t-radio-button value="vertical">垂直时间轴</t-radio-button>
        <t-radio-button value="horizontal">水平时间轴</t-radio-button>
      </t-radio-group>
    </t-space>
    <t-space align="center">
      <h3>对齐方式</h3>
      <t-radio-group v-model="labelAlign" variant="default-filled">
        <t-radio-button value="left">左对齐</t-radio-button>
        <t-radio-button value="alternate">交错对齐</t-radio-button>
        <t-radio-button value="right">右对齐</t-radio-button>
      </t-radio-group>
    </t-space>
    <t-space align="center">
      <h3>label对齐方式</h3>
      <t-radio-group v-model="mode" variant="default-filled">
        <t-radio-button value="same">同侧</t-radio-button>
        <t-radio-button value="alternate">交错</t-radio-button>
      </t-radio-group>
    </t-space>
    <t-timeline :layout="layout" :label-align="labelAlign" :mode="mode">
      <t-timeline-item
        v-for="(item, index) in options"
        :key="index"
        :label="item.label"
        dot-color="primary"
        :dot="item.dot"
      >
        {{ item.content }}
      </t-timeline-item>
    </t-timeline>
  </t-space>
</template>
<script setup>
import { ref, h } from 'vue';
import { TipsIcon, UserIcon, HeartIcon, HomeIcon } from 'tdesign-icons-vue-next';

const layout = ref('vertical');
const labelAlign = ref('left');
const mode = ref('same');
const options = [
  {
    label: '2022-01-01',
    content: '事件一 icon size 没设置',
    dot: () => h(TipsIcon),
  },
  {
    label: '2022-02-01',
    content: '事件二  icon size medium',
    dot: () => h(UserIcon, { size: 'medium' }),
  },
  {
    label: '2022-03-01',
    content: '事件三 icon size large',
    dot: () => h(HeartIcon, { size: 'large' }),
  },
  {
    label: '2022-04-01',
    content: '事件四 icon size small',
    dot: () => h(HomeIcon, { size: 'small' }),
  },
  {
    label: '2022-01-01',
    content: '事件五 icon size 没设置',
    dot: () => h(TipsIcon),
  },
];
</script>
```

### 💡 需求背景和解决方案

**问题背景**
- 在 `Timeline` 使用自定义 `dot` 时，如果写法是 `dot: () => h(Icon)`（未显式传 props），会出现 icon 与时间轴线未对齐。
- 该问题在混用不同 icon size（默认、small、medium、large）时更明显。

**根因分析**
- `TimelineItem` 中给自定义 dot 注入 `t-timeline-item__dot-content` 类名的逻辑依赖 `dotElement.props` 存在。
- 当 `dot` 返回的 VNode 没有 props 时，类名未注入，导致对应定位样式未生效。

**解决方案**
1. 在 `packages/components/timeline/timeline-item.tsx` 中：
   - 使用 `isVNode(dotElement)` 判断；
   - 当 `props` 为空时先初始化，再统一注入 `t-timeline-item__dot-content`；
   - 保留原有 class 合并逻辑，兼容已有自定义 class。
2. 在 `packages/components/timeline/__tests__/timeline.test.tsx` 中新增回归测试：
   - 覆盖“dot 无 props 时也应注入 `t-timeline-item__dot-content`”场景。

**影响范围**
- 仅影响 `TimelineItem` 自定义 `dot` 的类名注入逻辑；
- 无 API 变更，对默认 dot 和已有 props 的自定义 dot 行为无破坏。

**验证**
- 命令：`pnpm vitest packages/components/timeline/__tests__/timeline.test.tsx`
- 结果：`47 passed`

修改前
<img width="964" height="1160" alt="label对齐方式" src="https://github.com/user-attachments/assets/d76a7fe2-69a3-4dba-9454-af674beb537c" />
修改后
<img width="1074" height="1182" alt="label对齐方式" src="https://github.com/user-attachments/assets/7a35c1d2-8c79-4781-8ab3-67491f3b3b48" />


### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(Timeline): 修复部分场景下icon未对齐的问题

#### @tdesign-vue-next/chat


#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（无 API 变更）
- [x] 代码演示已提供或无须提供（复现场景已在 issue/描述中提供）
- [x] TypeScript 定义已补充或无须补充（无类型定义变更）
- [x] Changelog 已提供或无须提供（已在 `tdesign-vue-next` 填写）
