### PR TITLE
fix(swiper): fix switching logic when there are only two images

### DIFF
--- a/packages/components/swiper/swiper.tsx
+++ b/packages/components/swiper/swiper.tsx
@@ -136,32 +136,35 @@ export default defineComponent({
     };
 
     const swiperTo = (index: number, context: { source: SwiperChangeSource }) => {
-      let targetIndex = index % swiperItemLength.value;
+      const length = swiperItemLength.value;
+      let targetIndex = ((index % length) + length) % length;
       navActiveIndex.value = targetIndex;
       emit('update:current', targetIndex);
       props.onChange?.(targetIndex, context);
       isSwitching.value = true;
-      if (props.animation === 'slide' && swiperItemLength.value > 1 && props.type !== 'card') {
+      if (props.animation === 'slide' && length > 1 && props.type !== 'card') {
         targetIndex = index;
         isBeginToEnd = false;
         isEndToBegin = false;
-        if (index >= swiperItemLength.value) {
+
+        // 最后一张点击下一张：进入尾部克隆的第一张
+        if (index >= length) {
           clearTimer();
           setTimeout(() => {
             isEndToBegin = true;
             currentIndex.value = 0;
           }, props.duration);
         }
-        if (currentIndex.value === 0) {
-          if (swiperItemLength.value >= 2 && index === swiperItemLength.value - 1) {
-            targetIndex = -1;
-            navActiveIndex.value = swiperItemLength.value - 1;
-            clearTimer();
-            setTimeout(() => {
-              isBeginToEnd = true;
-              currentIndex.value = swiperItemLength.value - 1;
-            }, props.duration);
-          }
+
+        // 第一张点击上一张：进入头部克隆的最后一张
+        if (index < 0) {
+          targetIndex = -1;
+          navActiveIndex.value = length - 1;
+          clearTimer();
+          setTimeout(() => {
+            isBeginToEnd = true;
+            currentIndex.value = length - 1;
+          }, props.duration);
         }
       }
       currentIndex.value = targetIndex;
@@ -221,12 +224,6 @@ export default defineComponent({
     };
     const goPrevious = (context: { source: SwiperChangeSource }) => {
       if (isSwitching.value) return;
-      if (currentIndex.value - 1 < 0) {
-        if (props.animation === 'slide' && swiperItemLength.value === 2) {
-          return swiperTo(0, context);
-        }
-        return swiperTo(swiperItemLength.value - 1, context);
-      }
       return swiperTo(currentIndex.value - 1, context);
     };
     const renderPagination = () => {

--- a/packages/tdesign-vue-next/.changelog/pr-6830.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6830.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6830
+contributor: yuxi-ovo
+---
+
+- fix(Swiper): 修复只有两个轮播图内容场景下切换逻辑错误的问题 @yuxi-ovo ([#6830](https://github.com/Tencent/tdesign-vue-next/pull/6830))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#6820 

### 💡 需求背景和解决方案

<img width="807" height="538" alt="image" src="https://github.com/user-attachments/assets/cd098ec2-35e8-4115-bf52-d68821e0acd9" />
通过修改targetIndex计算逻辑 分辨方向 修复问题 

https://github.com/user-attachments/assets/8beb0324-37d8-4a3e-b2dd-b42d385dbcc6




### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

- fix(Swiper): 修复只有两个轮播图内容场景下切换逻辑错误的问题
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
