### PR TITLE
fix(checkbox): preserve falsy native values

### DIFF
--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -51,6 +51,16 @@ describe('Checkbox', () => {
       const input = wrapper.find('.t-checkbox input');
       expect(input.element.getAttribute('name')).toBe('name');
     });
+
+    it.each([
+      [0, '0'],
+      [false, 'false'],
+      ['', ''],
+    ] as const)('passes falsy value %j to the native input', (value, expected) => {
+      const wrapper = mount(Checkbox, { props: { value } });
+
+      expect(wrapper.get('input').attributes('value')).toBe(expected);
+    });
   });
   describe(': events', () => {
     it(':onChange', async () => {

--- a/packages/components/checkbox/checkbox.tsx
+++ b/packages/components/checkbox/checkbox.tsx
@@ -165,7 +165,7 @@ export default defineComponent({
                   readonly={isReadonly.value}
                   indeterminate={tIndeterminate.value}
                   name={tName.value}
-                  value={props.value ? props.value : undefined}
+                  value={props.value}
                   checked={tChecked.value}
                   onChange={handleChange}
                   onClick={(e: MouseEvent) => e.stopPropagation()}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

- Fixes #6851

### 💡 需求背景和解决方案

Checkbox used a truthy check before passing `value` to its native input. Valid documented values such as `0`, `false`, and the empty string were therefore omitted, which changed native form and `event.target.value` behavior.

This change passes the prop directly so Vue omits only `undefined`, with regression coverage for all three falsy values.

Validation:

- Checkbox tests: 21 passed
- Targeted ESLint
- `git diff --check`

### 📝 更新日志

#### tdesign-vue-next

- fix(Checkbox): 修复 falsy value 未透传到原生 input 的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供