### PR TITLE
fix(dialog): add dialog/drawer plugin type export

### DIFF
--- a/packages/components/dialog/index.ts
+++ b/packages/components/dialog/index.ts
@@ -12,4 +12,5 @@ export const Dialog = withInstall(_Dialog);
 export const DialogCard = withInstall(_DialogCard);
 
 export { default as DialogPlugin } from './plugin';
+export type { DialogPluginType } from './plugin';
 export default Dialog;

--- a/packages/components/drawer/index.ts
+++ b/packages/components/drawer/index.ts
@@ -9,4 +9,5 @@ export type DrawerProps = TdDrawerProps;
 
 export const Drawer = withInstall(_Drawer);
 export { default as DrawerPlugin } from './plugin';
+export type { DrawerPluginType } from './plugin';
 export default Drawer;

--- a/packages/tdesign-vue-next/.changelog/pr-6677.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6677.md
@@ -1,0 +1,7 @@
+---
+pr_number: 6677
+contributor: guozi9999
+---
+
+- fix(dialog): 导出 DialogPluginType 类型 @guozi9999 ([#6677](https://github.com/Tencent/tdesign-vue-next/pull/6677))
+- fix(drawer): 导出 DrawerPluginType 类型 @guozi9999 ([#6677](https://github.com/Tencent/tdesign-vue-next/pull/6677))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

fix https://github.com/Tencent/tdesign-vue-next/issues/6674

### 💡 需求背景和解决方案

 **问题**：`DialogPluginType` 和 `DrawerPluginType` 类型没有从 `tdesign-vue-next` 包中导出，用户无法直接导入这些类型，而其他 PluginType 可以直接从包中导入。

**解决方案**：在 `dialog/index.ts` 和 `drawer/index.ts` 中添加类型导出。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(dialog): 导出 DialogPluginType 类型
- fix(drawer): 导出 DrawerPluginType 类型


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
