### PR TITLE
fix(Dialog): prevent ESC from closing dialog during composition

### DIFF
--- a/packages/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/components/dialog/__tests__/dialog.test.tsx
@@ -579,6 +579,26 @@ describe('Dialog', () => {
       document.dispatchEvent(escEvent);
       await nextTick();
       expect(fn).toHaveBeenCalled();
+
+      // 中文输入法下按 ESC，不触发对话框关闭逻辑
+      const composingVisible = ref(true);
+      const composingFn = vi.fn();
+      const composingWrapper = mount(() => (
+        <Dialog
+          v-model:visible={composingVisible.value}
+          closeOnEscKeydown
+          onEscKeydown={composingFn}
+          body="this is content"
+        ></Dialog>
+      ));
+      await nextTick();
+
+      const composingEscEvent = new KeyboardEvent('keydown', { code: 'Escape', isComposing: true, bubbles: true });
+      document.dispatchEvent(composingEscEvent);
+      await nextTick();
+      expect(composingFn).not.toHaveBeenCalled();
+      expect(composingVisible.value).toBe(true);
+      composingWrapper.unmount();
     });
 
     it(':onOverlayClick', async () => {

--- a/packages/components/dialog/dialog.tsx
+++ b/packages/components/dialog/dialog.tsx
@@ -159,6 +159,8 @@ export default defineComponent({
       }
     };
     const keyboardEvent = (e: KeyboardEvent) => {
+      // 中文输入法组合态下按 ESC 仅用于取消候选词，不应关闭对话框
+      if (e.code === 'Escape' && e.isComposing) return;
       if (e.code === 'Escape' && isTopInteractivePopup()) {
         props.onEscKeydown?.({ e });
         // 根据closeOnEscKeydown判断按下ESC时是否触发close事件

--- a/packages/tdesign-vue-next/.changelog/pr-6740.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6740.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6740
+contributor: uyarn
+---
+
+- fix(Dialog): 修复对话框内使用中文输入法输入时 ESC 错误关闭对话框的问题 @uyarn ([#6740](https://github.com/Tencent/tdesign-vue-next/pull/6740))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/6739
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Dialog): 修复对话框内使用中文输入法输入时 ESC 错误关闭对话框的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
