### PR TITLE
fix(switch): add keyboard accessibility

### DIFF
--- a/packages/components/switch/__tests__/__snapshots__/switch.test.tsx.snap
+++ b/packages/components/switch/__tests__/__snapshots__/switch.test.tsx.snap
@@ -2,7 +2,10 @@
 
 exports[`Switch > :props > :customValue 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -19,7 +22,10 @@ exports[`Switch > :props > :customValue 1`] = `
 
 exports[`Switch > :props > :defaultValue 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -36,7 +42,10 @@ exports[`Switch > :props > :defaultValue 1`] = `
 
 exports[`Switch > :props > :disabled 1`] = `
 <div
+  aria-checked="false"
+  aria-disabled="true"
   class="t-switch t-size-m t-is-disabled"
+  role="switch"
 >
   <span
     class="t-switch__handle t-is-disabled"
@@ -53,7 +62,10 @@ exports[`Switch > :props > :disabled 1`] = `
 
 exports[`Switch > :props > :label 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -70,7 +82,11 @@ exports[`Switch > :props > :label 1`] = `
 
 exports[`Switch > :props > :loading 1`] = `
 <div
+  aria-busy="true"
+  aria-checked="false"
+  aria-disabled="true"
   class="t-switch t-size-m t-is-loading"
+  role="switch"
 >
   <span
     class="t-switch__handle t-is-loading"
@@ -110,7 +126,10 @@ exports[`Switch > :props > :loading 1`] = `
 
 exports[`Switch > :props > :modelValue 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -127,7 +146,10 @@ exports[`Switch > :props > :modelValue 1`] = `
 
 exports[`Switch > :props > :onChange 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -144,7 +166,10 @@ exports[`Switch > :props > :onChange 1`] = `
 
 exports[`Switch > :props > :size 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-s"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -161,7 +186,10 @@ exports[`Switch > :props > :size 1`] = `
 
 exports[`Switch > :props > :value 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -178,7 +206,10 @@ exports[`Switch > :props > :value 1`] = `
 
 exports[`Switch > <slot> > <label> 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"
@@ -197,7 +228,10 @@ exports[`Switch > <slot> > <label> 1`] = `
 
 exports[`Switch > @event > Event passthrough: change 1`] = `
 <div
+  aria-checked="false"
   class="t-switch t-size-m"
+  role="switch"
+  tabindex="0"
 >
   <span
     class="t-switch__handle"

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -85,6 +85,31 @@ describe('Switch', () => {
       });
       expect(wrapper.element).toMatchSnapshot();
     });
+
+    it('exposes switch semantics and updates aria-checked', async () => {
+      const wrapper = mount(Switch, { props: { defaultValue: false } });
+      const root = wrapper.get('.t-switch');
+
+      expect(root.attributes()).toMatchObject({ role: 'switch', 'aria-checked': 'false', tabindex: '0' });
+
+      await root.trigger('click');
+
+      expect(root.attributes('aria-checked')).toBe('true');
+    });
+
+    it('exposes disabled and loading states to assistive technology', () => {
+      const disabled = mount(Switch, { props: { disabled: true } });
+      const loading = mount(Switch, { props: { loading: true } });
+
+      expect(disabled.get('.t-switch').attributes('aria-disabled')).toBe('true');
+      expect(disabled.get('.t-switch').attributes('aria-busy')).toBeUndefined();
+      expect(disabled.get('.t-switch').attributes('tabindex')).toBeUndefined();
+      expect(loading.get('.t-switch').attributes()).toMatchObject({
+        'aria-disabled': 'true',
+        'aria-busy': 'true',
+      });
+      expect(loading.get('.t-switch').attributes('tabindex')).toBeUndefined();
+    });
   });
 
   describe('@event', () => {
@@ -98,6 +123,44 @@ describe('Switch', () => {
       expect(wrapper.element).toMatchSnapshot();
       wrapper.find('.t-switch').trigger('click');
       expect(fn).toHaveBeenCalled();
+    });
+
+    it.each([' ', 'Enter'])('toggles with the %j key', async (key) => {
+      const beforeChange = vi.fn(() => true);
+      const onChange = vi.fn();
+      const wrapper = mount(Switch, { props: { beforeChange, defaultValue: false, onChange } });
+      const root = wrapper.get('.t-switch');
+
+      await root.trigger('keydown', { key });
+      await Promise.resolve();
+
+      expect(beforeChange).toHaveBeenCalledOnce();
+      expect(onChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
+      expect(root.attributes('aria-checked')).toBe('true');
+    });
+
+    it('prevents Space scrolling and ignores unrelated keys', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(Switch, { props: { onChange } });
+      const root = wrapper.get('.t-switch');
+      const spaceEvent = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+
+      root.element.dispatchEvent(spaceEvent);
+      await root.trigger('keydown', { key: 'ArrowRight' });
+
+      expect(spaceEvent.defaultPrevented).toBe(true);
+      expect(onChange).toHaveBeenCalledOnce();
+    });
+
+    it.each([{ disabled: true }, { loading: true }])('blocks keyboard toggles with %o', async (props) => {
+      const beforeChange = vi.fn(() => true);
+      const onChange = vi.fn();
+      const wrapper = mount(Switch, { props: { ...props, beforeChange, onChange } });
+
+      await wrapper.get('.t-switch').trigger('keydown', { key: ' ' });
+
+      expect(beforeChange).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/components/switch/switch.tsx
+++ b/packages/components/switch/switch.tsx
@@ -58,6 +58,14 @@ export default defineComponent({
         });
     }
 
+    function handleKeydown(e: KeyboardEvent) {
+      if (e.key !== ' ' && e.key !== 'Enter') return;
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).click();
+    }
+
+    const isChecked = computed(() => innerValue.value === activeValue.value || props.modelValue === activeValue.value);
+
     // classes
     const classes = computed(() => [
       `${COMPONENT_NAME.value}`,
@@ -65,7 +73,7 @@ export default defineComponent({
       {
         [STATUS.value.disabled]: disabled.value,
         [STATUS.value.loading]: props.loading,
-        [STATUS.value.checked]: innerValue.value === activeValue.value || props.modelValue === activeValue.value,
+        [STATUS.value.checked]: isChecked.value,
       },
     ]);
     const nodeClasses = computed(() => {
@@ -131,7 +139,16 @@ export default defineComponent({
       }
 
       return (
-        <div class={classes.value} onClick={toggle}>
+        <div
+          class={classes.value}
+          role="switch"
+          aria-checked={isChecked.value}
+          aria-disabled={disabled.value || props.loading || undefined}
+          aria-busy={props.loading || undefined}
+          tabindex={disabled.value || props.loading ? undefined : '0'}
+          onClick={toggle}
+          onKeydown={handleKeydown}
+        >
           <span class={nodeClasses.value}>{loadingContent}</span>
           <div class={contentClasses.value}>{switchContent}</div>
         </div>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 组件样式/交互改进
- [x] 测试用例

### 🔗 相关 Issue

- Fixes #6849

### 💡 需求背景和解决方案

Switch previously rendered as a click-only div without switch semantics, focusability, state announcements, or keyboard activation.

This change adds `role="switch"`, live `aria-checked`, disabled/loading ARIA state, and keyboard focus management. Space and Enter activate the existing click/toggle path, so disabled, loading, and `beforeChange` behavior remains shared. Space also prevents page scrolling.

Validation:

- Switch tests: 38 passed across 3 files
- 11 snapshots updated for the accessibility attributes
- Targeted ESLint
- `git diff --check`

### 📝 更新日志

#### tdesign-vue-next

- fix(Switch): 补充开关语义、状态属性和键盘操作支持

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供