### PR TITLE
perf(nuxt): adding lodash es to vite pre build to optimize developmen…

### DIFF
--- a/packages/tdesign-vue-next-nuxt/src/module.ts
+++ b/packages/tdesign-vue-next-nuxt/src/module.ts
@@ -6,6 +6,7 @@ import {
   resolveTDesignPlugins,
   resolveTDesignVariables,
   resolveTDesignIcons,
+  resolveLodashEsOptimize,
 } from './resolvers';
 
 import type { ModuleOptions } from './interface';
@@ -86,5 +87,7 @@ export default defineNuxtModule<ModuleOptions>({
     resolveTDesignComponents(options);
     resolveTDesignPlugins(options);
     resolveTDesignIcons(options);
+
+    resolveLodashEsOptimize(nuxt);
   },
 });

--- a/packages/tdesign-vue-next-nuxt/src/module.ts
+++ b/packages/tdesign-vue-next-nuxt/src/module.ts
@@ -6,7 +6,7 @@ import {
   resolveTDesignPlugins,
   resolveTDesignVariables,
   resolveTDesignIcons,
-  resolveLodashEsOptimize,
+  resolveEsmOptimize,
 } from './resolvers';
 
 import type { ModuleOptions } from './interface';
@@ -88,6 +88,6 @@ export default defineNuxtModule<ModuleOptions>({
     resolveTDesignPlugins(options);
     resolveTDesignIcons(options);
 
-    resolveLodashEsOptimize(nuxt);
+    resolveEsmOptimize(nuxt);
   },
 });

--- a/packages/tdesign-vue-next-nuxt/src/resolvers.ts
+++ b/packages/tdesign-vue-next-nuxt/src/resolvers.ts
@@ -116,19 +116,28 @@ export const resolveTDesignVariables = async (options: ModuleOptions) => {
 };
 
 /**
- * 仅在开发模式下将 lodash-es 加入 Vite 预构建，生产环境 rollup tree-shaking 已够用。
- * 减少开发时 lodash-es 大量 ESM 模块请求导致的性能问题。
+ * 仅在开发模式下优化 lodash-es 的 Vite 构建。
+ * resolvers.ts 静态导入 lodash-es，组件内部也可能用到。
  */
-export const resolveLodashEsOptimize = (nuxt: Nuxt) => {
+export const resolveEsmOptimize = (nuxt: Nuxt) => {
   if (!nuxt.options.dev) return;
 
   nuxt.hook('vite:extendConfig', (config) => {
+    const cfg = config as Record<string, unknown>;
+
+    // --- 1. optimizeDeps.include ---
     const existing = (config.optimizeDeps?.include ?? []) as string[];
     if (!existing.includes('lodash-es')) {
-      (config as Record<string, unknown>).optimizeDeps = {
+      cfg.optimizeDeps = {
         ...config.optimizeDeps,
         include: [...existing, 'lodash-es'],
       };
     }
+
+    // --- 2. SSR noExternal ---
+    cfg.ssr = {
+      ...config.ssr,
+      noExternal: [...(Array.isArray(config.ssr?.noExternal) ? config.ssr.noExternal : []), 'lodash-es'],
+    };
   });
 };

--- a/packages/tdesign-vue-next-nuxt/src/resolvers.ts
+++ b/packages/tdesign-vue-next-nuxt/src/resolvers.ts
@@ -6,6 +6,7 @@ import { pluginList, iconList, pluginMap } from './config';
 import { isMatch } from './utils';
 import { WEB_COMPONENT_MAP } from '@tdesign/common-js/components';
 
+import type { Nuxt } from '@nuxt/schema';
 import type { ModuleOptions } from './interface';
 
 const componentSpecialCases: Record<string, Record<string, { tag: string; export: 'default' | string }>> = {
@@ -112,4 +113,22 @@ export const resolveTDesignVariables = async (options: ModuleOptions) => {
         : Promise.reject('Unable to resolve tdesign-vue-next Global Style. Is it installed?'),
   );
   nuxt.options.css.push(tdesignGlobalStyle);
+};
+
+/**
+ * 仅在开发模式下将 lodash-es 加入 Vite 预构建，生产环境 rollup tree-shaking 已够用。
+ * 减少开发时 lodash-es 大量 ESM 模块请求导致的性能问题。
+ */
+export const resolveLodashEsOptimize = (nuxt: Nuxt) => {
+  if (!nuxt.options.dev) return;
+
+  nuxt.hook('vite:extendConfig', (config) => {
+    const existing = (config.optimizeDeps?.include ?? []) as string[];
+    if (!existing.includes('lodash-es')) {
+      (config as Record<string, unknown>).optimizeDeps = {
+        ...config.optimizeDeps,
+        include: [...existing, 'lodash-es'],
+      };
+    }
+  });
 };


### PR DESCRIPTION
…t performance

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/6725
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题链路：
tdesign-vue-next (v1.20.1) 在 package.json 中声明了对 lodash-es (^4.18.1) 的依赖
lodash-es 是一个 ESM 模块化版本的 lodash，包含 647 个独立的 .js 文件（每个函数一个文件）
Nuxt 4 / Vite 在开发模式下会对每个模块做按需转换（on-demand transformation），每个 lodash-es 文件都会触发一次 @fs 虚拟模块请求
tdesign-vue-next 的多个组件各自按需 import lodash 函数，所以 Vite dev server 会发出一大堆 lodash-es 模块请求
这不是 bug，是正常行为
Vite 开发模式会对每个 import 的模块做 ESM 转换，lodash-es 的 647 个文件是 tree-shakeable 设计的代价
生产构建时 Vite/Rollup 会做 tree-shaking，只打包实际用到的函数，所以生产包不会包含整个 lodash
开发模式下首次加载会慢一些，但 Vite 有缓存，后续请求会很快
如果需要优化，可以：
不做任何处理 — 这只是开发模式的表现，不影响生产构建
在 nuxt.config.ts 中配置 Vite 预构建优化，让 lodash-es 被提前打包成一个 chunk

```ts
export default defineNuxtConfig({
  vite: {
    optimizeDeps: {
      include: ['lodash-es'],
    },
  },
```

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

- perf(nuxt): 将 lodash-es 加入 Vite 预构建优化开发性能

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
