### PR TITLE
fix(drawer): prevent ESC from closing drawer during IME composition

### DIFF
--- a/packages/components/drawer/__tests__/drawer.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.test.tsx
@@ -450,6 +450,27 @@ describe('Drawer', () => {
       w2.unmount();
     });
 
+    it('should not close on ESC during IME composition', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(Drawer, {
+        attachTo: document.body,
+        props: { visible: true, body: '内容', closeOnEscKeydown: true, onClose },
+      });
+      vi.runAllTimers();
+      await nextTick();
+      // Pressing ESC to cancel an IME candidate fires keydown with isComposing,
+      // it must not close the drawer.
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', isComposing: true }));
+      await nextTick();
+      expect(onClose).not.toHaveBeenCalled();
+      // A normal ESC still closes the drawer.
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await nextTick();
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onClose.mock.calls[0][0].trigger).toBe('esc');
+      wrapper.unmount();
+    });
+
     it(':destroyOnClose[boolean]', async () => {
       const w = mount(Drawer, {
         props: { visible: true, body: '内容', destroyOnClose: true },

--- a/packages/components/drawer/drawer.tsx
+++ b/packages/components/drawer/drawer.tsx
@@ -95,6 +95,8 @@ export default defineComponent({
     }));
 
     const handleEscKeydown = (e: KeyboardEvent) => {
+      // 中文输入法组合态下按 ESC 仅用于取消候选词，不应关闭抽屉
+      if (e.key === 'Escape' && e.isComposing) return;
       if (
         (props.closeOnEscKeydown ?? globalConfig.value.closeOnEscKeydown) &&
         e.key === 'Escape' &&

--- a/packages/tdesign-vue-next/.changelog/pr-6756.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6756.md
@@ -3,4 +3,4 @@ pr_number: 6756
 contributor: greymoth-jp
 ---
 
-- fix(drawer): 修复抽屉内使用输入法输入时 ESC 错误关闭抽屉的问题 @greymoth-jp ([#6756](https://github.com/Tencent/tdesign-vue-next/pull/6756))
+- fix(Drawer): 修复抽屉内使用输入法输入时 ESC 错误关闭抽屉的问题 @greymoth-jp ([#6756](https://github.com/Tencent/tdesign-vue-next/pull/6756))

--- a/packages/tdesign-vue-next/.changelog/pr-6756.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6756.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6756
+contributor: greymoth-jp
+---
+
+- fix(drawer): 修复抽屉内使用输入法输入时 ESC 错误关闭抽屉的问题 @greymoth-jp ([#6756](https://github.com/Tencent/tdesign-vue-next/pull/6756))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

无。与 #6740 属于同一类问题：#6740 修复了 Dialog 在中文输入法组合态下按 ESC 误关闭的问题，Drawer 的 `handleEscKeydown` 存在同样的遗漏。

### 💡 需求背景和解决方案

`t-drawer` 在开启 `closeOnEscKeydown` 时，于输入法组合（IME composition）态下按 ESC 取消候选词会触发 `handleEscKeydown`，从而错误地关闭抽屉。此时 ESC 应仅用于取消候选词，不应关闭抽屉。

Dialog 已在 #6740 通过 `if (e.code === 'Escape' && e.isComposing) return;` 修复同样的问题。Drawer 的 `handleEscKeydown` 使用 `e.key === 'Escape'` 判断且未做组合态判断，这里补充相同的守卫，并补充一条单测：组合态下按 ESC 不关闭抽屉，组合结束后按 ESC 仍正常关闭。

- test demo: https://stackblitz.com/edit/gvpc1urb-o5mcfurj?file=src%2FDemo.vue
### 📝 更新日志

#### tdesign-vue-next

- fix(Drawer): 修复抽屉内使用输入法输入时 ESC 错误关闭抽屉的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
