### PR TITLE
fix(checkbox): clean up lazy load observers

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import Checkbox, { CheckboxGroup } from '@tdesign/components/checkbox';
 
 describe('Checkbox', () => {
@@ -50,6 +50,35 @@ describe('Checkbox', () => {
       const wrapper = mount(() => <Checkbox name="name" />);
       const input = wrapper.find('.t-checkbox input');
       expect(input.element.getAttribute('name')).toBe('name');
+    });
+
+    it('cleans up lazy-load observers and shows content when disabled', async () => {
+      const unobserve = vi.fn();
+      const observe = vi.fn();
+      const originalIntersectionObserver = window.IntersectionObserver;
+      window.IntersectionObserver = class {
+        observe = observe;
+        unobserve = unobserve;
+      } as unknown as typeof IntersectionObserver;
+      const wrapper = mount(Checkbox, { props: { lazyLoad: true, label: 'label' } });
+      await nextTick();
+
+      expect(wrapper.find('input').exists()).toBe(false);
+      await wrapper.setProps({ lazyLoad: false });
+
+      expect(unobserve).toHaveBeenCalled();
+      expect(wrapper.find('input').exists()).toBe(true);
+      wrapper.unmount();
+      window.IntersectionObserver = originalIntersectionObserver;
+    });
+
+    it('unmounts safely without IntersectionObserver', () => {
+      const originalIntersectionObserver = window.IntersectionObserver;
+      window.IntersectionObserver = undefined;
+      const wrapper = mount(Checkbox, { props: { lazyLoad: true, label: 'label' } });
+
+      expect(() => wrapper.unmount()).not.toThrow();
+      window.IntersectionObserver = originalIntersectionObserver;
     });
   });
   describe(': events', () => {

--- a/packages/components/checkbox/hooks/useCheckboxLazyLoad.ts
+++ b/packages/components/checkbox/hooks/useCheckboxLazyLoad.ts
@@ -4,8 +4,18 @@ import observe from '@tdesign/common-js/utils/observe';
 export function useCheckboxLazyLoad(labelRef: Ref<HTMLElement>, lazyLoad: Ref<boolean>) {
   const ioObserver = ref<IntersectionObserver>();
   const showCheckbox = ref(true);
+  const clearObserver = () => {
+    if (ioObserver.value && labelRef.value) {
+      ioObserver.value.unobserve(labelRef.value);
+    }
+    ioObserver.value = undefined;
+  };
   const handleLazyLoad = () => {
-    if (!lazyLoad.value) return;
+    clearObserver();
+    if (!lazyLoad.value) {
+      showCheckbox.value = true;
+      return;
+    }
     showCheckbox.value = false;
     const io = observe(
       labelRef.value,
@@ -22,10 +32,7 @@ export function useCheckboxLazyLoad(labelRef: Ref<HTMLElement>, lazyLoad: Ref<bo
 
   watch([lazyLoad, labelRef], handleLazyLoad);
 
-  onBeforeUnmount(() => {
-    if (!lazyLoad.value) return;
-    ioObserver.value.unobserve(labelRef.value);
-  });
+  onBeforeUnmount(clearObserver);
 
   return {
     showCheckbox,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

Fixes #6853

### 💡 需求背景和解决方案

Checkbox lazy loading assumed `observe()` always returned an observer and based unmount cleanup on the current `lazyLoad` prop. This could dereference `null`, leave content hidden after disabling lazy loading, or leak an existing observer.

The hook now clears an existing observer before state changes, immediately reveals content when lazy loading is disabled, and performs unmount cleanup based on observer existence. Tests cover runtime disabling and environments without IntersectionObserver.

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit checkbox` (20 passed)
- `pnpm exec eslint packages/components/checkbox/hooks/useCheckboxLazyLoad.ts packages/components/checkbox/__tests__/checkbox.test.tsx --max-warnings 0`
- `git diff --check`