### PR TITLE
fix(drawer): stop resizing when mouseup is missed

### DIFF
--- a/packages/components/drawer/__tests__/drawer.hooks.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.hooks.test.tsx
@@ -5,12 +5,13 @@ import { defineComponent, nextTick } from 'vue';
 import { useDrag } from '@tdesign/components/drawer/hooks';
 import type { TdDrawerProps } from '@tdesign/components/drawer/type';
 
-// jsdom MouseEvent does not support x/y properties
+// jsdom MouseEvent does not reflect x/y and buttons from the init dict
 class FakeMouseEvent extends MouseEvent {
   constructor(type: string, values: Record<string, unknown> = {}) {
-    const { x, y, ...mouseValues } = values;
+    const { x, y, buttons, ...mouseValues } = values;
     super(type, mouseValues as MouseEventInit);
     Object.assign(this, { x: x || 0, y: y || 0 });
+    Object.defineProperty(this, 'buttons', { value: buttons ?? 0, configurable: true });
   }
 }
 
@@ -40,7 +41,8 @@ const DragTestComponent = defineComponent({
 async function performDrag(handleEl: Element, x: number, y: number) {
   handleEl.dispatchEvent(new FakeMouseEvent('mousedown', { bubbles: true }));
   await nextTick();
-  document.dispatchEvent(new FakeMouseEvent('mousemove', { x, y }));
+  // buttons: 1 表示拖拽过程中鼠标主键处于按下状态
+  document.dispatchEvent(new FakeMouseEvent('mousemove', { x, y, buttons: 1 }));
   await nextTick();
   document.dispatchEvent(new FakeMouseEvent('mouseup', { x, y }));
   await nextTick();
@@ -243,6 +245,36 @@ describe('Drawer Hooks', () => {
         expect(typeof onSizeDragEnd.mock.calls[0][0].size).toBe('number');
       });
 
+      // https://github.com/Tencent/tdesign-vue-next/issues/6781
+      // 拖拽过程中在浏览器窗口外或切换窗口时松开鼠标，document 收不到 mouseup，
+      // 回到页面移动鼠标时（buttons 为 0）应主动结束拖拽，避免尺寸继续跟随鼠标变化
+      it('stops dragging when mouseup is missed and mouse button is released', async () => {
+        const onSizeDragEnd = vi.fn();
+        const removeSpy = vi.spyOn(document, 'removeEventListener');
+        wrapper = mount(DragTestComponent, {
+          attachTo: document.body,
+          props: { placement: 'right', onSizeDragEnd },
+        });
+
+        wrapper.find('.drag-handle').element.dispatchEvent(new FakeMouseEvent('mousedown', { bubbles: true }));
+        await nextTick();
+
+        // 回到页面后的第一次移动，鼠标主键已抬起（buttons 为 0），应结束拖拽并移除监听
+        document.dispatchEvent(new FakeMouseEvent('mousemove', { x: 200, y: 100, buttons: 0 }));
+        await nextTick();
+
+        expect(removeSpy).toHaveBeenCalledWith('mouseup', expect.any(Function), true);
+        expect(removeSpy).toHaveBeenCalledWith('mousemove', expect.any(Function), true);
+        expect(onSizeDragEnd).not.toHaveBeenCalled();
+
+        // 结束拖拽后即使再有按下状态的移动，也不应再触发尺寸变化
+        document.dispatchEvent(new FakeMouseEvent('mousemove', { x: 260, y: 100, buttons: 1 }));
+        await nextTick();
+        expect(onSizeDragEnd).not.toHaveBeenCalled();
+
+        removeSpy.mockRestore();
+      });
+
       it(':sizeDraggable[false] prevents drag', async () => {
         const onSizeDragEnd = vi.fn();
         wrapper = mount(DragTestComponent, {
@@ -253,7 +285,7 @@ describe('Drawer Hooks', () => {
         wrapper.find('.drag-handle').element.dispatchEvent(new FakeMouseEvent('mousedown', { bubbles: true }));
         await nextTick();
 
-        document.dispatchEvent(new FakeMouseEvent('mousemove', { x: 400, y: 100 }));
+        document.dispatchEvent(new FakeMouseEvent('mousemove', { x: 400, y: 100, buttons: 1 }));
         await nextTick();
 
         expect(onSizeDragEnd).not.toHaveBeenCalled();

--- a/packages/components/drawer/__tests__/drawer.hooks.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.hooks.test.tsx
@@ -54,6 +54,8 @@ describe('Drawer Hooks', () => {
   });
 
   afterEach(() => {
+    // 清理可能残留的拖拽全局事件监听，避免影响其他测试文件
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     document.body.innerHTML = '';
   });
 

--- a/packages/components/drawer/__tests__/drawer.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.test.tsx
@@ -6,18 +6,24 @@ import { Drawer } from '@tdesign/components';
 import drawerProps from '@tdesign/components/drawer/props';
 import { CloseIcon } from 'tdesign-icons-vue-next';
 
+// jsdom MouseEvent does not reflect x/y and buttons from the init dict
 class FakeMouseEvent extends MouseEvent {
   constructor(type: string, values: Record<string, unknown> = {}) {
-    const { x, y, ...mouseValues } = values;
+    const { x, y, buttons, ...mouseValues } = values;
     super(type, mouseValues as MouseEventInit);
     Object.assign(this, { x: x || 0, y: y || 0 });
+    Object.defineProperty(this, 'buttons', { value: buttons ?? 0, configurable: true });
   }
 }
 
-function moveElement(element: Element, x: number, y: number) {
+async function moveElement(element: Element, x: number, y: number) {
   element.dispatchEvent(new FakeMouseEvent('mousedown', {}));
-  document.dispatchEvent(new FakeMouseEvent('mousemove', { x, y }));
+  await nextTick();
+  // buttons: 1 表示拖拽过程中鼠标主键处于按下状态
+  document.dispatchEvent(new FakeMouseEvent('mousemove', { x, y, buttons: 1 }));
+  await nextTick();
   document.dispatchEvent(new FakeMouseEvent('mouseup', { x, y }));
+  await nextTick();
 }
 
 describe('Drawer', () => {
@@ -742,8 +748,7 @@ describe('Drawer', () => {
       await nextTick();
 
       const content = w.find('.t-drawer__content-wrapper');
-      moveElement(content.element.lastChild as Element, 400, 100);
-      await nextTick();
+      await moveElement(content.element.lastChild as Element, 400, 100);
       expect(onSizeDragEnd).toHaveBeenCalled();
       expect(onSizeDragEnd.mock.calls[0][0].e).toBeInstanceOf(MouseEvent);
       expect(typeof onSizeDragEnd.mock.calls[0][0].size).toBe('number');
@@ -916,8 +921,7 @@ describe('Drawer', () => {
         await nextTick();
 
         const content = w.find('.t-drawer__content-wrapper');
-        moveElement(content.element.lastChild as Element, x, y);
-        await nextTick();
+        await moveElement(content.element.lastChild as Element, x, y);
         expect(onSizeDragEnd).toHaveBeenCalled();
         expect(onSizeDragEnd.mock.calls[0][0].e).toBeInstanceOf(MouseEvent);
         expect(typeof onSizeDragEnd.mock.calls[0][0].size).toBe('number');
@@ -933,8 +937,7 @@ describe('Drawer', () => {
       await nextTick();
 
       const content = w.find('.t-drawer__content-wrapper');
-      moveElement(content.element.lastChild as Element, 500, 100);
-      await nextTick();
+      await moveElement(content.element.lastChild as Element, 500, 100);
       expect((content.element as HTMLElement).style.width).toBe('300px');
       w.unmount();
     });

--- a/packages/components/drawer/__tests__/drawer.test.tsx
+++ b/packages/components/drawer/__tests__/drawer.test.tsx
@@ -32,6 +32,8 @@ describe('Drawer', () => {
   });
 
   afterEach(() => {
+    // 清理可能残留的拖拽全局事件监听，避免影响其他测试文件
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     document.body.innerHTML = '';
     vi.useRealTimers();
   });

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue';
+import { computed, getCurrentScope, onScopeDispose, ref } from 'vue';
 import { Styles } from '../../common';
 import { getSizeDraggable, calcMoveSize } from '@tdesign/common-js/drawer/utils';
 import type { TdDrawerProps } from '../type';
@@ -111,6 +111,12 @@ export const useDrag = (props: TdDrawerProps) => {
   });
 
   const draggingStyles = computed<Styles>(() => (isSizeDragging.value ? { userSelect: 'none' } : {}));
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      handleMouseup();
+    });
+  }
 
   return {
     draggedSizeValue,

--- a/packages/components/drawer/hooks/index.ts
+++ b/packages/components/drawer/hooks/index.ts
@@ -52,6 +52,11 @@ export const useDrag = (props: TdDrawerProps) => {
   };
 
   const handleMousemove = (e: MouseEvent) => {
+    // 若鼠标主键已松开（如在浏览器窗口外或切换窗口时释放，导致 document 未收到 mouseup），主动结束拖拽，避免松手后尺寸仍跟随鼠标变化
+    if (e.buttons === 0) {
+      handleMouseup();
+      return;
+    }
     // 鼠标移动时计算draggedSizeValue的值
     const { x, y } = e;
     const maxHeight = document.documentElement.clientHeight;

--- a/packages/tdesign-vue-next/.changelog/pr-6789.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6789.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6789
+contributor: xuxiao1797
+---
+
+- fix(drawer): 修复 `sizeDraggable` 场景下在窗口外释放鼠标（如 `Alt + Tab` 切换窗口后释放）导致松手后仍持续调整抽屉尺寸的问题 @xuxiao1797 ([#6789](https://github.com/Tencent/tdesign-vue-next/pull/6789))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/6781

### 💡 需求背景和解决方案

#### 问题背景

`Drawer` 开启 `sizeDraggable` 时，存在偶发问题：鼠标松开后抽屉尺寸仍会继续随鼠标移动。

该问题可通过以下步骤稳定触发（`document` 丢失 `mouseup`）：

1. 打开 `sizeDraggable` 示例，按住拖拽线开始拖拽  
2. 拖拽过程中按 `Alt + Tab` 切换到其他窗口后松开鼠标（或拖出浏览器窗口后松开）  
3. 切回页面继续移动鼠标，抽屉尺寸仍会变化  

#### 根因分析

当前拖拽逻辑在 `document` 上监听 `mousemove/mouseup`。  
当鼠标在窗口外释放或切换窗口释放时，`document` 可能收不到 `mouseup`，导致拖拽状态未结束，后续 `mousemove` 仍继续计算尺寸。

#### 解决方案

- 在 `handleMousemove` 中增加兜底判断：当 `e.buttons === 0`（主键已释放）时主动执行结束拖拽逻辑并移除监听器。
- 补充单测覆盖 `mouseup` 丢失场景，验证在 `buttons = 0` 的后续移动中会停止拖拽，且不再触发尺寸更新。
- 同时调整测试事件构造，显式支持 `buttons`，使拖拽按键状态更贴近真实浏览器行为。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(drawer): 修复 `sizeDraggable` 场景下在窗口外释放鼠标（如 `Alt + Tab` 切换窗口后释放）导致松手后仍持续调整抽屉尺寸的问题

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/nuxt

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供