### PR TITLE
fix(checkbox): guard missing input keyboard events

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -51,6 +51,15 @@ describe('Checkbox', () => {
       const input = wrapper.find('.t-checkbox input');
       expect(input.element.getAttribute('name')).toBe('name');
     });
+
+    it('does not throw when keyboard interaction happens before lazy content mounts', async () => {
+      const wrapper = mount(() => <Checkbox lazyLoad label="label" />);
+      const label = wrapper.get('label');
+      const input = label.element.querySelector('input');
+      input?.remove();
+
+      await expect(label.trigger('keydown', { key: 'Enter' })).resolves.toBeUndefined();
+    });
   });
   describe(': events', () => {
     it(':onChange', async () => {

--- a/packages/components/checkbox/hooks/useKeyboardEvent.ts
+++ b/packages/components/checkbox/hooks/useKeyboardEvent.ts
@@ -5,8 +5,10 @@ export function useKeyboardEvent(handleChange: (e: Event) => void) {
     const isCheckedCode = CHECKED_CODE_REG.test(e.key) || CHECKED_CODE_REG.test(e.code);
     if (isCheckedCode) {
       e.preventDefault();
-      const { disabled } = (e.currentTarget as HTMLElement).querySelector('input');
-      !disabled && handleChange(e);
+      const input = (e.currentTarget as HTMLElement).querySelector('input');
+      if (input && !input.disabled) {
+        handleChange(e);
+      }
     }
   };
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

Fixes #6854

### 💡 需求背景和解决方案

A lazy-loaded Checkbox can receive keyboard events while its native input is not mounted. The keyboard handler previously destructured the result of `querySelector('input')`, causing a TypeError.

The handler now checks that the input exists and is enabled before calling the shared change handler. A regression test covers keyboard interaction during the hidden lazy-load stage.

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit checkbox` (19 passed)
- `pnpm exec eslint packages/components/checkbox/hooks/useKeyboardEvent.ts packages/components/checkbox/__tests__/checkbox.test.tsx --max-warnings 0`
- `git diff --check`