### PR TITLE
fix(dialog): preserve content before visible

### DIFF
--- a/packages/components/dialog/dialog.tsx
+++ b/packages/components/dialog/dialog.tsx
@@ -105,7 +105,7 @@ export default defineComponent({
     /**是否已经第一次渲染，懒加载判断 */
     const isMounted = ref(false);
     /** 控制弹窗主体的挂载，关闭时需保留至离场动画结束，避免缩放动画无法触发 */
-    const cardVisible = ref(props.visible);
+    const cardVisible = ref(!props.lazy || props.visible);
 
     watch(
       () => props.visible,
@@ -208,7 +208,7 @@ export default defineComponent({
 
     // 关闭弹窗动画结束时事件
     const afterLeave = () => {
-      cardVisible.value = false;
+      cardVisible.value = !props.destroyOnClose;
       dialogCardRef.value?.resetPosition?.();
       props.onClosed?.();
     };

--- a/packages/components/dialog/plugin.tsx
+++ b/packages/components/dialog/plugin.tsx
@@ -73,6 +73,7 @@ const createDialog: DialogMethod = (props, context) => {
         return h(DialogComponent, {
           ...dialogOptions.value,
           onClose,
+          lazy: dialogOptions.value.lazy ?? true,
           visible: visible.value,
         });
       };

--- a/packages/tdesign-vue-next/.changelog/pr-6754.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6754.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6754
+contributor: uyarn
+---
+
+- fix(Dialog): 修复`1.20.2` 版本更新导致弹窗未显示前内部组件 ref 不可访问的问题 @uyarn ([#6754](https://github.com/Tencent/tdesign-vue-next/pull/6754))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next/issues/6752
- https://github.com/Tencent/tdesign-vue-next/issues/6767

- demo https://stackblitz.com/edit/4mqhipfh?file=src%2FDemo.vue
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Dialog): 修复`1.20.2` 版本更新导致弹窗未显示前内部组件 ref 不可访问的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
