### PR TITLE
[wip]方案一 fix(popup): 修复 Shadow DOM 下事件穿透导致弹层异常关闭

### DIFF
--- a/packages/components/popup/__tests__/popup.test.tsx
+++ b/packages/components/popup/__tests__/popup.test.tsx
@@ -1,10 +1,28 @@
 // @ts-nocheck
 import { mount } from '@vue/test-utils';
-import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 import { usePrefixClass } from '@tdesign/shared-hooks';
 import Popup from '@tdesign/components/popup';
 
 const POPUPClASS = `.${usePrefixClass('popup').value}`;
+
+function createShadowDomMountPoint() {
+  const host = document.createElement('div');
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const mountPoint = document.createElement('div');
+  const popupContainer = document.createElement('div');
+
+  shadowRoot.appendChild(mountPoint);
+  shadowRoot.appendChild(popupContainer);
+  document.body.appendChild(host);
+
+  return { shadowRoot, mountPoint, popupContainer };
+}
+
+function wait(ms = 0) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('Popup', () => {
   beforeEach(() => {
     // create teleport target
@@ -321,6 +339,104 @@ describe('Popup', () => {
     it('onScroll', () => {});
     /** 当浮层隐藏或显示时触发，`trigger=document` 表示点击非浮层元素触发；`trigger=context-menu` 表示右击触发 */
     it('onVisibleChange', () => {});
+    it('keeps popup open when clicking overlay in shadow DOM', async () => {
+      const { shadowRoot, mountPoint, popupContainer } = createShadowDomMountPoint();
+      const onVisibleChange = vi.fn();
+
+      await mount(Popup, {
+        attachTo: mountPoint,
+        props: {
+          defaultVisible: true,
+          trigger: 'click',
+          delay: [0, 0],
+          content,
+          attach: () => popupContainer,
+          onVisibleChange,
+        },
+        slots: {
+          default: <button id="btn">btn</button>,
+        },
+      });
+
+      await wait();
+
+      const popupContent = shadowRoot.querySelector(`${POPUPClASS}__content`) as HTMLElement;
+      popupContent.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+
+      await wait();
+
+      const popup = shadowRoot.querySelector(POPUPClASS) as HTMLElement;
+      expect(popup.style.display).not.toBe('none');
+      expect(onVisibleChange).not.toHaveBeenCalledWith(false, expect.anything());
+    });
+
+    it('keeps parent popup open when moving to child popup in shadow DOM', async () => {
+      const { shadowRoot, mountPoint, popupContainer } = createShadowDomMountPoint();
+      const onParentVisibleChange = vi.fn();
+
+      await mount(Popup, {
+        attachTo: mountPoint,
+        props: {
+          defaultVisible: true,
+          trigger: 'hover',
+          delay: [0, 0],
+          attach: () => popupContainer,
+          onVisibleChange: onParentVisibleChange,
+        },
+        slots: {
+          default: <button id="parent-btn">parent</button>,
+          content: () => (
+            <div>
+              parent content
+              <Popup trigger="click" delay={[0, 0]} content="child content" attach={() => popupContainer}>
+                <button id="child-btn">child</button>
+              </Popup>
+            </div>
+          ),
+        },
+      });
+
+      await wait(20);
+
+      const childButton = shadowRoot.querySelector('#child-btn') as HTMLElement;
+      childButton.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      await wait(20);
+
+      const popups = shadowRoot.querySelectorAll(POPUPClASS);
+      expect(popups.length).toBe(2);
+      const parentPopup = popups[0] as HTMLElement;
+      const childPopup = popups[1] as HTMLElement;
+
+      childPopup.getBoundingClientRect = vi.fn(
+        () =>
+          ({
+            x: 50,
+            y: 50,
+            width: 100,
+            height: 100,
+            top: 50,
+            left: 50,
+            right: 150,
+            bottom: 150,
+            toJSON: () => ({}),
+          } as DOMRect),
+      );
+
+      const mouseleaveEvent = new MouseEvent('mouseleave', { bubbles: true, composed: true, clientX: 80, clientY: 80 });
+      Object.defineProperties(mouseleaveEvent, {
+        x: { value: 80 },
+        y: { value: 80 },
+      });
+
+      parentPopup.dispatchEvent(mouseleaveEvent);
+
+      await wait();
+
+      expect(parentPopup.style.display).not.toBe('none');
+      expect(onParentVisibleChange).not.toHaveBeenCalledWith(false, expect.anything());
+    });
+
     it('keydown-esc hide popup', async () => {
       const wrapper = await mount(Popup, {
         props: {
@@ -341,7 +457,7 @@ describe('Popup', () => {
       });
       const btn = wrapper.find('#btn');
       await btn.trigger('keydown.esc');
-      await new Promise(setTimeout);
+      await wait();
       expect(wrapper.emitted()['update:visible'][0]).toEqual([false]);
     });
   });

--- a/packages/components/popup/popup.tsx
+++ b/packages/components/popup/popup.tsx
@@ -26,13 +26,49 @@ import { PopupTriggerEvent, TdPopupProps } from './type';
 const POPUP_ATTR_NAME = 'data-td-popup';
 const POPUP_PARENT_ATTR_NAME = 'data-td-popup-parent';
 
+const popupElements = new Set<Element>();
+const popupIds = new WeakMap<Element, string>();
+const popupParentIds = new WeakMap<Element, string | undefined>();
+
+let popupCount = 0;
+
+function getPopupId() {
+  popupCount += 1;
+  return `td-popup-${popupCount}`;
+}
+
+function registerPopup(el: Element, id: string, parentId?: string) {
+  popupElements.add(el);
+  popupIds.set(el, id);
+  popupParentIds.set(el, parentId);
+}
+
+function unregisterPopup(el?: Element) {
+  if (!el) return;
+  popupElements.delete(el);
+}
+
+function getEventPath(ev: Event) {
+  return typeof ev.composedPath === 'function' ? ev.composedPath() : [];
+}
+
+function isEventInsideElement(ev: Event, el?: Element) {
+  if (!el) return false;
+  const path = getEventPath(ev);
+  if (path.length) {
+    return path.includes(el);
+  }
+  return el.contains(ev.target as Node);
+}
+
 /**
  * @param id
  * @param upwards query upwards poppers
  */
 function getPopperTree(id: number | string, upwards?: boolean): Element[] {
-  const list = [] as any;
+  const list: Element[] = [];
   const selectors = [POPUP_PARENT_ATTR_NAME, POPUP_ATTR_NAME];
+  const visited = new Set<number | string>();
 
   if (!id) return list;
   if (upwards) {
@@ -44,8 +80,23 @@ function getPopperTree(id: number | string, upwards?: boolean): Element[] {
   return list;
 
   function recurse(id: number | string) {
+    if (visited.has(id)) return;
+    visited.add(id);
+
+    popupElements.forEach((el) => {
+      const sourceId = upwards ? popupIds.get(el) : popupParentIds.get(el);
+      if (sourceId !== id || list.includes(el)) return;
+
+      list.push(el);
+      const childId = upwards ? popupParentIds.get(el) : popupIds.get(el);
+      if (childId && childId !== id) {
+        recurse(childId);
+      }
+    });
+
     const children = document.querySelectorAll(`[${selectors[0]}="${id}"]`);
     children.forEach((el) => {
+      if (list.includes(el)) return;
       list.push(el);
       const childId = el.getAttribute(selectors[1]);
       if (childId && childId !== id) {
@@ -57,6 +108,7 @@ function getPopperTree(id: number | string, upwards?: boolean): Element[] {
 
 const parentKey = Symbol() as InjectionKey<{
   id: string;
+  attrId: string;
   assertMouseLeave: (ev: MouseEvent) => void;
 }>;
 
@@ -112,14 +164,17 @@ export default defineComponent({
     const popperEl = ref<HTMLElement>();
     const containerRef = ref<typeof Container>();
     const isOverlayHover = ref(false);
+    const registeredPopperEl = ref<HTMLElement>();
 
     const arrowStyle = ref<CSSProperties>({});
 
-    const id = typeof process !== 'undefined' && process.env?.TEST ? '' : Date.now().toString(36);
+    const popupId = getPopupId();
+    const id = typeof process !== 'undefined' && process.env?.TEST ? '' : popupId;
     const parent = inject(parentKey, undefined);
 
     provide(parentKey, {
-      id,
+      id: popupId,
+      attrId: id,
       assertMouseLeave: onMouseLeave,
     });
 
@@ -240,6 +295,7 @@ export default defineComponent({
     onUnmounted(() => {
       destroyPopper();
       clearAllTimeout();
+      unregisterPopup(registeredPopperEl.value);
       off(document, 'mousedown', onDocumentMouseDown, true);
     });
 
@@ -434,21 +490,18 @@ export default defineComponent({
 
     function onDocumentMouseDown(ev: MouseEvent) {
       // click content
-      if (popperEl.value?.contains(ev.target as Node)) {
+      if (isEventInsideElement(ev, popperEl.value)) {
         return;
       }
 
       // click trigger element
-      if (triggerEl.value?.contains(ev.target as Node)) {
+      if (isEventInsideElement(ev, triggerEl.value)) {
         return;
       }
 
       // ignore upwards
-      const activedPopper = getPopperTree(id).find((el) => el.contains(ev.target as Node));
-      if (
-        activedPopper &&
-        getPopperTree(activedPopper.getAttribute(POPUP_PARENT_ATTR_NAME), true).some((el) => el === popperEl.value)
-      ) {
+      const activedPopper = getPopperTree(popupId).find((el) => isEventInsideElement(ev, el));
+      if (activedPopper && getPopperTree(popupIds.get(activedPopper), true).some((el) => el === popperEl.value)) {
         return;
       }
 
@@ -459,7 +512,7 @@ export default defineComponent({
       isOverlayHover.value = false;
       if (props.trigger !== 'hover' || triggerEl.value.contains(ev.target as Node)) return;
 
-      const isCursorOverlaps = getPopperTree(id).some((el) => {
+      const isCursorOverlaps = getPopperTree(popupId).some((el) => {
         const rect = el.getBoundingClientRect();
 
         return ev.x > rect.x && ev.x < rect.x + rect.width && ev.y > rect.y && ev.y < rect.y + rect.height;
@@ -506,10 +559,19 @@ export default defineComponent({
           <div
             {...{
               [POPUP_ATTR_NAME]: id,
-              [POPUP_PARENT_ATTR_NAME]: parent?.id,
+              [POPUP_PARENT_ATTR_NAME]: parent?.attrId,
             }}
             class={[prefixCls.value, props.overlayClassName]}
-            ref={(ref: HTMLElement) => (popperEl.value = ref)}
+            ref={(ref: HTMLElement) => {
+              popperEl.value = ref;
+              if (registeredPopperEl.value && registeredPopperEl.value !== ref) {
+                unregisterPopup(registeredPopperEl.value);
+              }
+              if (ref) {
+                registerPopup(ref, popupId, parent?.id);
+              }
+              registeredPopperEl.value = ref;
+            }}
             style={[{ zIndex: props.zIndex }, getOverlayStyle(), hidePopup && { visibility: 'hidden' }]}
             v-show={visible.value}
             onClick={onOverlayClick}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

t-popup 在 shadow DOM 下有两处 broken：

1. onDocumentMouseDown 用 popperEl.contains(ev.target) 判断点击是否在弹层内，
   shadow DOM 下 document 层的 ev.target 被重定向到 shadow host，contains 恒为
   false → 点击弹层内部误关闭。
2. onMouseLeave → getPopperTree 用 document.querySelectorAll 查找子弹层判断光标
   是否仍在弹层上，querySelectorAll 不穿透 shadow 边界 → 返回 [] → hover 移向
   子弹层时父弹层误关闭。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
