### PR TITLE
fix(checkbox): enforce group max boundary

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -146,6 +146,17 @@ describe('CheckboxGroup', () => {
       expect(checkboxs[0].classes()).toContain('t-is-checked');
       expect(checkboxs[1].classes()).not.toContain('t-is-checked');
     });
+
+    it('disables unchecked options when a controlled value already exceeds max', async () => {
+      const wrapper = mount(CheckboxGroup, {
+        props: { value: ['a', 'b'], max: 1, options: ['a', 'b', 'c'] },
+      });
+
+      expect(wrapper.findAll('.t-checkbox')[2].classes()).toContain('t-is-disabled');
+      await wrapper.findAll('input')[2].trigger('change');
+
+      expect(wrapper.emitted('update:value')).toBeUndefined();
+    });
   });
 
   describe(':events', () => {
@@ -161,6 +172,63 @@ describe('CheckboxGroup', () => {
       const checkboxs = wrapper.findAll('.t-checkbox input');
       await checkboxs[0].trigger('change');
       expect(checked.value).toEqual(['1', '2']);
+    });
+
+    it(':checkAll respects max', async () => {
+      const checked = ref([]);
+      const wrapper = mount(() => (
+        <CheckboxGroup
+          v-model={checked.value}
+          max={1}
+          options={[
+            { label: '全选', checkAll: true },
+            { label: '选项一', value: '1' },
+            { label: '选项二', value: '2' },
+          ]}
+        />
+      ));
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(checked.value).toEqual(['1']);
+    });
+
+    it(':checkAll selects nothing when max is zero', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(CheckboxGroup, {
+        props: {
+          max: 0,
+          onChange,
+          options: [
+            { label: '全选', checkAll: true },
+            { label: '选项一', value: '1' },
+          ],
+        },
+      });
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(onChange).toHaveBeenCalledWith([], expect.objectContaining({ type: 'check' }));
+    });
+
+    it(':checkAll preserves selected disabled options within max', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(CheckboxGroup, {
+        props: {
+          defaultValue: ['disabled'],
+          max: 1,
+          onChange,
+          options: [
+            { label: '全选', checkAll: true },
+            { label: '普通选项', value: 'enabled' },
+            { label: '禁用选项', value: 'disabled', disabled: true },
+          ],
+        },
+      });
+
+      await wrapper.findAll('input')[0].trigger('change');
+
+      expect(onChange).toHaveBeenCalledWith(['disabled'], expect.objectContaining({ type: 'check' }));
     });
 
     it(':onChange', async () => {

--- a/packages/components/checkbox/group.tsx
+++ b/packages/components/checkbox/group.tsx
@@ -51,7 +51,7 @@ export default defineComponent({
       () => !isCheckAll.value && intersectionLen.value < optionList.value.length && intersectionLen.value !== 0,
     );
 
-    const maxExceeded = computed<boolean>(() => !isUndefined(props.max) && innerValue.value.length === props.max);
+    const maxExceeded = computed<boolean>(() => !isUndefined(props.max) && innerValue.value.length >= props.max);
 
     watchEffect(() => {
       if (!props.options) return [];
@@ -63,31 +63,34 @@ export default defineComponent({
     /**
      * 获取所有复选框的值。
      * 此函数遍历 `optionList` 中的项，忽略被标记为 `checkAll`、`disabled` 或 `readonly` 的项，
-     * 并收集非这些状态的项的值到一个 Set 集合中。如果达到最大限制 `maxExceeded`，则停止遍历。
+     * 并收集非这些状态的项的值到一个 Set 集合中。收集结果不会超过 `max` 限制。
      *
      */
     const getAllCheckboxValue = () => {
       const checkAllVal = new Set<TdCheckboxProps['value']>();
       const uncheckAllVal = new Set<TdCheckboxProps['value']>();
+      const immutableValues = new Set(
+        optionList.value
+          .filter((item) => (item.disabled || item.readonly) && innerValue.value.includes(item.value))
+          .map((item) => item.value),
+      );
+      let availableCount = isUndefined(props.max) ? Infinity : Math.max(props.max - immutableValues.size, 0);
       // 遍历选项列表，忽略特定状态的项，并收集有效值
       for (let i = 0, len = optionList.value.length; i < len; i++) {
         const item = optionList.value[i];
 
         // 如果项被标记为检查所有、禁用或只读，且未选中，则跳过当前循环迭代
         if (item.checkAll) continue;
-        if (item.disabled) {
+        if (item.disabled || item.readonly) {
           if (!innerValue.value.includes(item.value)) continue;
-          else uncheckAllVal.add(item.value); // 添加禁用状态项的值到集合中
-        }
-        if (item.readonly) {
-          if (!innerValue.value.includes(item.value)) continue;
-          else uncheckAllVal.add(item.value); // 添加禁用状态项的值到集合中
+          uncheckAllVal.add(item.value); // 取消全选时保留不可变选项
+          checkAllVal.add(item.value);
+          continue;
         }
 
-        checkAllVal.add(item.value); // 添加非排除状态项的值到集合中
-
-        // 如果已达到最大限制，则终止循环
-        if (maxExceeded.value) break;
+        if (availableCount <= 0) continue;
+        if (!checkAllVal.has(item.value)) availableCount -= 1;
+        checkAllVal.add(item.value); // 添加未超过最大限制的选项
       }
 
       return { checkAllVal: [...checkAllVal], uncheckAllVal: [...uncheckAllVal] }; // 从 Set 集合转换为数组并返回


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

- Fixes #6852

### 💡 需求背景和解决方案

CheckboxGroup previously treated the limit as reached only when the current value length exactly equaled `max`. A controlled value already above the limit could therefore grow further, while check-all evaluated the stale group state and could select too many options.

This change treats `max` as an upper boundary, limits check-all as values are collected, handles `max={0}`, and preserves already-selected disabled or readonly values while applying the remaining allowance to mutable options.

Regression tests cover controlled values above max, check-all with max 1 and 0, and selected disabled values.

Validation:

- Checkbox tests: 22 passed
- Full unit suite: 153 files, 3559 passed, 2 skipped, 3 todo
- Targeted ESLint
- `git diff --check`

### 📝 更新日志

#### tdesign-vue-next

- fix(Checkbox): 修复 CheckboxGroup 的 max 限制可被受控值和全选绕过的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供