### PR TITLE
fix(tabs): preserve numeric zero default value

### DIFF
--- a/packages/components/tabs/__tests__/tabs.test.tsx
+++ b/packages/components/tabs/__tests__/tabs.test.tsx
@@ -71,6 +71,25 @@ describe('Tabs', () => {
       });
       expect(wrapper.element).toMatchSnapshot();
     });
+    it(':defaultValue[0]', () => {
+      const wrapper = mount({
+        render() {
+          return (
+            <Tabs defaultValue={0}>
+              <TabPanel value={0} label="Zero">
+                Zero panel
+              </TabPanel>
+              <TabPanel value={1} label="One">
+                One panel
+              </TabPanel>
+            </Tabs>
+          );
+        },
+      });
+
+      expect(wrapper.find('.t-tabs__nav-item.t-is-active').text()).toBe('Zero');
+      expect(wrapper.findAll('.t-tab-panel')[0].classes()).not.toContain('t-is-hidden');
+    });
   });
 
   // test events

--- a/packages/components/tabs/tabs.tsx
+++ b/packages/components/tabs/tabs.tsx
@@ -21,7 +21,7 @@ export default defineComponent({
     const renderTNodeJSX = useTNodeJSX();
 
     const { value, modelValue } = toRefs(props);
-    const [tabValue, setTabValue] = useVModel(value, modelValue, props.defaultValue || '', props.onChange);
+    const [tabValue, setTabValue] = useVModel(value, modelValue, props.defaultValue ?? '', props.onChange);
 
     provide<InjectTabs>('tabs', { value: tabValue });
 

--- a/packages/tdesign-vue-next/.changelog/pr-6866.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6866.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6866
+contributor: kyui-azusa
+---
+
+- fix(Tabs): 修复 `defaultValue` 为 `0` 时无法默认激活选项卡的问题 @kyui-azusa ([#6866](https://github.com/Tencent/tdesign-vue-next/pull/6866))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6861

Related test coverage work: #6859

### 💡 需求背景和解决方案

`Tabs` accepts `number` values, but its uncontrolled value initialization used `props.defaultValue || ''`. This treated the valid numeric value `0` as absent, so neither the matching navigation item nor its panel became active.

This change uses a nullish fallback instead, preserving `0` while retaining the existing empty-string fallback for missing values. It also adds a focused regression test covering the active navigation item and visible panel.

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Tabs): 修复 `defaultValue` 为 `0` 时无法默认激活选项卡的问题

#### @tdesign-vue-next/chat



#### @tdesign-vue-next/nuxt



#### @tdesign-vue-next/auto-import-resolver



### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit tabs`
- `TEST_TARGET=snap pnpm -C packages/tdesign-vue-next/test exec vitest run tabs`
- `pnpm exec eslint packages/components/tabs/tabs.tsx packages/components/tabs/__tests__/tabs.test.tsx --max-warnings 0`
- `pnpm lint:tsc`

Validated with Node.js 22 and pnpm 10.33.0.