### PR TITLE
fix(Table): reserve-selected-row-on-paginatesetting breaks when filtering changes the data

### DIFF
--- a/packages/components/table/__tests__/pagination-select.test.tsx
+++ b/packages/components/table/__tests__/pagination-select.test.tsx
@@ -1,0 +1,225 @@
+// @ts-nocheck
+import { defineComponent, ref, nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { PrimaryTable } from '@tdesign/components/table';
+import { getLocalPaginationPageData } from '../utils';
+
+function createTableData(total: number) {
+  return Array.from({ length: total }, (_, index) => ({
+    id: index + 1,
+    name: `row-${index + 1}`,
+  }));
+}
+
+const SELECT_COLUMNS = [
+  { colKey: 'row-select', type: 'multiple', width: 50 },
+  { colKey: 'id', title: 'id' },
+  { colKey: 'name', title: 'name' },
+];
+
+function mountSelectTable(reserveSelectedRowOnPaginate: boolean) {
+  const data = ref(createTableData(12));
+  const selectedRowKeys = ref<(string | number)[]>([]);
+  const pagination = ref({ current: 1, pageSize: 5, total: 12 });
+
+  const TableDemo = defineComponent({
+    setup() {
+      return () => (
+        <PrimaryTable
+          rowKey="id"
+          data={data.value}
+          columns={SELECT_COLUMNS}
+          pagination={pagination.value}
+          selectedRowKeys={selectedRowKeys.value}
+          onUpdate:selectedRowKeys={(value) => {
+            selectedRowKeys.value = value;
+          }}
+          reserveSelectedRowOnPaginate={reserveSelectedRowOnPaginate}
+        />
+      );
+    },
+  });
+
+  const wrapper = mount(TableDemo);
+
+  return { wrapper, data, selectedRowKeys, pagination };
+}
+
+function mountSelectTableByProps(props: Record<string, unknown>) {
+  const selectedRowKeys = ref<(string | number)[]>([]);
+  const wrapper = mount(
+    <PrimaryTable
+      rowKey="id"
+      columns={SELECT_COLUMNS}
+      selectedRowKeys={selectedRowKeys.value}
+      onUpdate:selectedRowKeys={(value) => {
+        selectedRowKeys.value = value;
+      }}
+      {...props}
+    />,
+  );
+  return { wrapper, selectedRowKeys };
+}
+
+async function setHeaderSelectAll(wrapper: ReturnType<typeof mount>, checked: boolean) {
+  const headerCheckboxInput = wrapper.find('.t-table__cell-check input[type="checkbox"]');
+  await headerCheckboxInput.setValue(checked);
+  await nextTick();
+}
+
+describe('getLocalPaginationPageData', () => {
+  const data = createTableData(12);
+
+  it('local pagination works fine', () => {
+    const result = getLocalPaginationPageData(data, { current: 2, pageSize: 5 });
+    expect(result.map((item) => item.id)).toEqual([6, 7, 8, 9, 10]);
+  });
+
+  it('data length less than or equal pageSize works fine', () => {
+    const shortData = createTableData(3);
+    const result = getLocalPaginationPageData(shortData, { current: 1, pageSize: 5 });
+    expect(result).toHaveLength(3);
+  });
+
+  it('disableDataPage is true works fine', () => {
+    const pageData = createTableData(5);
+    const result = getLocalPaginationPageData(pageData, { current: 1, pageSize: 5 }, true);
+    expect(result).toHaveLength(5);
+  });
+
+  it('pagination is undefined works fine', () => {
+    const result = getLocalPaginationPageData(data, undefined, false);
+    expect(result).toHaveLength(12);
+  });
+});
+
+describe('reserveSelectedRowOnPaginate', () => {
+  it('reserveSelectedRowOnPaginate={false}: header select all only selects current page rows', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTable(false);
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(5);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('reserveSelectedRowOnPaginate={true}: header select all selects all rows across pages', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTable(true);
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(12);
+    expect(selectedRowKeys.value).toEqual(createTableData(12).map((item) => item.id));
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: after data changes header select all still selects current page only', async () => {
+    const { wrapper, data, selectedRowKeys, pagination } = mountSelectTable(false);
+
+    data.value = createTableData(6);
+    pagination.value = { current: 1, pageSize: 5, total: 6 };
+    await nextTick();
+
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(5);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: after data reference changes with same length, display and select all stay on current page', async () => {
+    const { wrapper, data, selectedRowKeys } = mountSelectTable(false);
+
+    data.value = Array.from({ length: 12 }, (_, index) => ({
+      id: index + 101,
+      name: `new-row-${index + 1}`,
+    }));
+    await nextTick();
+
+    expect(wrapper.findAll('tbody tr')).toHaveLength(5);
+    expect(wrapper.find('tbody tr').text()).toContain('new-row-1');
+
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(5);
+    expect(selectedRowKeys.value).toEqual([101, 102, 103, 104, 105]);
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: after in-place push, header select all still follows current page', async () => {
+    const { wrapper, data, selectedRowKeys, pagination } = mountSelectTable(false);
+
+    data.value.push({ id: 13, name: 'row-13' });
+    pagination.value = { ...pagination.value, total: 13 };
+    await nextTick();
+
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(5);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('reserveSelectedRowOnPaginate={true}: after data changes header select all selects all filtered rows', async () => {
+    const { wrapper, data, selectedRowKeys, pagination } = mountSelectTable(true);
+
+    data.value = createTableData(6);
+    pagination.value = { current: 1, pageSize: 5, total: 6 };
+    await nextTick();
+
+    await setHeaderSelectAll(wrapper, true);
+
+    expect(selectedRowKeys.value).toHaveLength(6);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: selected keys should be cleared when paginating', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTable(false);
+    await setHeaderSelectAll(wrapper, true);
+    expect(selectedRowKeys.value).toHaveLength(5);
+
+    const nextButton = wrapper.find('.t-pagination__btn-next');
+    await nextButton.trigger('click');
+    await nextTick();
+
+    expect(selectedRowKeys.value).toHaveLength(0);
+  });
+
+  it('reserveSelectedRowOnPaginate={true}: selected keys should be kept when paginating', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTable(true);
+    await setHeaderSelectAll(wrapper, true);
+    expect(selectedRowKeys.value).toHaveLength(12);
+
+    const nextButton = wrapper.find('.t-pagination__btn-next');
+    await nextButton.trigger('click');
+    await nextTick();
+
+    expect(selectedRowKeys.value).toHaveLength(12);
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: uncheck header select all should clear current-page keys', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTable(false);
+    await setHeaderSelectAll(wrapper, true);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5]);
+
+    await setHeaderSelectAll(wrapper, false);
+    expect(selectedRowKeys.value).toEqual([]);
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: disableDataPage=true should select all passed data', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTableByProps({
+      data: createTableData(12),
+      pagination: { current: 1, pageSize: 5, total: 12 },
+      disableDataPage: true,
+      reserveSelectedRowOnPaginate: false,
+    });
+
+    await setHeaderSelectAll(wrapper, true);
+    expect(selectedRowKeys.value).toEqual(createTableData(12).map((item) => item.id));
+  });
+
+  it('reserveSelectedRowOnPaginate={false}: uncontrolled pagination should still select current page only', async () => {
+    const { wrapper, selectedRowKeys } = mountSelectTableByProps({
+      data: createTableData(12),
+      pagination: { defaultCurrent: 1, defaultPageSize: 5, total: 12 },
+      reserveSelectedRowOnPaginate: false,
+    });
+
+    await setHeaderSelectAll(wrapper, true);
+    expect(selectedRowKeys.value).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/packages/components/table/hooks/usePagination.tsx
+++ b/packages/components/table/hooks/usePagination.tsx
@@ -2,6 +2,7 @@ import { Ref, ref, SetupContext, toRefs, watch } from 'vue';
 import { useConfig } from '@tdesign/shared-hooks';
 import Pagination, { PageInfo, PaginationProps } from '../../pagination';
 import { TdBaseTableProps, TableRowData } from '../type';
+import { getLocalPaginationPageData } from '../utils';
 
 // 分页功能包含：远程数据排序受控、远程数据排序非受控、本地数据排序受控、本地数据排序非受控 等 4 类功能
 export default function usePagination(
@@ -21,18 +22,12 @@ export default function usePagination(
     // data 数据数量超出分页大小时，则自动启动本地数据分页
     const t = Boolean(!disableDataPage.value && data.length > pageSize);
     isPaginateData.value = t;
-    if (t) {
-      const start = (current - 1) * pageSize;
-      const end = current * pageSize;
-      dataSource.value = data.slice(start, end);
-    } else {
-      dataSource.value = data;
-    }
+    dataSource.value = getLocalPaginationPageData(data, { current, pageSize }, disableDataPage.value);
   };
 
-  // 受控情况，只有 pagination.current 或者 pagination.pageSize 变化，才对数据进行排序
+  // 受控情况：current / pageSize / data 引用或条数变化时，同步本地分页展示数据
   watch(
-    () => [pagination.value?.current, pagination.value?.pageSize, data.value.length, disableDataPage],
+    [data, () => data.value.length, () => pagination.value?.current, () => pagination.value?.pageSize, disableDataPage],
     () => {
       if (!pagination.value || !pagination.value.current) return;
       const { current, pageSize } = pagination.value;

--- a/packages/components/table/hooks/useRowSelect.tsx
+++ b/packages/components/table/hooks/useRowSelect.tsx
@@ -26,9 +26,7 @@ export default function useRowSelect(
 ) {
   const { selectedRowKeys, columns, rowKey, data, reserveSelectedRowOnPaginate, pagination, disableDataPage } =
     toRefs(props);
-  const updateCurrentPaginateData = () => {
-    currentPaginateData.value = getLocalPaginationPageData(data.value, pagination.value, disableDataPage.value);
-  };
+
   const currentPaginateData = ref<TableRowData[]>(
     getLocalPaginationPageData(data.value, pagination.value, disableDataPage.value),
   );
@@ -78,6 +76,10 @@ export default function useRowSelect(
     },
     { immediate: true },
   );
+
+  const updateCurrentPaginateData = () => {
+    currentPaginateData.value = getLocalPaginationPageData(data.value, pagination.value, disableDataPage.value);
+  };
 
   // data / 分页变化时同步当前页数据：本地分页需 slice，远程分页 data 本身即为当前页
   watch([data, () => pagination.value?.current, () => pagination.value?.pageSize, disableDataPage], () => {

--- a/packages/components/table/hooks/useRowSelect.tsx
+++ b/packages/components/table/hooks/useRowSelect.tsx
@@ -14,6 +14,7 @@ import {
   TdPrimaryTableProps,
 } from '../type';
 import { isRowSelectedDisabled } from '@tdesign/common-js/table/utils';
+import { getLocalPaginationPageData } from '../utils';
 import { TableClassName } from './useClassName';
 import Checkbox from '../../checkbox';
 import Radio, { RadioProps } from '../../radio';
@@ -23,14 +24,13 @@ export default function useRowSelect(
   props: TdPrimaryTableProps,
   tableSelectedClasses: TableClassName['tableSelectedClasses'],
 ) {
-  const { selectedRowKeys, columns, rowKey, data, reserveSelectedRowOnPaginate, pagination } = toRefs(props);
+  const { selectedRowKeys, columns, rowKey, data, reserveSelectedRowOnPaginate, pagination, disableDataPage } =
+    toRefs(props);
+  const updateCurrentPaginateData = () => {
+    currentPaginateData.value = getLocalPaginationPageData(data.value, pagination.value, disableDataPage.value);
+  };
   const currentPaginateData = ref<TableRowData[]>(
-    pagination.value
-      ? data.value.slice(
-          (pagination.value.current - 1) * pagination.value.pageSize,
-          pagination.value.current * pagination.value.pageSize,
-        )
-      : data.value,
+    getLocalPaginationPageData(data.value, pagination.value, disableDataPage.value),
   );
   const selectedRowClassNames = ref();
   const [tSelectedRowKeys, setTSelectedRowKeys] = useDefaultValue(
@@ -79,9 +79,9 @@ export default function useRowSelect(
     { immediate: true },
   );
 
-  // 在远程分页场景下，当前页全选功能的状态判定需基于当前页数据是否存在进行动态重新计算
-  watch(data, () => {
-    currentPaginateData.value = data.value;
+  // data / 分页变化时同步当前页数据：本地分页需 slice，远程分页 data 本身即为当前页
+  watch([data, () => pagination.value?.current, () => pagination.value?.pageSize, disableDataPage], () => {
+    updateCurrentPaginateData();
   });
 
   function isDisabled(row: Record<string, any>, rowIndex: number): boolean {

--- a/packages/components/table/utils/index.ts
+++ b/packages/components/table/utils/index.ts
@@ -2,6 +2,7 @@ import { isFunction, get, isObject } from 'lodash-es';
 import { CellData, RowClassNameParams, TableColumnClassName, TableRowData, TdBaseTableProps } from '../type';
 import { ClassName, HTMLElementAttributes } from '../../common';
 import { AffixProps } from '../../affix';
+import { PaginationProps } from '../../pagination';
 
 export function toString(obj: any): string {
   return Object.prototype.toString.call(obj).slice(8, -1).toLowerCase();
@@ -99,6 +100,27 @@ export function getCurrentRowByKey<T extends { colKey?: string; children?: any[]
       return getCurrentRowByKey(columns[i]?.children, key);
     }
   }
+}
+
+/**
+ * 获取本地分页场景下的当前页数据；远程分页或数据不足一页时返回完整 data
+ */
+export function getLocalPaginationPageData(
+  data: TableRowData[],
+  pagination?: PaginationProps,
+  disableDataPage?: boolean,
+): TableRowData[] {
+  if (!pagination) return data;
+
+  const current = pagination.current ?? pagination.defaultCurrent ?? 1;
+  const pageSize = pagination.pageSize ?? pagination.defaultPageSize ?? 10;
+  const shouldPaginate = !disableDataPage && data.length > pageSize;
+
+  if (!shouldPaginate) return data;
+
+  const start = (current - 1) * pageSize;
+  const end = current * pageSize;
+  return data.slice(start, end);
 }
 
 /** 透传 Affix 组件全部特性 */

--- a/packages/tdesign-vue-next/.changelog/pr-6687.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6687.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6687
+contributor: RSS1102
+---
+
+- fix(table): 修复筛选导致数据变更后 `reserve-selected-row-on-paginate=false` 失效的问题 @RSS1102 ([#6687](https://github.com/Tencent/tdesign-vue-next/pull/6687))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
本地分页下，将「当前页数据」的 slice 逻辑提取为 getLocalPaginationPageData。
供 usePagination（展示）与 useRowSelect（当前页全选）复用。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

- fix(table): 修复筛选导致数据变更后 `reserve-selected-row-on-paginate=false` 失效的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
