### PR TITLE
fix(dialog): only allow dragging from header area

### DIFF
--- a/packages/components/dialog/dialog-card.tsx
+++ b/packages/components/dialog/dialog-card.tsx
@@ -53,8 +53,10 @@ export default defineComponent({
     // 是否全屏对话框
     const isFullScreen = computed(() => props.mode === 'full-screen');
     const closeBtnAction = (e: MouseEvent) => props?.onCloseBtnClick?.({ e });
+    // modal/modeless 模式开启 draggable 后，仅 header 作为拖拽手柄
+    // body / footer 区域阻止 mousedown 冒泡，避免误触发拖拽
     const onStopDown = (e: MouseEvent) => {
-      if (isModeLess.value && props?.draggable) e.stopPropagation();
+      if (isDraggableMode.value && props?.draggable) e.stopPropagation();
     };
 
     const resetPosition = () => {
@@ -135,14 +137,14 @@ export default defineComponent({
         };
         return (
           (header || props?.closeBtn) && (
-            <div class={headerClassName} onMousedown={onStopDown}>
+            <div class={headerClassName}>
               <div class={`${COMPONENT_NAME.value}__header-content`}>
                 {getIcon()}
                 {header}
               </div>
 
               {props?.closeBtn ? (
-                <span class={closeClassName} onClick={closeBtnAction}>
+                <span class={closeClassName} onClick={closeBtnAction} onMousedown={onStopDown}>
                   {renderTNodeJSX('closeBtn', <CloseIcon />)}
                 </span>
               ) : null}

--- a/packages/tdesign-vue-next/.changelog/pr-6648.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6648.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6648
+contributor: ruguoba
+---
+
+- fix(Dialog): 修复 modal 场景下允许拖动头部以外的区域移动的问题 @ruguoba ([#6648](https://github.com/Tencent/tdesign-vue-next/pull/6648))


### PR DESCRIPTION
## 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

## 问题描述

当 Dialog 开启 `draggable` 属性后，modal 模式下 body 和 footer 区域也可以触发拖拽，导致用户在操作内容时误触发拖拽。

## 修复方案

参考 @uyarn 的建议和 PR #6646 的实现方式：

1. **`dialog-card.tsx`**：
   - 将 `onStopDown` 中的 `isModeLess` 改为 `isDraggableMode`，让 modal 模式也阻止 body/footer 的 mousedown 冒泡
   - 移除 header 上的 `onMousedown={onStopDown}`，保留 header 作为拖拽手柄
   - 在 close 按钮上添加 `onMousedown={onStopDown}`，避免拖拽干扰

2. **`utils/index.ts`**：
   - 恢复为原始实现（移除之前的 header 检查逻辑）

## 效果

- modal/modeless 模式下，只有 header 区域可以触发拖拽
- body 和 footer 区域的操作不会误触发拖拽
- close 按钮的点击也不会触发拖拽

Fixes #6647

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Dialog): 修复 modal 场景下允许拖动头部以外的区域移动的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
