### PR TITLE
test(checkbox): improve checkbox test coverage

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox-group.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox-group.test.tsx
@@ -1,0 +1,422 @@
+import { mount, shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Checkbox, CheckboxGroup } from '..';
+import type { CheckboxGroupValue, CheckboxOptionObj } from '../type';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CheckboxGroup', () => {
+  describe('props', () => {
+    it(':default[slot]', () => {
+      const wrapper = mount(CheckboxGroup, {
+        slots: {
+          default: () => [<Checkbox value="a">Alpha</Checkbox>, <Checkbox value="b">Beta</Checkbox>],
+        },
+      });
+      const emptyOptions = mount(CheckboxGroup, {
+        props: { options: [] },
+        slots: { default: () => <Checkbox value="slot-value">Slot option</Checkbox> },
+      });
+      const childWithoutProps = mount(CheckboxGroup, {
+        slots: { default: () => <Checkbox>Unconfigured option</Checkbox> },
+      });
+
+      const group = wrapper.get('.t-checkbox-group');
+      expect(group.attributes('role')).toBe('group');
+      expect(group.attributes('aria-label')).toBe('checkbox-group');
+      expect(group.findAll('.t-checkbox__label').map((item) => item.text())).toEqual(['Alpha', 'Beta']);
+      expect(emptyOptions.get('.t-checkbox__label').text()).toBe('Slot option');
+      expect(childWithoutProps.get('.t-checkbox__label').text()).toBe('Unconfigured option');
+    });
+
+    it(':disabled[boolean]', () => {
+      const disabled = mount(CheckboxGroup, { props: { options: ['a', 'b'], disabled: true } });
+      const childOverride = mount(CheckboxGroup, {
+        props: { disabled: true },
+        slots: {
+          default: () => [
+            <Checkbox value="a">Inherited</Checkbox>,
+            <Checkbox value="b" disabled={false}>
+              Overridden
+            </Checkbox>,
+          ],
+        },
+      });
+      const formInherited = mount(CheckboxGroup, {
+        props: { options: ['a'] },
+        global: { provide: { formDisabled: { disabled: ref(true) } } },
+      });
+      const groupOverride = mount(CheckboxGroup, {
+        props: { options: ['a'], disabled: false },
+        global: { provide: { formDisabled: { disabled: ref(true) } } },
+      });
+
+      expect(disabled.findAll('label').every((item) => item.classes().includes('t-is-disabled'))).toBe(true);
+      expect(disabled.findAll('input').every((item) => item.attributes('disabled') !== undefined)).toBe(true);
+      expect(childOverride.findAll('label')[0].classes()).toContain('t-is-disabled');
+      expect(childOverride.findAll('label')[1].classes()).not.toContain('t-is-disabled');
+      expect(formInherited.get('label').classes()).toContain('t-is-disabled');
+      expect(groupOverride.get('label').classes()).not.toContain('t-is-disabled');
+    });
+
+    it(':lazyLoad[boolean]', () => {
+      const wrapper = shallowMount(CheckboxGroup, {
+        props: { lazyLoad: true, options: ['a', 'b'] },
+      });
+
+      expect(wrapper.findAllComponents(Checkbox).map((item) => item.props('lazyLoad'))).toEqual([true, true]);
+    });
+
+    describe(':max[number]', () => {
+      it('disables only unchecked options after reaching max', async () => {
+        const onChange = vi.fn();
+        const wrapper = mount(CheckboxGroup, {
+          props: { options: ['a', 'b'], defaultValue: ['a'], max: 1, onChange },
+        });
+
+        expect(wrapper.findAll('label')[0].classes()).not.toContain('t-is-disabled');
+        expect(wrapper.findAll('label')[1].classes()).toContain('t-is-disabled');
+
+        await wrapper.findAll('input')[1].trigger('change');
+        expect(onChange).not.toHaveBeenCalled();
+
+        await wrapper.findAll('input')[0].trigger('change');
+        expect(wrapper.findAll('label')[1].classes()).not.toContain('t-is-disabled');
+      });
+
+      // Current behavior tracked by #6852: maxExceeded checks equality, so an invalid controlled value can grow.
+      it('currently allows selection when a controlled value already exceeds max', async () => {
+        const wrapper = mount(CheckboxGroup, {
+          props: { options: ['a', 'b', 'c'], value: ['a', 'b'], max: 1 },
+        });
+
+        expect(wrapper.findAll('label')[2].classes()).not.toContain('t-is-disabled');
+
+        await wrapper.findAll('input')[2].trigger('change');
+
+        expect(wrapper.emitted('update:value')).toEqual([[['a', 'b', 'c']]]);
+      });
+
+      // Current behavior tracked by #6852: check-all evaluates max against the old value, not the collected result.
+      it('currently lets check-all bypass max', async () => {
+        const onChange = vi.fn();
+        const maxOne = mount(CheckboxGroup, {
+          props: {
+            max: 1,
+            onChange,
+            options: [
+              { label: 'All', checkAll: true },
+              { label: 'Alpha', value: 'a' },
+              { label: 'Beta', value: 'b' },
+            ],
+          },
+        });
+        const maxZeroChange = vi.fn();
+        const maxZero = mount(CheckboxGroup, {
+          props: {
+            max: 0,
+            onChange: maxZeroChange,
+            options: [
+              { label: 'All', checkAll: true },
+              { label: 'Alpha', value: 'a' },
+              { label: 'Beta', value: 'b' },
+            ],
+          },
+        });
+
+        await maxOne.findAll('input')[0].trigger('change');
+        await maxZero.findAll('input')[0].trigger('change');
+
+        expect(onChange).toHaveBeenCalledWith(
+          ['a', 'b'],
+          expect.objectContaining({ current: undefined, option: undefined, type: 'check', e: expect.any(Event) }),
+        );
+        expect(maxZeroChange).toHaveBeenCalledWith(
+          ['a'],
+          expect.objectContaining({ current: undefined, option: undefined, type: 'check', e: expect.any(Event) }),
+        );
+      });
+    });
+
+    it(':name[string]', () => {
+      const wrapper = mount(CheckboxGroup, {
+        props: {
+          name: 'group-name',
+          options: [
+            { label: 'Inherited', value: 'a' },
+            { label: 'Own', value: 'b', name: 'own-name' },
+          ],
+        },
+      });
+
+      expect(wrapper.findAll('input').map((item) => item.attributes('name'))).toEqual(['group-name', 'own-name']);
+    });
+
+    it(':options[array<string/number>]', () => {
+      const wrapper = mount(CheckboxGroup, { props: { options: ['Alpha', 0, 2] } });
+
+      expect(wrapper.findAll('.t-checkbox__label').map((item) => item.text())).toEqual(['Alpha', '0', '2']);
+      // The missing value for 0 is the Checkbox source behavior tracked by #6851.
+      expect(wrapper.findAll('input').map((item) => item.attributes('value'))).toEqual(['Alpha', undefined, '2']);
+    });
+
+    it(':options[array<object>]', async () => {
+      const options: CheckboxOptionObj[] = [
+        { label: 'Alpha', value: 'a', title: 'Alpha title' },
+        { label: 'Beta', value: 'b', disabled: true },
+      ];
+      const wrapper = mount(CheckboxGroup, { props: { options, defaultValue: ['a'] } });
+
+      expect(wrapper.findAll('label')[0].classes()).toContain('t-is-checked');
+      expect(wrapper.findAll('label')[0].attributes('title')).toBe('Alpha title');
+      expect(wrapper.findAll('label')[1].classes()).toContain('t-is-disabled');
+
+      await wrapper.setProps({ options: ['Gamma', 'Delta'] });
+
+      expect(wrapper.findAll('.t-checkbox__label').map((item) => item.text())).toEqual(['Gamma', 'Delta']);
+    });
+
+    it(':options[array<object>] checkAll', () => {
+      const partial = mount(CheckboxGroup, {
+        props: {
+          defaultValue: ['a'],
+          options: [
+            { label: 'All', checkAll: true },
+            { label: 'Alpha', value: 'a' },
+            { label: 'Beta', value: 'b' },
+          ],
+        },
+      });
+      const ignoresInactive = mount(CheckboxGroup, {
+        props: {
+          defaultValue: ['enabled'],
+          options: [
+            { label: 'All', checkAll: true },
+            { label: 'Disabled', value: 'disabled', disabled: true },
+            { label: 'Readonly', value: 'readonly', readonly: true },
+            { label: 'Enabled', value: 'enabled' },
+          ],
+        },
+      });
+
+      const checkAll = partial.findAll('label')[0];
+      expect(checkAll.classes()).toContain('t-is-indeterminate');
+      expect((checkAll.get('input').element as HTMLInputElement).indeterminate).toBe(true);
+      expect(checkAll.classes()).not.toContain('t-is-checked');
+      expect(ignoresInactive.findAll('label')[0].classes()).toContain('t-is-checked');
+    });
+
+    it(':readonly[boolean]', async () => {
+      const onChange = vi.fn();
+      const readonly = mount(CheckboxGroup, {
+        props: { options: ['a', 'b'], readonly: true, onChange },
+      });
+      const childOverride = mount(CheckboxGroup, {
+        props: { readonly: true, onChange },
+        slots: {
+          default: () => (
+            <Checkbox value="a" readonly={false}>
+              Overridden
+            </Checkbox>
+          ),
+        },
+      });
+
+      expect(readonly.findAll('input').every((item) => item.attributes('readonly') !== undefined)).toBe(true);
+      expect(childOverride.get('input').attributes('readonly')).toBeUndefined();
+
+      await readonly.findAll('input')[0].trigger('change');
+      expect(onChange).not.toHaveBeenCalled();
+
+      await childOverride.get('input').trigger('change');
+      expect(onChange).toHaveBeenCalledWith(
+        ['a'],
+        expect.objectContaining({ current: 'a', type: 'check', e: expect.any(Event) }),
+      );
+    });
+
+    it(':value[array]', async () => {
+      const wrapper = mount(CheckboxGroup, { props: { options: ['a', 'b'], value: ['a'] } });
+
+      await wrapper.findAll('input')[1].trigger('change');
+
+      expect(wrapper.emitted('update:value')).toEqual([[['a', 'b']]]);
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+      expect(wrapper.findAll('label')[1].classes()).not.toContain('t-is-checked');
+
+      await wrapper.setProps({ value: ['a', 'b'] });
+
+      expect(wrapper.findAll('label')[1].classes()).toContain('t-is-checked');
+    });
+
+    it(':value[undefined/non-array]', async () => {
+      const undefinedValue = mount(CheckboxGroup, { props: { options: ['a'], value: undefined } });
+      const invalidValue = mount(CheckboxGroup, {
+        props: { options: ['a'], value: null as unknown as CheckboxGroupValue },
+      });
+
+      await undefinedValue.get('input').trigger('change');
+      await invalidValue.get('input').trigger('change');
+
+      expect(undefinedValue.emitted('update:value')).toEqual([[['a']]]);
+      expect(invalidValue.emitted('update:value')).toEqual([[['a']]]);
+    });
+
+    it(':defaultValue[array]', async () => {
+      const wrapper = mount(CheckboxGroup, { props: { options: ['a', 'b'], defaultValue: ['a'] } });
+
+      expect(wrapper.findAll('label')[0].classes()).toContain('t-is-checked');
+      expect(wrapper.findAll('label')[1].classes()).not.toContain('t-is-checked');
+
+      await wrapper.findAll('input')[1].trigger('change');
+
+      expect(wrapper.findAll('label')[1].classes()).toContain('t-is-checked');
+    });
+
+    it(':modelValue[array]', async () => {
+      const wrapper = mount(CheckboxGroup, { props: { options: ['a', 'b'], modelValue: ['a'] } });
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[[]]]);
+      expect(wrapper.emitted('update:value')).toBeUndefined();
+      expect(wrapper.findAll('label')[0].classes()).toContain('t-is-checked');
+
+      await wrapper.setProps({ modelValue: ['b'], value: ['a'] });
+
+      expect(wrapper.findAll('label')[0].classes()).not.toContain('t-is-checked');
+      expect(wrapper.findAll('label')[1].classes()).toContain('t-is-checked');
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[[]], [['b', 'a']]]);
+      expect(wrapper.emitted('update:value')).toBeUndefined();
+    });
+  });
+
+  describe('events', () => {
+    it('change', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(CheckboxGroup, {
+        props: { options: ['a', 'b'], defaultValue: ['a'], onChange },
+      });
+
+      await wrapper.findAll('input')[1].trigger('change');
+
+      expect(onChange).toHaveBeenNthCalledWith(
+        1,
+        ['a', 'b'],
+        expect.objectContaining({ e: expect.any(Event), current: 'b', type: 'check' }),
+      );
+      expect(onChange.mock.calls[0][1].option).toEqual(expect.objectContaining({ value: 'b', label: 'b' }));
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(onChange).toHaveBeenNthCalledWith(
+        2,
+        ['b'],
+        expect.objectContaining({ e: expect.any(Event), current: 'a', type: 'uncheck' }),
+      );
+    });
+
+    it('change[checkAll]', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(CheckboxGroup, {
+        props: {
+          onChange,
+          options: [
+            { label: 'All', checkAll: true },
+            { label: 'Alpha', value: 'a' },
+            { label: 'Beta', value: 'b' },
+          ],
+        },
+      });
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(wrapper.findAll('label').every((item) => item.classes().includes('t-is-checked'))).toBe(true);
+      expect(onChange).toHaveBeenLastCalledWith(
+        ['a', 'b'],
+        expect.objectContaining({ current: undefined, option: undefined, type: 'check' }),
+      );
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(wrapper.findAll('label').every((item) => !item.classes().includes('t-is-checked'))).toBe(true);
+      expect(onChange).toHaveBeenLastCalledWith(
+        [],
+        expect.objectContaining({ current: undefined, option: undefined, type: 'uncheck' }),
+      );
+    });
+
+    it('change[checkAll disabled/readonly options]', async () => {
+      const selectChange = vi.fn();
+      const select = mount(CheckboxGroup, {
+        props: {
+          onChange: selectChange,
+          options: [
+            { label: 'All', checkAll: true },
+            { label: 'Disabled', value: 'disabled', disabled: true },
+            { label: 'Readonly', value: 'readonly', readonly: true },
+            { label: 'Enabled', value: 'enabled' },
+          ],
+        },
+      });
+      const unselectChange = vi.fn();
+      const unselect = mount(CheckboxGroup, {
+        props: {
+          defaultValue: ['disabled', 'readonly', 'enabled'],
+          onChange: unselectChange,
+          options: [
+            { label: 'All', checkAll: true },
+            { label: 'Disabled', value: 'disabled', disabled: true },
+            { label: 'Readonly', value: 'readonly', readonly: true },
+            { label: 'Enabled', value: 'enabled' },
+          ],
+        },
+      });
+
+      await select.findAll('input')[0].trigger('change');
+      await unselect.findAll('input')[0].trigger('change');
+
+      expect(selectChange).toHaveBeenCalledWith(
+        ['enabled'],
+        expect.objectContaining({ current: undefined, option: undefined, type: 'check' }),
+      );
+      expect(unselectChange).toHaveBeenCalledWith(
+        ['disabled', 'readonly'],
+        expect.objectContaining({ current: undefined, option: undefined, type: 'uncheck' }),
+      );
+    });
+
+    it('change[slot checkAll]', async () => {
+      const emptyValue = ref<CheckboxGroupValue>([]);
+      const emptyAttribute = { 'check-all': '' };
+      const emptyWrapper = mount(() => (
+        <CheckboxGroup v-model={emptyValue.value}>
+          <Checkbox {...emptyAttribute}>All</Checkbox>
+          <Checkbox value="a">Alpha</Checkbox>
+          <Checkbox value="b">Beta</Checkbox>
+        </CheckboxGroup>
+      ));
+      const booleanValue = ref<CheckboxGroupValue>([]);
+      const booleanAttribute = { 'check-all': true };
+      const booleanWrapper = mount(() => (
+        <CheckboxGroup v-model={booleanValue.value}>
+          <Checkbox {...booleanAttribute}>All</Checkbox>
+          <Checkbox value="a">Alpha</Checkbox>
+        </CheckboxGroup>
+      ));
+
+      await emptyWrapper.findAll('input')[0].trigger('change');
+      await booleanWrapper.findAll('input')[0].trigger('change');
+
+      expect(emptyValue.value).toEqual(['a', 'b']);
+      expect(booleanValue.value).toEqual(['a']);
+    });
+  });
+});

--- a/packages/components/checkbox/__tests__/checkbox.hooks.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.hooks.test.tsx
@@ -1,0 +1,256 @@
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Checkbox from '..';
+import useKeyboardEvent from '../hooks/useKeyboardEvent';
+
+type RegisteredKeyboardListener = (event: KeyboardEvent) => void;
+
+const createKeyboardEvent = (key: string, code = key) =>
+  ({
+    key,
+    code,
+    currentTarget: document.createElement('label'),
+    preventDefault: vi.fn(),
+  } as unknown as KeyboardEvent);
+
+const createKeyboardHarness = (inputDisabled = false, withInput = true) => {
+  const root = document.createElement('label');
+  if (withInput) {
+    const input = document.createElement('input');
+    input.disabled = inputDisabled;
+    root.appendChild(input);
+  }
+
+  const handleChange = vi.fn();
+  const addEventListener = vi.spyOn(root, 'addEventListener');
+  const removeEventListener = vi.spyOn(root, 'removeEventListener');
+  const { onCheckboxFocus, onCheckboxBlur } = useKeyboardEvent(handleChange);
+
+  onCheckboxFocus({ currentTarget: root } as unknown as FocusEvent);
+  const listener = addEventListener.mock.calls.find(([name]) => name === 'keydown')?.[1] as RegisteredKeyboardListener;
+
+  return { root, handleChange, listener, onCheckboxBlur, removeEventListener };
+};
+
+class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly root: Element | Document | null;
+
+  readonly rootMargin: string;
+
+  readonly thresholds: readonly number[];
+
+  readonly observe = vi.fn();
+
+  readonly unobserve = vi.fn();
+
+  readonly disconnect = vi.fn();
+
+  readonly takeRecords = vi.fn(() => [] as IntersectionObserverEntry[]);
+
+  constructor(private readonly callback: IntersectionObserverCallback, options: IntersectionObserverInit = {}) {
+    this.root = options.root ?? null;
+    this.rootMargin = options.rootMargin ?? '0px';
+    this.thresholds = Array.isArray(options.threshold) ? options.threshold : [options.threshold ?? 0];
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  trigger(isIntersecting: boolean) {
+    this.callback([{ isIntersecting } as IntersectionObserverEntry], this);
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Checkbox hooks', () => {
+  describe('useKeyboardEvent', () => {
+    it('registers on focus and unregisters on blur', () => {
+      const { root, listener, onCheckboxBlur, removeEventListener } = createKeyboardHarness();
+
+      onCheckboxBlur({ currentTarget: root } as unknown as FocusEvent);
+
+      expect(removeEventListener).toHaveBeenCalledWith('keydown', listener);
+    });
+
+    it.each([
+      ['Enter', 'Enter'],
+      ['Space', 'Space'],
+      ['', 'Enter'],
+    ])('handles checked key=%j and code=%j', (key, code) => {
+      const { root, handleChange, listener } = createKeyboardHarness();
+      const event = createKeyboardEvent(key, code);
+      Object.defineProperty(event, 'currentTarget', { value: root });
+
+      listener(event);
+
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+      expect(handleChange).toHaveBeenCalledWith(event);
+    });
+
+    it('matches checked keys case-insensitively', () => {
+      const { root, handleChange, listener } = createKeyboardHarness();
+      const event = createKeyboardEvent('enter', 'enter');
+      Object.defineProperty(event, 'currentTarget', { value: root });
+
+      listener(event);
+
+      expect(handleChange).toHaveBeenCalledWith(event);
+    });
+
+    it('ignores unrelated keys', () => {
+      const { root, handleChange, listener } = createKeyboardHarness();
+      const event = createKeyboardEvent('Escape', 'Escape');
+      Object.defineProperty(event, 'currentTarget', { value: root });
+
+      listener(event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('does not change a disabled input', () => {
+      const { root, handleChange, listener } = createKeyboardHarness(true);
+      const event = createKeyboardEvent('Enter');
+      Object.defineProperty(event, 'currentTarget', { value: root });
+
+      listener(event);
+
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    // Current behavior tracked by #6854: lazy content can leave the focusable label without an input.
+    it('currently throws for a checked key when no input is rendered', () => {
+      const { root, listener } = createKeyboardHarness(false, false);
+      const event = createKeyboardEvent('Enter');
+      Object.defineProperty(event, 'currentTarget', { value: root });
+
+      expect(() => listener(event)).toThrow(TypeError);
+      expect(event.preventDefault).toHaveBeenCalledOnce();
+    });
+
+    it('integrates with Checkbox focus and blur', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Checkbox, { props: { onChange } });
+      const root = wrapper.get('label');
+
+      await root.trigger('focus');
+      await root.trigger('keydown', { key: 'Enter' });
+
+      expect(wrapper.get('label').classes()).toContain('t-is-checked');
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(KeyboardEvent) });
+
+      onChange.mockClear();
+      await root.trigger('blur');
+      await root.trigger('keydown', { key: 'Enter' });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useCheckboxLazyLoad', () => {
+    beforeEach(() => {
+      MockIntersectionObserver.instances = [];
+      vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+    });
+
+    it('renders immediately without an observer when disabled', () => {
+      const wrapper = mount(Checkbox);
+
+      expect(wrapper.find('input').exists()).toBe(true);
+      expect(MockIntersectionObserver.instances).toHaveLength(0);
+
+      wrapper.unmount();
+    });
+
+    it('hides content until the label intersects', async () => {
+      const wrapper = mount(Checkbox, { props: { lazyLoad: true, label: 'Lazy checkbox' } });
+      await nextTick();
+      const observer = MockIntersectionObserver.instances.at(-1);
+
+      expect(observer).toBeDefined();
+      expect(wrapper.find('input').exists()).toBe(false);
+      expect(wrapper.get('label').text()).toBe('');
+      expect(observer.observe).toHaveBeenCalledWith(wrapper.get('label').element);
+      expect(observer.root).toBeNull();
+      expect(observer.rootMargin).toBe('0px 0px 0px 0px');
+
+      observer.trigger(false);
+      await nextTick();
+
+      expect(wrapper.find('input').exists()).toBe(false);
+      expect(observer.unobserve).not.toHaveBeenCalled();
+
+      observer.trigger(true);
+      await nextTick();
+
+      expect(wrapper.find('input').exists()).toBe(true);
+      expect(wrapper.get('.t-checkbox__label').text()).toBe('Lazy checkbox');
+      expect(observer.unobserve).toHaveBeenCalledWith(wrapper.get('label').element);
+
+      wrapper.unmount();
+    });
+
+    it('starts observing when lazyLoad becomes enabled', async () => {
+      const wrapper = mount(Checkbox, { props: { lazyLoad: false } });
+
+      await wrapper.setProps({ lazyLoad: true });
+
+      const observer = MockIntersectionObserver.instances.at(-1);
+      expect(observer).toBeDefined();
+      expect(wrapper.find('input').exists()).toBe(false);
+
+      observer.trigger(true);
+      await nextTick();
+
+      expect(wrapper.find('input').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it('unobserves the active label on unmount', () => {
+      const wrapper = mount(Checkbox, { props: { lazyLoad: true } });
+      const label = wrapper.get('label').element;
+      const observer = MockIntersectionObserver.instances.at(-1);
+
+      wrapper.unmount();
+
+      expect(observer.unobserve).toHaveBeenCalledWith(label);
+    });
+
+    // Current behavior tracked by #6853: disabling lazyLoad neither reveals content nor cleans up the observer.
+    it('currently keeps hidden content and its observer after lazyLoad is disabled', async () => {
+      const wrapper = mount(Checkbox, { props: { lazyLoad: true } });
+      const observer = MockIntersectionObserver.instances.at(-1);
+
+      await wrapper.setProps({ lazyLoad: false });
+
+      expect(wrapper.find('input').exists()).toBe(false);
+
+      wrapper.unmount();
+
+      expect(observer.unobserve).not.toHaveBeenCalled();
+    });
+
+    // Current behavior tracked by #6853: observe() returns null without IntersectionObserver, then cleanup dereferences it.
+    it('currently reports a lifecycle error when IntersectionObserver is unavailable', () => {
+      vi.stubGlobal('IntersectionObserver', undefined);
+      const errorHandler = vi.fn();
+      const wrapper = mount(Checkbox, {
+        props: { lazyLoad: true },
+        global: { config: { errorHandler } },
+      });
+
+      expect(wrapper.find('input').exists()).toBe(true);
+
+      wrapper.unmount();
+
+      expect(errorHandler).toHaveBeenCalledWith(expect.any(TypeError), expect.any(Object), expect.any(String));
+    });
+  });
+});

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,207 +1,286 @@
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
-import Checkbox, { CheckboxGroup } from '@tdesign/components/checkbox';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-describe('Checkbox', () => {
-  describe(':props', () => {
-    it(':checked', () => {
-      const checked = ref(true);
-      const wrapper = mount(() => <Checkbox v-model={checked.value} />);
-      const checkbox = wrapper.find('.t-checkbox');
-      expect(checkbox.classes()).toContain('t-is-checked');
-    });
+import Checkbox from '..';
 
-    it(':defaultChecked', () => {
-      const checked = ref(true);
-      const wrapper = mount(() => <Checkbox defaultChecked={checked.value} />);
-      const checkbox = wrapper.find('.t-checkbox');
-      expect(checkbox.classes()).toContain('t-is-checked');
-    });
-
-    it(':default', () => {
-      const checked = ref(true);
-      const wrapper = mount(() => <Checkbox defaultChecked={checked.value} default="checkbox" />);
-      const label = wrapper.find('.t-checkbox__label');
-      expect(label.exists()).toBeTruthy();
-      expect(label.text()).toBe('checkbox');
-    });
-
-    it(':disabled', () => {
-      const wrapper = mount(() => <Checkbox disabled default="checkbox" />);
-      const checkbox = wrapper.find('.t-checkbox');
-      expect(checkbox.classes()).toContain('t-is-disabled');
-    });
-
-    it(':indeterminate', () => {
-      const wrapper = mount(() => <Checkbox indeterminate default="checkbox" />);
-      const checkbox = wrapper.find('.t-checkbox');
-      expect(checkbox.classes()).toContain('t-is-indeterminate');
-    });
-
-    it(':label', () => {
-      const wrapper = mount(() => <Checkbox label="label" />);
-      const label = wrapper.find('.t-checkbox__label');
-      expect(label.exists()).toBeTruthy();
-      expect(label.text()).toBe('label');
-    });
-
-    it(':name', () => {
-      const wrapper = mount(() => <Checkbox name="name" />);
-      const input = wrapper.find('.t-checkbox input');
-      expect(input.element.getAttribute('name')).toBe('name');
-    });
-  });
-  describe(': events', () => {
-    it(':onChange', async () => {
-      const checked = ref(true);
-      const fn = vi.fn();
-      const wrapper = mount(() => <Checkbox v-model={checked.value} label="label" onChange={fn} />);
-      const input = wrapper.find('input');
-      await input.trigger('change');
-      expect(fn).toBeCalled();
-      expect(checked.value).toBeFalsy();
-    });
-  });
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
-describe('CheckboxGroup', () => {
-  describe(':props', () => {
-    it('', () => {
-      const wrapper = mount(() => (
-        <CheckboxGroup>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox');
-      expect(checkboxs.length).toBe(2);
+describe('Checkbox', () => {
+  describe('props', () => {
+    it(':checkAll[boolean]', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Checkbox, { props: { checkAll: true, onChange } });
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-checked');
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-checked');
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(Event) });
     });
 
-    it(':disabled', () => {
-      const wrapper = mount(() => (
-        <CheckboxGroup disabled>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox');
-      expect(checkboxs[0].classes()).toContain('t-is-disabled');
-      expect(checkboxs[1].classes()).toContain('t-is-disabled');
+    it(':checked[boolean]', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Checkbox, { props: { checked: false, onChange } });
+      const root = wrapper.get('label.t-checkbox');
+      const input = root.get('input.t-checkbox__former');
+
+      expect(root.attributes('tabindex')).toBe('0');
+      expect(root.classes()).not.toEqual(
+        expect.arrayContaining(['t-is-checked', 't-is-disabled', 't-is-indeterminate']),
+      );
+      expect(input.attributes('type')).toBe('checkbox');
+      expect(input.attributes('tabindex')).toBe('-1');
+      expect((input.element as HTMLInputElement).checked).toBe(false);
+      expect(root.get('.t-checkbox__input').element.tagName).toBe('SPAN');
+      expect(root.get('.t-checkbox__label').text()).toBe('');
+
+      await input.trigger('change');
+
+      expect(wrapper.emitted('update:checked')).toEqual([[true]]);
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(Event) });
+      expect(root.classes()).not.toContain('t-is-checked');
+
+      await wrapper.setProps({ checked: true });
+
+      expect(root.classes()).toContain('t-is-checked');
+      expect((input.element as HTMLInputElement).checked).toBe(true);
     });
 
-    it(':name', () => {
-      const wrapper = mount(() => (
-        <CheckboxGroup name="name">
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox input');
-      expect(checkboxs[0].element.getAttribute('name')).toBe('name');
-      expect(checkboxs[1].element.getAttribute('name')).toBe('name');
+    it(':modelValue[boolean]', async () => {
+      const wrapper = mount(Checkbox, { props: { modelValue: true } });
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+      expect(wrapper.emitted('update:checked')).toBeUndefined();
+      expect(wrapper.get('label').classes()).toContain('t-is-checked');
+
+      await wrapper.setProps({ modelValue: false, checked: true });
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-checked');
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false], [true]]);
+      expect(wrapper.emitted('update:checked')).toBeUndefined();
     });
 
-    it(':value', () => {
-      const checked = ref(['1']);
-      const wrapper = mount(() => (
-        <CheckboxGroup v-model={checked.value}>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox');
-      expect(checkboxs[0].classes()).toContain('t-is-checked');
-      expect(checkboxs[1].classes()).not.toContain('t-is-checked');
+    it(':defaultChecked[boolean]', async () => {
+      const wrapper = mount(Checkbox, { props: { defaultChecked: true } });
+
+      expect(wrapper.get('label').classes()).toContain('t-is-checked');
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-checked');
     });
 
-    it(':value', () => {
-      const defaultValue = ref(['1']);
-      const wrapper = mount(() => (
-        <CheckboxGroup defaultValue={defaultValue.value}>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox');
-      expect(checkboxs[0].classes()).toContain('t-is-checked');
-      expect(checkboxs[1].classes()).not.toContain('t-is-checked');
+    it(':default[string/slot/function]', () => {
+      const byString = mount(Checkbox, { props: { default: 'Default content' } });
+      const byFunction = mount(Checkbox, {
+        props: { default: () => <strong data-testid="default-node">Function content</strong> },
+      });
+      const bySlot = mount(Checkbox, {
+        props: { label: 'Label fallback' },
+        slots: { default: () => <span data-testid="default-slot">Slot content</span> },
+      });
+      const propBeforeSlot = mount(Checkbox, {
+        props: { default: 'Default prop', label: 'Label prop' },
+        slots: { default: () => <span data-testid="ignored-slot">Slot content</span> },
+      });
+
+      expect(byString.get('.t-checkbox__label').text()).toBe('Default content');
+      expect(byFunction.get('[data-testid="default-node"]').text()).toBe('Function content');
+      expect(bySlot.get('[data-testid="default-slot"]').text()).toBe('Slot content');
+      expect(propBeforeSlot.get('.t-checkbox__label').text()).toBe('Default prop');
+      expect(propBeforeSlot.find('[data-testid="ignored-slot"]').exists()).toBe(false);
     });
 
-    it(':options', () => {
-      const defaultValue = ref(['1']);
-      const options = [
-        {
-          label: '选项一',
-          value: '1',
-        },
-        {
-          label: '选项二',
-          value: '2',
-        },
-      ];
-      const wrapper = mount(() => <CheckboxGroup defaultValue={defaultValue.value} options={options}></CheckboxGroup>);
-      const checkboxs = wrapper.findAll('.t-checkbox');
-      expect(checkboxs.length).toBe(2);
-      expect(checkboxs[0].classes()).toContain('t-is-checked');
-      expect(checkboxs[1].classes()).not.toContain('t-is-checked');
+    it(':disabled[boolean]', async () => {
+      const onChange = vi.fn();
+      const disabled = mount(Checkbox, { props: { disabled: true, onChange } });
+      const inherited = mount(Checkbox, {
+        global: { provide: { formDisabled: { disabled: ref(true) } } },
+      });
+      const overridden = mount(Checkbox, {
+        props: { disabled: false },
+        global: { provide: { formDisabled: { disabled: ref(true) } } },
+      });
+
+      expect(disabled.get('label').classes()).toContain('t-is-disabled');
+      expect(disabled.get('label').attributes('tabindex')).toBeUndefined();
+      expect(disabled.get('input').attributes('disabled')).toBeDefined();
+      expect(inherited.get('label').classes()).toContain('t-is-disabled');
+      expect(overridden.get('label').classes()).not.toContain('t-is-disabled');
+
+      await disabled.get('input').trigger('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(disabled.get('label').classes()).not.toContain('t-is-checked');
+    });
+
+    it(':indeterminate[boolean]', async () => {
+      const wrapper = mount(Checkbox, { props: { indeterminate: true } });
+      const input = wrapper.get('input');
+
+      expect(wrapper.get('label').classes()).toContain('t-is-indeterminate');
+      expect((input.element as HTMLInputElement).indeterminate).toBe(true);
+
+      await wrapper.setProps({ indeterminate: false });
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-indeterminate');
+      expect((input.element as HTMLInputElement).indeterminate).toBe(false);
+    });
+
+    it(':label[string/function]', () => {
+      const byString = mount(Checkbox, { props: { label: 'Label content' } });
+      const byFunction = mount(Checkbox, {
+        props: { label: () => <strong data-testid="label-node">Node content</strong> },
+      });
+
+      expect(byString.get('.t-checkbox__label').text()).toBe('Label content');
+      expect(byFunction.get('[data-testid="label-node"]').text()).toBe('Node content');
+    });
+
+    it(':lazyLoad[boolean]', () => {
+      vi.stubGlobal('IntersectionObserver', undefined);
+      const immediate = mount(Checkbox, { props: { lazyLoad: false } });
+      const lazy = mount(Checkbox, { props: { lazyLoad: true } });
+
+      expect(immediate.find('input').exists()).toBe(true);
+      expect(lazy.find('input').exists()).toBe(true);
+    });
+
+    it(':name[string]', async () => {
+      const wrapper = mount(Checkbox, { props: { name: 'first-name' } });
+
+      expect(wrapper.get('input').attributes('name')).toBe('first-name');
+
+      await wrapper.setProps({ name: 'second-name' });
+
+      expect(wrapper.get('input').attributes('name')).toBe('second-name');
+    });
+
+    it(':readonly[boolean]', async () => {
+      const onChange = vi.fn();
+      const readonly = mount(Checkbox, { props: { readonly: true, onChange } });
+      const formReadonly = ref(true);
+      const inherited = mount(Checkbox, {
+        global: { provide: { formReadonly: { readonly: formReadonly } } },
+      });
+      const overridden = mount(Checkbox, {
+        props: { readonly: false },
+        global: { provide: { formReadonly: { readonly: formReadonly } } },
+      });
+
+      expect(readonly.get('input').attributes('readonly')).toBeDefined();
+      expect(inherited.get('input').attributes('readonly')).toBeDefined();
+      expect(overridden.get('input').attributes('readonly')).toBeUndefined();
+
+      await readonly.get('input').trigger('change');
+
+      expect(onChange).not.toHaveBeenCalled();
+
+      formReadonly.value = false;
+      await inherited.vm.$nextTick();
+
+      expect(inherited.get('input').attributes('readonly')).toBeUndefined();
+    });
+
+    it(':title[string]', async () => {
+      const wrapper = mount(Checkbox, { props: { title: 'Checkbox title' } });
+
+      expect(wrapper.get('label').attributes('title')).toBe('Checkbox title');
+
+      await wrapper.setProps({ title: '' });
+
+      expect(wrapper.get('label').attributes('title')).toBeUndefined();
+    });
+
+    it(':value[string/number/boolean]', () => {
+      const stringValue = mount(Checkbox, { props: { value: 'alpha' } });
+      const numberValue = mount(Checkbox, { props: { value: 7 } });
+      const booleanValue = mount(Checkbox, { props: { value: true } });
+
+      expect(stringValue.get('input').attributes('value')).toBe('alpha');
+      expect(numberValue.get('input').attributes('value')).toBe('7');
+      expect(booleanValue.get('input').attributes('value')).toBe('true');
+
+      // Current behavior tracked by #6851: documented falsy values are omitted from the native input.
+      for (const value of [0, false, ''] as const) {
+        const wrapper = mount(Checkbox, { props: { value } });
+        expect(wrapper.get('input').attributes('value')).toBeUndefined();
+      }
+    });
+
+    it(':needRipple[boolean]', () => {
+      vi.useFakeTimers();
+      const wrapper = mount(Checkbox, { props: { needRipple: true } });
+      const root = wrapper.get('label');
+
+      root.element.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+      expect(root.element.children).toHaveLength(4);
+
+      root.element.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+      vi.runAllTimers();
+
+      expect(root.element.children).toHaveLength(3);
+    });
+
+    it(':stopLabelTrigger[boolean]', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Checkbox, { props: { stopLabelTrigger: true, onChange } });
+      const stoppedEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+      wrapper.get('label').element.dispatchEvent(stoppedEvent);
+      expect(stoppedEvent.defaultPrevented).toBe(true);
+
+      await wrapper.get('.t-checkbox__input').trigger('click');
+      expect(wrapper.get('label').classes()).toContain('t-is-checked');
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
+
+      await wrapper.setProps({ stopLabelTrigger: false });
+      const nativeEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+      wrapper.get('label').element.dispatchEvent(nativeEvent);
+
+      expect(nativeEvent.defaultPrevented).toBe(false);
     });
   });
 
-  describe(':events', () => {
-    it(':checkAll', async () => {
-      const checked = ref([]);
-      const wrapper = mount(() => (
-        <CheckboxGroup v-model={checked.value}>
-          <Checkbox checkAll>全选</Checkbox>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox input');
-      await checkboxs[0].trigger('change');
-      expect(checked.value).toEqual(['1', '2']);
+  describe('events', () => {
+    it('change', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Checkbox, { props: { onChange } });
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.get('label').classes()).toContain('t-is-checked');
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(Event) });
+
+      await wrapper.get('input').trigger('change');
+
+      expect(wrapper.get('label').classes()).not.toContain('t-is-checked');
+      expect(onChange).toHaveBeenLastCalledWith(false, { e: expect.any(Event) });
     });
 
-    it(':onChange', async () => {
-      const checked = ref(['1']);
-      const fn = vi.fn();
+    it('click', async () => {
+      const onParentClick = vi.fn();
       const wrapper = mount(() => (
-        <CheckboxGroup v-model={checked.value} onChange={fn}>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
+        <div onClick={onParentClick}>
+          <Checkbox />
+        </div>
       ));
-      const checkboxs = wrapper.findAll('.t-checkbox input');
-      await checkboxs[1].trigger('change');
-      expect(fn).toBeCalled();
-      expect(checked.value).toEqual(['1', '2']);
-    });
 
-    it(':value=null allows checking checkboxes', async () => {
-      const checked = ref(null);
-      const wrapper = mount(() => (
-        <CheckboxGroup v-model={checked.value}>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox input');
-      await checkboxs[0].trigger('change');
-      expect(checked.value).toEqual(['1']);
-    });
+      await wrapper.get('input').trigger('click');
 
-    it(':value=undefined allows checking checkboxes', async () => {
-      const checked = ref(undefined);
-      const wrapper = mount(() => (
-        <CheckboxGroup v-model={checked.value}>
-          <Checkbox value="1">选项一</Checkbox>
-          <Checkbox value="2">选项二</Checkbox>
-        </CheckboxGroup>
-      ));
-      const checkboxs = wrapper.findAll('.t-checkbox input');
-      await checkboxs[0].trigger('change');
-      expect(checked.value).toEqual(['1']);
+      expect(onParentClick).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## 关联

- 测试覆盖率专项：#5631
- 本次测试确认的源码问题：#6851、#6852、#6853、#6854

## 变更说明

删除 Checkbox 原有测试并完整重写，不修改组件源码；参照 Form 的组织方式拆分为组件、子组件和 hooks 三个文件，共 51 个用例：

| 文件 | 用例数 | 覆盖内容 |
| --- | ---: | --- |
| `checkbox.test.tsx` | 17 | Checkbox `props`、`events` |
| `checkbox-group.test.tsx` | 19 | CheckboxGroup `props`、`events` |
| `checkbox.hooks.test.tsx` | 15 | `useKeyboardEvent`、`useCheckboxLazyLoad` |

组件与子组件用例名称采用 `:propName[type]` 和事件名；基础类型、string/number/boolean、slot/function、受控/非受控模型均分别覆盖。键盘和懒加载不再按场景拆文件，而是统一归入 hooks 测试。所有断言均针对明确行为和 DOM 状态，不依赖 snapshot，也没有 `ts-nocheck`。

## 覆盖率

Checkbox 目录：

| 指标 | 修改前 | 修改后 |
| --- | ---: | ---: |
| Statements | 95.45% | 100% |
| Branches | 81.05% | 100% |
| Functions | 88.88% | 100% |
| Lines | 95.45% | 100% |

`checkbox.tsx`、`group.tsx`、`useKeyboardEvent.ts`、`useCheckboxLazyLoad.ts` 四项指标均为 100%。

## 测试中记录的当前行为

以下源码问题均按当前真实行为保留特征断言：

1. #6851：`0`、`false`、`''` 没有透传到原生 input 的 value；
2. #6852：CheckboxGroup 的 max 可被超长受控值和 check-all 绕过；
3. #6853：lazyLoad 在缺少 IntersectionObserver 或运行时关闭时会清理报错/泄漏；
4. #6854：lazyLoad 尚未渲染 input 时，Enter/Space 会因空 querySelector 抛错。

本 PR 不修复源码；源码修复后，这些用例会提醒同步更新为期望行为。

## 验证

- Checkbox 定向测试：3 files / 51 tests passed
- Checkbox 定向覆盖率：Statements / Branches / Functions / Lines 均为 100%
- `pnpm lint:tsc`
- `pnpm lint`
- 完整 unit：155 files passed，3592 passed / 2 skipped / 3 todo
- 完整 snapshot：155 files passed，3574 passed / 20 skipped / 3 todo
- `git diff --check`

Refs #5631
