### PR TITLE
fix(image-viewer): use thumbnail as default trigger image

### DIFF
--- a/packages/components/image-viewer/__tests__/image-viewer.test.tsx
+++ b/packages/components/image-viewer/__tests__/image-viewer.test.tsx
@@ -58,6 +58,41 @@ describe('ImageViewer', () => {
       expect(document.querySelector('.t-image-viewer-preview-image')).toBeTruthy();
     });
 
+    it(':trigger default thumbnail', () => {
+      const wrapper = mount(ImageViewer, {
+        props: {
+          images: [
+            {
+              mainImage: 'https://example.com/main.svg',
+              thumbnail: 'https://example.com/thumb.png',
+            },
+          ],
+        },
+      });
+
+      const img = wrapper.find('.t-image-viewer__trigger img');
+
+      expect(img.exists()).toBeTruthy();
+      expect(img.attributes('src')).toBe('https://example.com/thumb.png');
+    });
+
+    it(':trigger default fallback', () => {
+      const wrapper = mount(ImageViewer, {
+        props: {
+          images: [
+            {
+              mainImage: 'https://example.com/main.svg',
+            },
+          ],
+        },
+      });
+
+      const img = wrapper.find('.t-image-viewer__trigger img');
+
+      expect(img.exists()).toBeTruthy();
+      expect(img.attributes('src')).toBe('https://example.com/main.svg');
+    });
+
     it(':images[string[]]', () => {
       mount(ImageViewer, { props: { visible: true, images } });
       expect(document.querySelector('.t-image-viewer-preview-image')).toMatchSnapshot();

--- a/packages/components/image-viewer/image-viewer.tsx
+++ b/packages/components/image-viewer/image-viewer.tsx
@@ -253,7 +253,7 @@ export default defineComponent({
 
     const renderDefaultTrigger = () => {
       const firstImage = images.value[0] || '';
-      const imageSrc = typeof firstImage === 'string' ? firstImage : firstImage.mainImage || firstImage.thumbnail;
+      const imageSrc = typeof firstImage === 'string' ? firstImage : firstImage.thumbnail || firstImage.mainImage;
       return (
         <div class={`${COMPONENT_NAME.value}__trigger`}>
           <Image src={imageSrc} alt="preview" fit="contain" class={`${COMPONENT_NAME.value}__trigger-img`} />

--- a/packages/tdesign-vue-next/.changelog/pr-6634.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6634.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6634
+contributor: hmingv
+---
+
+- fix(ImageViewer): 修复默认 trigger 使用图片与文档描述不符的问题 @hmingv ([#6634](https://github.com/Tencent/tdesign-vue-next/pull/6634))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

Close #6633

### 💡 需求背景和解决方案

ImageViewer 文档中说明，默认 trigger 是预览图片的缩略图。

但当前实现中，默认 trigger 使用的是 `mainImage || thumbnail`，导致即使传入了 `thumbnail`，默认触发图仍然优先显示 `mainImage`。

### 📝 更新日志

#### tdesign-vue-next
fix(image-viewer): 修复默认 trigger 使用的缩略图图片与文档描述不符的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
