### PR TITLE
fix(head-menu): handle single vnode slots

### DIFF
--- a/packages/components/menu/__tests__/head-menu.test.tsx
+++ b/packages/components/menu/__tests__/head-menu.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
-import { HeadMenu } from '@tdesign/components/menu';
+import { defineComponent, h } from 'vue';
+import { HeadMenu, MenuItem } from '@tdesign/components/menu';
 
 // every component needs four parts: props/events/slots/functions.
 describe('HeadMenu', () => {
@@ -25,6 +26,25 @@ describe('HeadMenu', () => {
   });
 
   describe('slot', () => {
+    it('accepts a single VNode returned by a wrapper component', () => {
+      const MenuContent = defineComponent({
+        setup(_, { slots }) {
+          return () => <div>{slots.default?.()}</div>;
+        },
+      });
+      const wrapper = mount(HeadMenu, {
+        props: { expandType: 'popup' },
+        slots: {
+          default: () =>
+            h(MenuContent, null, {
+              default: () => <MenuItem value="one">One</MenuItem>,
+            }),
+        },
+      });
+
+      expect(wrapper.find('.t-menu__item').text()).toBe('One');
+    });
+
     it('<logo>', () => {
       const wrapper = mount(HeadMenu, {
         slots: {

--- a/packages/components/menu/head-menu.tsx
+++ b/packages/components/menu/head-menu.tsx
@@ -418,9 +418,9 @@ export default defineComponent({
     /**
      * 通过递归扁平化 slot VNode 树来获取所有叶子菜单项节点
      */
-    const flattenSlotNodes = (nodes: VNode[]): VNode[] => {
+    const flattenSlotNodes = (nodes: VNode | VNode[]): VNode[] => {
       const result: VNode[] = [];
-      for (const node of nodes) {
+      for (const node of isArray(nodes) ? nodes : [nodes]) {
         // Fragment 节点：Vue 将 v-for 列表、多根节点等包装为 Fragment
         if (node.type === Fragment) {
           if (isArray(node.children)) {
@@ -431,7 +431,8 @@ export default defineComponent({
         } else if (isArray(node.children)) {
           result.push(...flattenSlotNodes(node.children as VNode[]));
         } else if (isFunction((node.children as any)?.default)) {
-          result.push(...flattenSlotNodes((node.children as any).default()));
+          const children = (node.children as any).default();
+          result.push(...flattenSlotNodes(children));
         } else {
           result.push(node);
         }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

Fixes #6857

### 💡 需求背景和解决方案

HeadMenu recursively flattened wrapper component slots as if every slot returned an array. A valid render slot may return one VNode, causing `nodes is not iterable` during popup menu measurement.

The flattening helper now accepts either one VNode or an array and normalizes the result before recursion. A regression test covers a wrapper component whose default slot returns a single `MenuItem`.

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit head-menu` (5 passed)
- `pnpm exec eslint packages/components/menu/head-menu.tsx packages/components/menu/__tests__/head-menu.test.tsx --max-warnings 0`
- `git diff --check`