### PR TITLE
fix(dialog): remove default close wrapper for custom closeBtn

### DIFF
--- a/packages/components/dialog/__tests__/dialog-card.test.tsx
+++ b/packages/components/dialog/__tests__/dialog-card.test.tsx
@@ -131,7 +131,40 @@ describe('DialogCard', () => {
       });
 
       expect(typeof wrapper1.vm.$props.closeBtn).toBe('function');
-      expect(wrapper1.find('.t-dialog__close').exists()).toBe(true);
+      // 自定义 closeBtn（TNode）时应完全替换默认关闭按钮，不再套用 t-dialog__close 样式容器
+      expect(wrapper1.find('.t-dialog__close').exists()).toBe(false);
+      expect(wrapper1.text()).toContain('Custom Close');
+    });
+
+    it(':closeBtn[function] should fully replace the default close button', () => {
+      const closeBtnFn = () => <span class="custom-close-btn">关闭</span>;
+      const wrapper1 = mount(DialogCard, {
+        props: {
+          closeBtn: closeBtnFn,
+          header: true,
+        },
+      });
+
+      const customBtn = wrapper1.find('.custom-close-btn');
+      expect(customBtn.exists()).toBe(true);
+      // 自定义节点不应被 t-dialog__close 包裹
+      expect(wrapper1.find('.t-dialog__close').exists()).toBe(false);
+      expect(customBtn.element.closest('.t-dialog__close')).toBeNull();
+    });
+
+    it(':closeBtn[slot] should fully replace the default close button', () => {
+      const wrapper1 = mount(DialogCard, {
+        props: {
+          closeBtn: true,
+          header: true,
+        },
+        slots: {
+          closeBtn: '<span class="custom-close-slot">X</span>',
+        },
+      });
+
+      expect(wrapper1.find('.custom-close-slot').exists()).toBe(true);
+      expect(wrapper1.find('.t-dialog__close').exists()).toBe(false);
     });
 
     it(':confirmBtn[string]', () => {

--- a/packages/components/dialog/dialog-card.tsx
+++ b/packages/components/dialog/dialog-card.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, toRefs } from 'vue';
+import { computed, defineComponent, getCurrentInstance, ref, toRefs } from 'vue';
 import {
   CloseIcon as TdCloseIcon,
   InfoCircleFilledIcon as TdInfoCircleFilledIcon,
@@ -30,6 +30,7 @@ export default defineComponent({
     ...dialogCardProps,
   },
   setup(props, { expose }) {
+    const instance = getCurrentInstance();
     const rootRef = ref<HTMLElement | null>(null);
     const COMPONENT_NAME = usePrefixClass('dialog');
     const classPrefix = usePrefixClass();
@@ -128,6 +129,9 @@ export default defineComponent({
         const closeClassName = isFullScreen.value
           ? [`${COMPONENT_NAME.value}__close`, `${COMPONENT_NAME.value}__close--fullscreen`]
           : `${COMPONENT_NAME.value}__close`;
+        // 自定义关闭按钮（TNode 或插槽）时，不套用默认 __close 容器样式，实现完全替换
+        const isCustomCloseBtn =
+          typeof props?.closeBtn === 'function' || Boolean(instance?.slots?.closeBtn || instance?.slots?.['close-btn']);
         const getIcon = () => {
           const icon = {
             info: <InfoCircleFilledIcon class={`${classPrefix.value}-is-info`} />,
@@ -146,7 +150,11 @@ export default defineComponent({
               </div>
 
               {props?.closeBtn ? (
-                <span class={closeClassName} onClick={closeBtnAction} onMousedown={onStopDown}>
+                <span
+                  class={isCustomCloseBtn ? undefined : closeClassName}
+                  onClick={closeBtnAction}
+                  onMousedown={onStopDown}
+                >
                   {renderTNodeJSX('closeBtn', <CloseIcon />)}
                 </span>
               ) : null}

--- a/packages/tdesign-vue-next/.changelog/pr-6801.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6801.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6801
+contributor: xuxiao1797
+---
+
+- fix(Dialog): 修复自定义 closeBtn 时外层 t-dialog__close 样式影响按钮展示的问题 @xuxiao1797 ([#6801](https://github.com/Tencent/tdesign-vue-next/pull/6801))


### PR DESCRIPTION
Custom TNode/slot closeBtn should fully replace the default close button instead of being wrapped by t-dialog__close styles.

Fixes #6794

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6794

- Issue 讨论：https://github.com/Tencent/tdesign-vue-next/issues/6794

### 💡 需求背景和解决方案

当 `closeBtn` 传入自定义 TNode（如 `<t-button>`）或 `#closeBtn` 插槽时，组件始终用 `<span class="t-dialog__close">` 包裹自定义内容。`t-dialog__close` 带有固定宽高、padding、hover 背景等针对默认关闭图标的样式，导致自定义按钮展示异常，无法完全替换默认关闭按钮。


API 无变更，用法保持不变：

- `closeBtn={true}` / `string`：继续使用默认 `t-dialog__close` 样式容器（向后兼容）
- `closeBtn` 为 TNode / 插槽：直接渲染自定义内容，不再套用 `t-dialog__close` 样式类


**改动前：** 自定义 `closeBtn` 被 `t-dialog__close` 样式包裹

<img width="1292" height="565" alt="image" src="https://github.com/user-attachments/assets/c0cc2a8e-d080-4488-acc4-baedc4ea5857" />


**改动后：** 自定义 `closeBtn` 完全替换默认关闭按钮

<img width="1243" height="537" alt="image" src="https://github.com/user-attachments/assets/2cda5f7d-e7d6-4191-8617-4eb97f92dbca" />


### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Dialog): 修复自定义 closeBtn 时外层 t-dialog__close 样式影响按钮展示的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供