### PR TITLE
fix(Drawer): destroyOnClose don't take effect during initialization

### DIFF
--- a/packages/components/config-provider/__tests__/config-provider.test.ts
+++ b/packages/components/config-provider/__tests__/config-provider.test.ts
@@ -49,7 +49,7 @@ describe('ConfigProvider Works with Plugins', () => {
 
     MessagePlugin.success({ content: 'Message Content', duration: 10 });
 
-    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     // Check that the attach element has the custom prefix class
     expect(document.getElementsByClassName(`${customPrefix}-loading`).length).toBe(1);

--- a/packages/components/drawer/drawer.tsx
+++ b/packages/components/drawer/drawer.tsx
@@ -203,7 +203,12 @@ export default defineComponent({
           if (destroyOnCloseVisible.value) {
             destroyOnCloseVisible.value = false;
           }
-          setTimeout(() => (destroyOnCloseVisible.value = true), 300);
+          // 首次加载（初始化）且为关闭状态时，无需等待动画，立即设置 destroyOnCloseVisible，避免初始 DOM 存在
+          if (!isMounted.value) {
+            destroyOnCloseVisible.value = true;
+          } else {
+            setTimeout(() => (destroyOnCloseVisible.value = true), 300);
+          }
         }
         return;
       }
@@ -280,6 +285,10 @@ export default defineComponent({
 
     const shouldRender = computed(() => {
       if (!isMounted.value) {
+        // 如果开启了 destroyOnClose 且当前处于 destroyOnCloseVisible 状态，初始化时不应渲染内容
+        if (props.destroyOnClose && destroyOnCloseVisible.value) {
+          return false;
+        }
         return !props.lazy;
       } else {
         return isVisible.value || !destroyOnCloseVisible.value;

--- a/packages/tdesign-vue-next/.changelog/pr-6702.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6702.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6702
+contributor: Wesley-0808
+---
+
+- fix(Drawer): 修复开启 `destroyOnClose` 时，初始状态下内容未销毁的问题。 @Wesley-0808 ([#6702](https://github.com/Tencent/tdesign-vue-next/pull/6702))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #6701
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

修复后 #6700 所提及的问题同步修复
<img width="1067" height="673" alt="image" src="https://github.com/user-attachments/assets/94eb7338-3e70-4c05-985d-1db44888d161" />

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Drawer): 修复开启 `destroyOnClose` 时，初始状态下内容未销毁的问题。

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
