### PR TITLE
fix(pagination): avoid duplicate jumper page change

### DIFF
--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -282,6 +282,33 @@ describe('Pagination', () => {
       wrapper.unmount();
     });
 
+    it('onChange triggers once when jumper enter is followed by blur', async () => {
+      const onChangeFn = vi.fn();
+      const wrapper = mount(<Pagination total={100} defaultCurrent={2} showJumper onChange={onChangeFn} />);
+      const input = wrapper.find('.t-pagination__jump input');
+
+      await input.setValue('3');
+      await input.trigger('keydown', { code: 'Enter', key: 'Enter' });
+      await input.trigger('blur');
+
+      expect(onChangeFn).toHaveBeenCalledTimes(1);
+      expect(onChangeFn.mock.calls[0][0]).toEqual(expect.objectContaining({ current: 3, previous: 2, pageSize: 10 }));
+      wrapper.unmount();
+    });
+
+    it('onChange triggers when jumper only blurs', async () => {
+      const onChangeFn = vi.fn();
+      const wrapper = mount(<Pagination total={100} defaultCurrent={2} showJumper onChange={onChangeFn} />);
+      const input = wrapper.find('.t-pagination__jump input');
+
+      await input.setValue('4');
+      await input.trigger('blur');
+
+      expect(onChangeFn).toHaveBeenCalledTimes(1);
+      expect(onChangeFn.mock.calls[0][0]).toEqual(expect.objectContaining({ current: 4, previous: 2, pageSize: 10 }));
+      wrapper.unmount();
+    });
+
     it('onCurrentChange', async () => {
       const onCurrentChangeFn = vi.fn();
       const wrapper = mount(<Pagination total={100} onCurrentChange={onCurrentChangeFn} />);

--- a/packages/components/pagination/pagination.tsx
+++ b/packages/components/pagination/pagination.tsx
@@ -81,6 +81,7 @@ export default defineComponent({
     );
 
     const jumpIndex = ref(innerCurrent.value);
+    const lastEnterJumpTarget = ref<number>();
 
     const isFolded = computed(() => pageCount.value > props.maxPageBtn);
 
@@ -211,11 +212,32 @@ export default defineComponent({
       });
     };
 
-    const onJumperChange = (val: number) => {
+    const getJumperTarget = (val: string | number) => {
       const currentIndex = Math.trunc(+val);
-      if (isNaN(currentIndex)) return;
+      if (isNaN(currentIndex)) return undefined;
+      return Math.min(Math.max(currentIndex, min), pageCount.value);
+    };
+
+    const onJumperChange = (val: string | number) => {
+      const currentIndex = getJumperTarget(val);
+      if (currentIndex === undefined) return;
       jumpIndex.value = currentIndex;
       toPage(currentIndex);
+    };
+
+    const onJumperEnter = (val: string | number) => {
+      lastEnterJumpTarget.value = getJumperTarget(val);
+      onJumperChange(val);
+    };
+
+    const onJumperBlur = (val: string | number) => {
+      const currentIndex = getJumperTarget(val);
+      if (currentIndex === lastEnterJumpTarget.value) {
+        lastEnterJumpTarget.value = undefined;
+        return;
+      }
+      lastEnterJumpTarget.value = undefined;
+      onJumperChange(val);
     };
 
     return () => {
@@ -229,8 +251,8 @@ export default defineComponent({
             <TInputNumber
               class={CLASS_MAP.jumperInputClass.value}
               v-model={jumpIndex.value}
-              onBlur={onJumperChange}
-              onEnter={onJumperChange}
+              onBlur={onJumperBlur}
+              onEnter={onJumperEnter}
               max={pageCount.value}
               min={min}
               size={size}

--- a/packages/tdesign-vue-next/.changelog/pr-6671.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6671.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6671
+contributor: ruguoba
+---
+
+- fix(Pagination): 修复 showJumper 回车跳页后失焦重复触发分页变化的问题 @ruguoba ([#6671](https://github.com/Tencent/tdesign-vue-next/pull/6671))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix #6635

### 💡 需求背景和解决方案

`Pagination` 开启 `showJumper` 后，在输入页码并按 Enter 跳转时，输入框随后失焦会再次触发同一次跳页逻辑，导致 `onChange` 重复触发。`Table` 透传分页事件后表现为 `page-change` 被触发两次。

本 PR 在 `Pagination` Jumper 内部区分 Enter 与 blur 提交：记录 Enter 已提交的目标页，后续 blur 如果对应同一目标页则跳过重复提交；单独 blur 跳页行为保持不变。

已补充回归测试，覆盖：
- Jumper Enter 后紧随 blur 时 `onChange` 只触发一次
- 仅 blur 时仍正常触发跳页

验证：
- `pnpm vitest run ../../components/pagination/__tests__/pagination.test.tsx`
- `pnpm test:unit`

### 📝 更新日志

#### tdesign-vue-next

- fix(Pagination): 修复 showJumper 回车跳页后失焦重复触发分页变化的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
