### PR TITLE
fix(checkbox): Fix Cascader checkboxes remaining interactive when disabled

### DIFF
--- a/packages/components/checkbox/checkbox.tsx
+++ b/packages/components/checkbox/checkbox.tsx
@@ -124,7 +124,7 @@ export default defineComponent({
     );
 
     const handleChange = (e: Event) => {
-      if (isReadonly.value) return;
+      if (isReadonly.value || isDisabled.value) return;
       const checked = !tChecked.value;
       setInnerChecked(checked, { e });
       if (checkboxGroupData?.value.handleCheckboxChange) {

--- a/packages/tdesign-vue-next/.changelog/pr-6813.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6813.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6813
+contributor: ZhuYuRan001
+---
+
+- fix(checkbox):  修复复选框禁用状态下仍可触发选中变更的问题 @ZhuYuRan001 ([#6813](https://github.com/Tencent/tdesign-vue-next/pull/6813))

--- a/packages/tdesign-vue-next/.changelog/pr-6813.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6813.md
@@ -3,4 +3,4 @@ pr_number: 6813
 contributor: ZhuYuRan001
 ---
 
-- fix(checkbox):  修复复选框禁用状态下仍可触发选中变更的问题 @ZhuYuRan001 ([#6813](https://github.com/Tencent/tdesign-vue-next/pull/6813))
+- fix(Checkbox):  修复复选框禁用状态下仍可触发选中变更的问题 @ZhuYuRan001 ([#6813](https://github.com/Tencent/tdesign-vue-next/pull/6813))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/6812

### 💡 需求背景和解决方案

#### 需求背景
在`Cascader`组件中设置`checkProps="{disabled: true}"`的情况下，点击父集复选框时依然会选中所有子集选项。经排查发现当`Cascader`组件渲染`Checkbox`的时候会给`Checkbox`组件添加一个`stopLabelTrigger`的props用来阻止默认原生点击label会改变`Checkbox`状态的事件，自然也就绕过了原生`Checkbox`对`disabled`的保护，但是为了保证在点击真正的`Checkbox`时仍可以触发`change`事件又手动添加了一个`click`事件来调用`handleChange`函数，但是`Checkbox`组件中的`handleChange`函数中没有检查`isDisabled`状态就导致了后续的代码正常执行。

#### 修复方案
在`Checkbox`组件的`change`事件中增加对`isDisabled`的判断
### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Checkbox):  修复复选框禁用状态下仍可触发选中变更的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
