### PR TITLE
feat(chat): add ChatThoughtChain component

### DIFF
--- a/packages/pro-components/chat/chat-thought-chain/__tests__/__snapshots__/index.test.jsx.snap
+++ b/packages/pro-components/chat/chat-thought-chain/__tests__/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,185 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ChatThoughtChain > :props > :items - array 1`] = `
+<div
+  class="t-chat__thought-chain"
+>
+  
+  <div
+    class="t-chat__thought-chain-item t-chat__thought-chain-item--success"
+  >
+    <div
+      class="t-chat__thought-chain-item__node"
+    >
+      <span
+        class="t-chat__thought-chain-item__icon"
+      >
+        <svg
+          class="t-icon t-icon-check-circle"
+          fill="none"
+          height="1em"
+          style="fill: none;"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <g
+            id="check-circle"
+          >
+            <path
+              d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12Z"
+              fill="transparent"
+              id="fill1"
+            />
+            <path
+              d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12Z"
+              id="stroke1"
+              stroke="currentColor"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+            <path
+              d="M16.5 9L10.5 15L7.5 12"
+              id="stroke2"
+              stroke="currentColor"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+      </span>
+      <span
+        class="t-chat__thought-chain-item__line"
+      />
+    </div>
+    <div
+      class="t-chat__thought-chain-item__detail"
+    >
+      <div
+        class="t-chat__thought-chain-item__header t-chat__thought-chain-item__header--collapsible"
+      >
+        <span
+          class="t-chat__thought-chain-item__title"
+        >
+          分析问题
+        </span>
+        <svg
+          class="t-icon t-icon-chevron-down t-chat__thought-chain-item__arrow"
+          fill="none"
+          height="1em"
+          style="fill: none;"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <g
+            id="chevron-down"
+          >
+            <path
+              d="M17.5 9.5L12 15L6.5 9.5"
+              id="stroke1"
+              stroke="currentColor"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <div
+    class="t-chat__thought-chain-item t-chat__thought-chain-item--processing"
+  >
+    <div
+      class="t-chat__thought-chain-item__node"
+    >
+      <span
+        class="t-chat__thought-chain-item__icon"
+      >
+        <svg
+          class="t-icon t-icon-loading"
+          fill="none"
+          height="1em"
+          style="fill: none;"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M12 2.25C6.61556 2.25 2.25 6.61556 2.25 12C2.25 17.3844 6.61556 21.75 12 21.75V19.3125C7.96142 19.3125 4.6875 16.0386 4.6875 12C4.6875 7.96142 7.96142 4.6875 12 4.6875C16.0386 4.6875 19.3125 7.96142 19.3125 12H21.75C21.75 6.61556 17.3844 2.25 12 2.25Z"
+            fill="currentColor"
+            id="loading"
+          />
+        </svg>
+      </span>
+      <span
+        class="t-chat__thought-chain-item__line"
+      />
+    </div>
+    <div
+      class="t-chat__thought-chain-item__detail"
+    >
+      <div
+        class="t-chat__thought-chain-item__header t-chat__thought-chain-item__header--collapsible"
+      >
+        <span
+          class="t-chat__thought-chain-item__title"
+        >
+          检索资料
+        </span>
+        <svg
+          class="t-icon t-icon-chevron-down t-chat__thought-chain-item__arrow"
+          fill="none"
+          height="1em"
+          style="fill: none;"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <g
+            id="chevron-down"
+          >
+            <path
+              d="M17.5 9.5L12 15L6.5 9.5"
+              id="stroke1"
+              stroke="currentColor"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
+      </div>
+      <!---->
+    </div>
+  </div>
+  <div
+    class="t-chat__thought-chain-item t-chat__thought-chain-item--pending"
+  >
+    <div
+      class="t-chat__thought-chain-item__node"
+    >
+      <span
+        class="t-chat__thought-chain-item__icon"
+      >
+        <span
+          class="t-chat__thought-chain-dot"
+        />
+      </span>
+      <!---->
+    </div>
+    <div
+      class="t-chat__thought-chain-item__detail"
+    >
+      <div
+        class="t-chat__thought-chain-item__header"
+      >
+        <span
+          class="t-chat__thought-chain-item__title"
+        >
+          输出回答
+        </span>
+        <!---->
+      </div>
+      <!---->
+    </div>
+  </div>
+  
+</div>
+`;

--- a/packages/pro-components/chat/chat-thought-chain/__tests__/index.test.jsx
+++ b/packages/pro-components/chat/chat-thought-chain/__tests__/index.test.jsx
@@ -1,0 +1,78 @@
+import { mount } from '@vue/test-utils';
+import { vi } from 'vitest';
+import ChatThoughtChain from '@tdesign/pro-components-chat/chat-thought-chain/index';
+
+const items = [
+  { key: 'a', title: '分析问题', content: '分析中的详细内容', status: 'success' },
+  { key: 'b', title: '检索资料', content: '检索的详细内容', status: 'processing' },
+  { key: 'c', title: '输出回答', status: 'pending' },
+];
+
+describe('ChatThoughtChain', () => {
+  describe(':props', () => {
+    it(':items - array', () => {
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items },
+      });
+      const nodes = wrapper.findAll('.t-chat__thought-chain-item');
+      expect(nodes.length).toBe(3);
+      expect(nodes[0].classes()).toContain('t-chat__thought-chain-item--success');
+      expect(nodes[1].classes()).toContain('t-chat__thought-chain-item--processing');
+      expect(nodes[2].classes()).toContain('t-chat__thought-chain-item--pending');
+      expect(wrapper.element).toMatchSnapshot();
+    });
+
+    it(':defaultExpandedValue - array', () => {
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items, defaultExpandedValue: ['a'] },
+      });
+      const contents = wrapper.findAll('.t-chat__thought-chain-item__content');
+      expect(contents.length).toBe(1);
+      expect(contents[0].text()).toBe('分析中的详细内容');
+    });
+
+    it(':collapsible - false', async () => {
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items, collapsible: false },
+      });
+      await wrapper.findAll('.t-chat__thought-chain-item__header')[0].trigger('click');
+      expect(wrapper.findAll('.t-chat__thought-chain-item__content').length).toBe(0);
+      expect(wrapper.findAll('.t-chat__thought-chain-item__arrow').length).toBe(0);
+    });
+
+    it(':icon - custom slot', () => {
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items },
+        slots: {
+          icon: ({ item }) => <span class="custom-icon">{item.key}</span>,
+        },
+      });
+      expect(wrapper.findAll('.custom-icon').length).toBe(3);
+    });
+  });
+
+  describe('@event', () => {
+    it('onExpandChange', async () => {
+      const onExpandChange = vi.fn();
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items, onExpandChange },
+      });
+      await wrapper.findAll('.t-chat__thought-chain-item__header')[0].trigger('click');
+      expect(onExpandChange).toHaveBeenCalledWith(['a'], expect.objectContaining({ index: 0, expanded: true }));
+      expect(wrapper.findAll('.t-chat__thought-chain-item__content').length).toBe(1);
+
+      await wrapper.findAll('.t-chat__thought-chain-item__header')[0].trigger('click');
+      expect(onExpandChange).toHaveBeenCalledWith([], expect.objectContaining({ index: 0, expanded: false }));
+    });
+
+    it('expandedValue - controlled', async () => {
+      const wrapper = mount(ChatThoughtChain, {
+        props: { items, expandedValue: ['b'] },
+      });
+      expect(wrapper.findAll('.t-chat__thought-chain-item__content').length).toBe(1);
+      // 受控模式下点击不直接改变展开状态
+      await wrapper.findAll('.t-chat__thought-chain-item__header')[0].trigger('click');
+      expect(wrapper.findAll('.t-chat__thought-chain-item__content').length).toBe(1);
+    });
+  });
+});

--- a/packages/pro-components/chat/chat-thought-chain/_example/thought-chain-custom.vue
+++ b/packages/pro-components/chat/chat-thought-chain/_example/thought-chain-custom.vue
@@ -1,0 +1,25 @@
+<template>
+  <t-chat-thought-chain :items="items" :default-expanded-value="[1]">
+    <template #icon="{ item }">
+      <SearchIcon v-if="item.key === 'search'" />
+    </template>
+    <template #content="{ item }">
+      <div v-if="item.key === 'search'">
+        <t-tag v-for="doc in docs" :key="doc" theme="primary" variant="light" style="margin: 0 8px 4px 0">
+          {{ doc }}
+        </t-tag>
+      </div>
+    </template>
+  </t-chat-thought-chain>
+</template>
+<script setup>
+import { SearchIcon } from 'tdesign-icons-vue-next';
+
+const docs = ['产品白皮书.pdf', '性能测试报告.xlsx', 'API 设计文档.md'];
+
+const items = [
+  { title: '理解问题', content: '识别为产品技术选型类问题。', status: 'success' },
+  { key: 'search', title: '检索知识库', status: 'success' },
+  { title: '生成回答', status: 'error', content: '生成超时，已自动重试。' },
+];
+</script>

--- a/packages/pro-components/chat/chat-thought-chain/_example/thought-chain-stream.vue
+++ b/packages/pro-components/chat/chat-thought-chain/_example/thought-chain-stream.vue
@@ -1,0 +1,35 @@
+<template>
+  <t-space direction="vertical" style="width: 100%">
+    <t-button :disabled="running" @click="start">{{ running ? '规划执行中...' : '模拟 Agent 执行' }}</t-button>
+    <t-chat-thought-chain v-model:expanded-value="expandedValue" :items="items" />
+  </t-space>
+</template>
+<script setup>
+import { ref } from 'vue';
+
+const PLAN = [
+  { key: 'intent', title: '理解任务目标', content: '解析用户输入，确认任务为多步骤数据分析。' },
+  { key: 'plan', title: '制定执行计划', content: '拆分为数据拉取、清洗、统计、生成报告 4 个子任务。' },
+  { key: 'tool', title: '调用工具执行', content: '调用 SQL 工具拉取近 30 天数据并完成聚合统计。' },
+  { key: 'report', title: '汇总生成报告', content: '整合各步骤结果，生成最终分析报告。' },
+];
+
+const items = ref([]);
+const expandedValue = ref([]);
+const running = ref(false);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const start = async () => {
+  running.value = true;
+  items.value = [];
+  expandedValue.value = [];
+  for (const step of PLAN) {
+    items.value = [...items.value, { ...step, status: 'processing' }];
+    expandedValue.value = [...expandedValue.value, step.key];
+    await sleep(1200);
+    items.value = items.value.map((it) => (it.key === step.key ? { ...it, status: 'success' } : it));
+  }
+  running.value = false;
+};
+</script>

--- a/packages/pro-components/chat/chat-thought-chain/_example/thought-chain.vue
+++ b/packages/pro-components/chat/chat-thought-chain/_example/thought-chain.vue
@@ -1,0 +1,34 @@
+<template>
+  <t-chat-thought-chain :items="items" :default-expanded-value="['search']" @expand-change="onExpandChange" />
+</template>
+<script setup>
+const items = [
+  {
+    key: 'analyze',
+    title: '分析用户问题',
+    content: '拆解用户意图：需要对比 3 款产品在性能、价格、生态上的差异。',
+    status: 'success',
+  },
+  {
+    key: 'search',
+    title: '检索相关资料',
+    content: '已检索 12 篇文档，筛选出 4 篇高相关内容作为回答依据。',
+    status: 'success',
+  },
+  {
+    key: 'plan',
+    title: '生成回答计划',
+    content: '按"结论先行 + 维度对比表格 + 选型建议"的结构组织回答。',
+    status: 'processing',
+  },
+  {
+    key: 'answer',
+    title: '输出最终回答',
+    status: 'pending',
+  },
+];
+
+const onExpandChange = (value, context) => {
+  console.log('expand-change', value, context);
+};
+</script>

--- a/packages/pro-components/chat/chat-thought-chain/chat-thought-chain-props.ts
+++ b/packages/pro-components/chat/chat-thought-chain/chat-thought-chain-props.ts
@@ -1,0 +1,52 @@
+/* eslint-disable */
+
+/**
+ * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
+ * */
+
+import { TdChatThoughtChainProps } from '../type';
+import { PropType } from 'vue';
+
+export default {
+  /** 是否支持折叠每个思考节点的内容 */
+  collapsible: {
+    type: Boolean as PropType<TdChatThoughtChainProps['collapsible']>,
+    default: true,
+  },
+  /** 思维链节点列表 */
+  items: {
+    type: Array as PropType<TdChatThoughtChainProps['items']>,
+    default: (): TdChatThoughtChainProps['items'] => [],
+  },
+  /** 展开的节点。支持语法糖 v-model:expandedValue */
+  expandedValue: {
+    type: Array as PropType<TdChatThoughtChainProps['expandedValue']>,
+    default: undefined as TdChatThoughtChainProps['expandedValue'],
+  },
+  modelValue: {
+    type: Array as PropType<TdChatThoughtChainProps['expandedValue']>,
+    default: undefined as TdChatThoughtChainProps['expandedValue'],
+  },
+  /** 展开的节点。非受控属性 */
+  defaultExpandedValue: {
+    type: Array as PropType<TdChatThoughtChainProps['defaultExpandedValue']>,
+    default: (): TdChatThoughtChainProps['defaultExpandedValue'] => [],
+  },
+  /** 自定义节点内容 */
+  content: {
+    type: Function as PropType<TdChatThoughtChainProps['content']>,
+  },
+  /** 自定义节点图标 */
+  icon: {
+    type: Function as PropType<TdChatThoughtChainProps['icon']>,
+  },
+  /** 自定义节点标题 */
+  title: {
+    type: Function as PropType<TdChatThoughtChainProps['title']>,
+  },
+  /** 节点展开/收起时触发 */
+  onExpandChange: {
+    type: Function as PropType<TdChatThoughtChainProps['onExpandChange']>,
+    default: () => {},
+  },
+};

--- a/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.less
+++ b/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.less
@@ -1,0 +1,133 @@
+// 临时样式：待 UI 样式沉淀到 tdesign-common 子仓库后迁移并删除该文件
+.t-chat__thought-chain {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  color: var(--td-text-color-primary);
+
+  &-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 2px solid var(--td-component-border);
+    box-sizing: border-box;
+  }
+
+  &-item {
+    display: flex;
+    gap: 8px;
+
+    &__node {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 20px;
+      flex-shrink: 0;
+    }
+
+    &__icon {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 22px;
+      font-size: 16px;
+      color: var(--td-text-color-placeholder);
+    }
+
+    &__line {
+      flex: 1;
+      width: 1px;
+      background: var(--td-component-stroke);
+      margin: 2px 0;
+    }
+
+    &__detail {
+      flex: 1;
+      min-width: 0;
+      padding-bottom: 16px;
+    }
+
+    &:last-child &__detail {
+      padding-bottom: 0;
+    }
+
+    &__header {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      min-height: 22px;
+      line-height: 22px;
+
+      &--collapsible {
+        cursor: pointer;
+      }
+    }
+
+    &__title {
+      font-weight: 500;
+    }
+
+    &__arrow {
+      font-size: 16px;
+      color: var(--td-text-color-placeholder);
+      transition: transform 0.2s;
+    }
+
+    &--expanded &__arrow {
+      transform: rotate(180deg);
+    }
+
+    &__content {
+      margin-top: 4px;
+      font-size: 13px;
+      line-height: 22px;
+      color: var(--td-text-color-secondary);
+    }
+
+    &--success &__icon {
+      color: var(--td-success-color);
+    }
+
+    &--error &__icon {
+      color: var(--td-error-color);
+    }
+
+    &--processing &__icon {
+      color: var(--td-brand-color);
+
+      .t-icon-loading {
+        animation: t-chat-thought-chain-spin 1s linear infinite;
+      }
+    }
+
+    &--processing &__title {
+      background: linear-gradient(90deg, var(--td-text-color-primary) 25%, var(--td-brand-color) 50%, var(--td-text-color-primary) 75%);
+      background-size: 200% 100%;
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+      animation: t-chat-thought-chain-flow 2s linear infinite;
+    }
+  }
+}
+
+@keyframes t-chat-thought-chain-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes t-chat-thought-chain-flow {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: 0 0;
+  }
+}

--- a/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.md
+++ b/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.md
@@ -1,0 +1,32 @@
+:: BASE_DOC ::
+
+## API
+
+### ChatThoughtChain Props
+
+名称 | 类型 | 默认值 | 描述 | 必传
+-- | -- | -- | -- | --
+collapsible | Boolean | true | 是否支持折叠每个思考节点的内容 | N
+items | Array | [] | 思维链节点列表。TS 类型：`TdThoughtChainItem[]`。[详细类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/pro-components/chat/type.ts) | N
+expandedValue | Array | [] | 展开的节点。支持语法糖 v-model:expandedValue。TS 类型：`Array<string \| number>` | N
+defaultExpandedValue | Array | [] | 展开的节点。非受控属性。TS 类型：`Array<string \| number>` | N
+title | Slot / Function | - | 自定义节点标题。TS 类型：`TNode<{ item: TdThoughtChainItem; index: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
+content | Slot / Function | - | 自定义节点内容。TS 类型：`TNode<{ item: TdThoughtChainItem; index: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
+icon | Slot / Function | - | 自定义节点图标，优先级高于节点 status 对应的默认图标。TS 类型：`TNode<{ item: TdThoughtChainItem; index: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue-next/blob/develop/packages/components/common.ts) | N
+onExpandChange | Function | — | TS 类型：`(value: Array<string \| number>, context: { item: TdThoughtChainItem; index: number; expanded: boolean }) => void`<br/>节点展开/收起时触发 | N
+
+### TdThoughtChainItem
+
+名称 | 类型 | 默认值 | 描述 | 必传
+-- | -- | -- | -- | --
+key | String / Number | - | 节点唯一标识，缺省时使用节点索引 | N
+title | String / Function | - | 节点标题。TS 类型：`string \| TNode` | N
+content | String / Function | - | 节点描述内容，为空时该节点不可展开。TS 类型：`string \| TNode` | N
+status | String | pending | 节点状态。可选项：pending/processing/success/error | N
+icon | Function | - | 自定义节点图标，优先级高于 status 对应的默认图标。TS 类型：`TNode` | N
+
+### ChatThoughtChain Events
+
+名称 | 参数 | 描述
+-- | -- | --
+expand-change | `(value: Array<string \| number>, context: { item: TdThoughtChainItem; index: number; expanded: boolean })` | 节点展开/收起时触发

--- a/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.md
+++ b/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.md
@@ -1,4 +1,30 @@
-:: BASE_DOC ::
+---
+title: ChatThoughtChain 思维链
+description: 以时间线形式结构化展示 AI 的思考过程与执行计划，适用于深度思考、Agent 任务规划等场景。
+isComponent: true
+usage: { title: '', description: '' }
+spline: ai
+---
+
+## 组件类型
+
+### 基础思维链
+
+通过 `items` 配置思考节点，每个节点支持标题、内容与状态（`pending`/`processing`/`success`/`error`），内容可折叠展开。
+
+{{ thought-chain }}
+
+### 流式执行场景
+
+配合 Agent 流式执行，逐步追加节点并更新状态，`processing` 状态自带加载动画。
+
+{{ thought-chain-stream }}
+
+### 自定义节点
+
+通过 `icon`、`title`、`content` 插槽（携带 `{ item, index }` 参数）自定义任意节点的渲染。
+
+{{ thought-chain-custom }}
 
 ## API
 

--- a/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.tsx
+++ b/packages/pro-components/chat/chat-thought-chain/chat-thought-chain.tsx
@@ -1,0 +1,93 @@
+import { defineComponent, computed, toRefs } from 'vue';
+import { CheckCircleIcon, ErrorCircleIcon, ChevronDownIcon, LoadingIcon } from 'tdesign-icons-vue-next';
+import { usePrefixClass, useTNodeJSX, useVModel } from '@tdesign/shared-hooks';
+import props from './chat-thought-chain-props';
+import type { TdThoughtChainItem } from '../type';
+import './chat-thought-chain.less';
+
+export default defineComponent({
+  name: 'TChatThoughtChain',
+  props,
+  emits: ['update:expandedValue'],
+  setup(props) {
+    const COMPONENT_NAME = usePrefixClass('chat');
+    const renderTNodeJSX = useTNodeJSX();
+    const baseClass = computed(() => `${COMPONENT_NAME.value}__thought-chain`);
+
+    const { expandedValue, modelValue } = toRefs(props);
+    const [innerExpanded, setInnerExpanded] = useVModel(
+      expandedValue,
+      modelValue,
+      props.defaultExpandedValue,
+      props.onExpandChange,
+      'expandedValue',
+    );
+
+    const getItemKey = (item: TdThoughtChainItem, index: number) => item.key ?? index;
+
+    const isExpanded = (item: TdThoughtChainItem, index: number) =>
+      (innerExpanded.value || []).includes(getItemKey(item, index));
+
+    const toggleExpand = (item: TdThoughtChainItem, index: number) => {
+      if (!props.collapsible || !item.content) return;
+      const key = getItemKey(item, index);
+      const expanded = !isExpanded(item, index);
+      const next = expanded
+        ? [...(innerExpanded.value || []), key]
+        : (innerExpanded.value || []).filter((k) => k !== key);
+      setInnerExpanded(next, { item, index, expanded });
+    };
+
+    const renderItemNode = (node: TdThoughtChainItem['title']) => (typeof node === 'function' ? node(null) : node);
+
+    const renderIcon = (item: TdThoughtChainItem, index: number) => {
+      const custom = renderTNodeJSX('icon', { params: { item, index } }) ?? renderItemNode(item.icon);
+      if (custom) return custom;
+      const status = item.status || 'pending';
+      if (status === 'success') return <CheckCircleIcon />;
+      if (status === 'error') return <ErrorCircleIcon />;
+      if (status === 'processing') return <LoadingIcon />;
+      return <span class={`${baseClass.value}-dot`} />;
+    };
+
+    return () => (
+      <div class={baseClass.value}>
+        {(props.items || []).map((item, index) => {
+          const status = item.status || 'pending';
+          const expanded = isExpanded(item, index);
+          const expandable = props.collapsible && Boolean(item.content);
+          const title = renderTNodeJSX('title', { params: { item, index } }) ?? renderItemNode(item.title);
+          const content = renderTNodeJSX('content', { params: { item, index } }) ?? renderItemNode(item.content);
+          return (
+            <div
+              key={getItemKey(item, index)}
+              class={[
+                `${baseClass.value}-item`,
+                `${baseClass.value}-item--${status}`,
+                { [`${baseClass.value}-item--expanded`]: expanded },
+              ]}
+            >
+              <div class={`${baseClass.value}-item__node`}>
+                <span class={`${baseClass.value}-item__icon`}>{renderIcon(item, index)}</span>
+                {index < (props.items || []).length - 1 && <span class={`${baseClass.value}-item__line`} />}
+              </div>
+              <div class={`${baseClass.value}-item__detail`}>
+                <div
+                  class={[
+                    `${baseClass.value}-item__header`,
+                    { [`${baseClass.value}-item__header--collapsible`]: expandable },
+                  ]}
+                  onClick={() => toggleExpand(item, index)}
+                >
+                  <span class={`${baseClass.value}-item__title`}>{title}</span>
+                  {expandable && <ChevronDownIcon class={`${baseClass.value}-item__arrow`} />}
+                </div>
+                {item.content && expanded && <div class={`${baseClass.value}-item__content`}>{content}</div>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  },
+});

--- a/packages/pro-components/chat/chat-thought-chain/index.ts
+++ b/packages/pro-components/chat/chat-thought-chain/index.ts
@@ -1,0 +1,2 @@
+import _ChatThoughtChain from './chat-thought-chain';
+export default _ChatThoughtChain;

--- a/packages/pro-components/chat/index.ts
+++ b/packages/pro-components/chat/index.ts
@@ -5,6 +5,7 @@ import _ChatItem from './chat-item';
 import _ChatInput from './chat-input';
 import _ChatContent from './chat-content';
 import _ChatReasoning from './chat-reasoning';
+import _ChatThoughtChain from './chat-thought-chain';
 import _ChatLoading from './chat-loading';
 
 import _ChatActionbar from './chat-actionbar';
@@ -28,6 +29,7 @@ import {
   TdChatInputProps,
   TdChatSenderProps,
   TdChatReasoningProps,
+  TdChatThoughtChainProps,
   TdChatLoadingProps,
 } from './type';
 
@@ -46,6 +48,7 @@ export type ChatActionProps = TdChatActionProps;
 export type ChatInputProps = TdChatInputProps;
 export type ChatSenderProps = TdChatSenderProps;
 export type ChatReasoningProps = TdChatReasoningProps;
+export type ChatThoughtChainProps = TdChatThoughtChainProps;
 export type ChatLoadingProps = TdChatLoadingProps;
 
 export const ChatList = withInstall(_ChatList);
@@ -62,6 +65,8 @@ export const ChatSearchContent = withInstall(ChatSearchContentComponent, 't-chat
 export const ChatSuggestionContent = withInstall(ChatSuggestionContentComponent, 't-chat-suggestion-content');
 
 export const ChatMarkdown = withInstall(_ChatMarkdown, 't-chat-markdown');
+
+export const ChatThoughtChain = withInstall(_ChatThoughtChain);
 
 // TODO：待下线的组件
 export const Chat = withInstall(_ChatList); // 兼容历史版本，分别导出ChatList，Chat
@@ -93,6 +98,7 @@ export default {
     app.use(ChatInput, config);
     app.use(ChatItem, config);
     app.use(ChatReasoning, config);
+    app.use(ChatThoughtChain, config);
     app.component('TChat', Chat);
     app.component('TChatAction', ChatAction);
   },

--- a/packages/pro-components/chat/type.ts
+++ b/packages/pro-components/chat/type.ts
@@ -487,6 +487,71 @@ export interface UploadActionConfig {
   action: (params: { files: File[]; name: UploadActionType; e?: Event }) => void;
 }
 
+export type ThoughtChainItemStatus = 'pending' | 'processing' | 'success' | 'error';
+
+export interface TdThoughtChainItem {
+  /**
+   * 节点唯一标识，缺省时使用节点索引
+   */
+  key?: string | number;
+  /**
+   * 节点标题
+   */
+  title?: string | TNode;
+  /**
+   * 节点描述内容，为空时该节点不可展开
+   */
+  content?: string | TNode;
+  /**
+   * 节点状态，可选项：pending/processing/success/error
+   * @default pending
+   */
+  status?: ThoughtChainItemStatus;
+  /**
+   * 自定义节点图标，优先级高于 status 对应的默认图标
+   */
+  icon?: TNode;
+}
+
+export interface TdChatThoughtChainProps {
+  /**
+   * 是否支持折叠每个思考节点的内容
+   * @default true
+   */
+  collapsible?: boolean;
+  /**
+   * 思维链节点列表
+   */
+  items?: TdThoughtChainItem[];
+  /**
+   * 展开的节点。支持语法糖 v-model:expandedValue
+   */
+  expandedValue?: Array<string | number>;
+  /**
+   * 展开的节点。非受控属性
+   */
+  defaultExpandedValue?: Array<string | number>;
+  /**
+   * 自定义节点内容
+   */
+  content?: TNode<{ item: TdThoughtChainItem; index: number }>;
+  /**
+   * 自定义节点图标
+   */
+  icon?: TNode<{ item: TdThoughtChainItem; index: number }>;
+  /**
+   * 自定义节点标题
+   */
+  title?: TNode<{ item: TdThoughtChainItem; index: number }>;
+  /**
+   * 节点展开/收起时触发
+   */
+  onExpandChange?: (
+    value: Array<string | number>,
+    context: { item: TdThoughtChainItem; index: number; expanded: boolean },
+  ) => void;
+}
+
 export type * from 'tdesign-web-components/lib/chat-sender/type';
 export type * from 'tdesign-web-components/lib/filecard/type';
 export type * from 'tdesign-web-components/lib/chat-message/index';

--- a/packages/tdesign-vue-next-chat/site/site.config.mjs
+++ b/packages/tdesign-vue-next-chat/site/site.config.mjs
@@ -49,6 +49,13 @@ const componentDocs = [
     component: () => import('@tdesign/pro-components-chat/chat-thinking/chat-thinking.md'),
   },
   {
+    title: 'ChatThoughtChain 思维链',
+    titleEn: 'ChatThoughtChain',
+    name: 'ChatThoughtChain',
+    path: '/vue-next-chat/components/chat-thought-chain',
+    component: () => import('@tdesign/pro-components-chat/chat-thought-chain/chat-thought-chain.md'),
+  },
+  {
     title: 'ChatLoading 对话加载',
     titleEn: 'ChatLoading',
     name: 'ChatLoading',


### PR DESCRIPTION
Closes #6640

## Summary

新增 `ChatThoughtChain` 思维链组件，用于以时间线/步骤形式结构化展示 AI 的思考过程与执行计划（参考 issue 中提到的 ai-elements-vue Chain of Thought 与 semi.design 同类组件），补足现有 `ChatReasoning`（单一折叠面板）在复杂 Agent 场景下表现力不足的问题。

主要能力：
- `items` 节点列表，每个节点支持 `title` / `content` / `status`（pending / processing / success / error，对应默认图标与配色）/ 自定义 `icon`
- 节点内容折叠展开：`collapsible`、受控 `v-model:expandedValue` 与非受控 `defaultExpandedValue`、`expand-change` 事件
- `title` / `content` / `icon` 插槽（带 `{ item, index }` 参数），支持完全自定义渲染
- processing 节点带加载动画与流光标题，天然适配流式/逐步追加的 Agent 计划场景

包含：组件实现（tsx + 临时 less，待样式沉淀至 tdesign-common 后迁移）、类型定义、API 文档（md）、3 个示例（基础 / 流式执行 / 自定义插槽）、单元测试，并已注册到入口导出与 chat 站点导航。

## How verified

- 单元测试：6 个新用例全部通过（vitest，覆盖 items 渲染与状态类、默认展开、collapsible=false、自定义 icon 插槽、expand-change 事件、受控模式）
- `eslint --max-warnings 0` 对改动文件通过；`tsc --noEmit` 全仓通过
- 本地 `pnpm run dev:chat` 启动站点，`/vue-next-chat/components/chat-thought-chain` 文档页与 3 个示例均正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)