### PR TITLE
fix(select): avoid scrollTo error when popup content not ready

### DIFF
--- a/packages/components/select/__tests__/select.hooks.test.tsx
+++ b/packages/components/select/__tests__/select.hooks.test.tsx
@@ -417,6 +417,37 @@ describe('Select Hooks', () => {
         await nextTick();
         expect(ctx.scrollToMock).toHaveBeenCalledWith({ top: 32, behavior: 'smooth' });
       });
+
+      // https://github.com/Tencent/tdesign-vue-next/issues/6750
+      // 首次通过键盘（Tab 聚焦后按方向键）打开下拉时，popup 内容尚未渲染，
+      // popupContentRef.value 为 undefined，滚动逻辑不应报错
+      it('does not scroll or throw when popup content is not ready (unit)', async () => {
+        const { useKeyboardControl } = await import('../hooks/useKeyboardControl');
+        const ctx = createKeyboardControlContext({
+          popupContentRef: computed((): HTMLElement => undefined),
+        });
+        const { hoverIndex } = useKeyboardControl(ctx);
+        hoverIndex.value = 1;
+        await nextTick();
+        expect(ctx.scrollToMock).not.toHaveBeenCalled();
+      });
+
+      // 选项高度取不到时（列表未渲染出选项）同样跳过滚动，避免 NaN 滚动
+      it('does not scroll when option height is unavailable (unit)', async () => {
+        const { useKeyboardControl } = await import('../hooks/useKeyboardControl');
+        const mockSelectPanelRef = {
+          isVirtual: false,
+          innerRef: { querySelector: () => null } as unknown as HTMLDivElement,
+        };
+        const ctx = createKeyboardControlContext({
+          // @ts-ignore
+          selectPanelRef: ref(mockSelectPanelRef),
+        });
+        const { hoverIndex } = useKeyboardControl(ctx);
+        hoverIndex.value = 1;
+        await nextTick();
+        expect(ctx.scrollToMock).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/components/select/__tests__/select.hooks.test.tsx
+++ b/packages/components/select/__tests__/select.hooks.test.tsx
@@ -437,7 +437,7 @@ describe('Select Hooks', () => {
         const { useKeyboardControl } = await import('../hooks/useKeyboardControl');
         const mockSelectPanelRef = {
           isVirtual: false,
-          innerRef: { querySelector: () => null } as unknown as HTMLDivElement,
+          innerRef: { querySelector: (): null => null } as unknown as HTMLDivElement,
         };
         const ctx = createKeyboardControlContext({
           // @ts-ignore

--- a/packages/components/select/hooks/useKeyboardControl.ts
+++ b/packages/components/select/hooks/useKeyboardControl.ts
@@ -151,6 +151,9 @@ export function useKeyboardControl({
       `.${classPrefix.value}-select-option`,
     )?.clientHeight;
 
+    // popup 内容可能尚未渲染（如首次通过键盘打开下拉列表），此时无需滚动，避免访问 undefined 报错
+    if (!popupContentRef.value || !optionHeight) return;
+
     const scrollHeight = optionHeight * index;
 
     popupContentRef.value.scrollTo({

--- a/packages/tdesign-vue-next/.changelog/pr-6790.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6790.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6790
+contributor: xuxiao1797
+---
+
+- fix(Select): 修复提供 Tab 键盘操作打开下拉框出现告警的问题 @xuxiao1797 ([#6790](https://github.com/Tencent/tdesign-vue-next/pull/6790))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- #6750

### 💡 需求背景和解决方案
修复 `Select` 组件在键盘交互场景下的异常：当用户通过键盘首次打开下拉（例如 `Tab` 聚焦后直接按方向键触发），`hoverIndex` 的滚动 watcher 可能在 popup 内容尚未渲染时执行，导致 `popupContentRef.value` 为 `undefined`，进而触发 `TypeError: Cannot read properties of undefined (reading 'scrollTo')`。

本 PR 处理方式：
- 在 `packages/components/select/hooks/useKeyboardControl.ts` 的 `watch(hoverIndex, ...)` 中增加守卫：
  - 当 `popupContentRef.value` 未就绪或 `optionHeight` 获取不到时，直接 `return`，避免调用 `scrollTo`
  - popup 已渲染且高度可用时保持原有滚动行为不变
- 在 `packages/components/select/__tests__/select.hooks.test.tsx` 新增覆盖用例：
  - `popupContentRef.value` 为 `undefined` 时不应滚动且不应抛错
  - `optionHeight` 不可用时不应滚动（避免滚动计算异常）

### 📝 更新日志
- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
- fix(Select): 修复提供 Tab 键盘操作打开下拉框出现告警的问题

### ☑️ 请求合并前的自查清单
⚠️ 请自检并全部**勾选全部选项**。⚠️
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供