### PR TITLE
fix(menu): ignore missing popup expanded values

### DIFF
--- a/packages/components/menu/__tests__/head-menu.test.tsx
+++ b/packages/components/menu/__tests__/head-menu.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from '@vue/test-utils';
+import { defineComponent, inject } from 'vue';
 import { HeadMenu } from '@tdesign/components/menu';
+import { TdMenuInterface } from '../types';
 
 // every component needs four parts: props/events/slots/functions.
 describe('HeadMenu', () => {
@@ -25,6 +27,28 @@ describe('HeadMenu', () => {
   });
 
   describe('slot', () => {
+    it('keeps expanded values when removing a missing popup value', async () => {
+      const MenuContextProbe = defineComponent({
+        setup() {
+          const menu = inject<TdMenuInterface>('TdMenu');
+          return () => (
+            <div>
+              <span data-testid="expanded-values">{menu?.expandValues?.value.join(',')}</span>
+              <button onClick={() => menu?.open?.('missing', 'remove')} />
+            </div>
+          );
+        },
+      });
+      const wrapper = mount(HeadMenu, {
+        props: { expandType: 'popup', defaultExpanded: ['one', 'two'] },
+        slots: { default: () => <MenuContextProbe /> },
+      });
+
+      await wrapper.get('button').trigger('click');
+
+      expect(wrapper.get('[data-testid="expanded-values"]').text()).toBe('one,two');
+    });
+
     it('<logo>', () => {
       const wrapper = mount(HeadMenu, {
         slots: {

--- a/packages/components/menu/__tests__/menu.test.tsx
+++ b/packages/components/menu/__tests__/menu.test.tsx
@@ -1,5 +1,19 @@
 import { mount } from '@vue/test-utils';
+import { defineComponent, inject } from 'vue';
 import { Menu } from '@tdesign/components/menu';
+import { TdMenuInterface } from '../types';
+
+const MenuContextProbe = defineComponent({
+  setup() {
+    const menu = inject<TdMenuInterface>('TdMenu');
+    return () => (
+      <div>
+        <span data-testid="expanded-values">{menu?.expandValues?.value.join(',')}</span>
+        <button data-testid="remove-missing" onClick={() => menu?.open?.('missing', 'remove')} />
+      </div>
+    );
+  },
+});
 
 // every component needs four parts: props/events/slots/functions.
 describe('Menu', () => {
@@ -52,6 +66,17 @@ describe('Menu', () => {
   });
 
   describe('slot', () => {
+    it('keeps expanded values when removing a missing popup value', async () => {
+      const wrapper = mount(Menu, {
+        props: { expandType: 'popup', defaultExpanded: ['one', 'two'] },
+        slots: { default: () => <MenuContextProbe /> },
+      });
+
+      await wrapper.get('[data-testid="remove-missing"]').trigger('click');
+
+      expect(wrapper.get('[data-testid="expanded-values"]').text()).toBe('one,two');
+    });
+
     it('<logo>', () => {
       const wrapper = mount(Menu, {
         slots: {

--- a/packages/components/menu/head-menu.tsx
+++ b/packages/components/menu/head-menu.tsx
@@ -81,7 +81,9 @@ export default defineComponent({
               expanded.push(value);
             }
           } else if (type === 'remove') {
-            expanded.splice(index, 1);
+            if (index !== -1) {
+              expanded.splice(index, 1);
+            }
           }
         } else if (mode.value === 'normal' && value !== undefined) {
           expanded.splice(0, 1);

--- a/packages/components/menu/menu.tsx
+++ b/packages/components/menu/menu.tsx
@@ -76,7 +76,9 @@ export default defineComponent({
         } else if (type === 'remove') {
           const index = expandValues.value.indexOf(value);
           const tmp = [...expandValues.value];
-          tmp.splice(index, 1);
+          if (index !== -1) {
+            tmp.splice(index, 1);
+          }
           setExpand(tmp);
         }
       },


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

Fixes #6856

### 💡 需求背景和解决方案

Menu and HeadMenu removed popup expanded values with `splice(index, 1)` without checking whether the value existed. A missing value produced `splice(-1, 1)` and incorrectly removed the last expanded item.

Both implementations now remove only when the value index is present. Regression tests cover the non-existent value in Menu and HeadMenu popup mode.

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit menu` (44 passed)
- `pnpm exec eslint packages/components/menu/menu.tsx packages/components/menu/head-menu.tsx packages/components/menu/__tests__/menu.test.tsx packages/components/menu/__tests__/head-menu.test.tsx --max-warnings 0`
- `git diff --check`