### PR TITLE
fix(textarea): align native input behavior

### DIFF
--- a/packages/components/textarea/__tests__/textarea.test.tsx
+++ b/packages/components/textarea/__tests__/textarea.test.tsx
@@ -107,6 +107,61 @@ describe('Textarea', () => {
       value.value = '123456';
       expect(textarea.element.value).toBe('12345');
     });
+
+    it('reconciles controlled maxcharacter input without readonly warnings', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const wrapper = mount(Textarea, { props: { value: '', maxcharacter: 4 } });
+      const textarea = wrapper.get('textarea');
+
+      await textarea.setValue('你好a');
+
+      expect(textarea.element.value).toBe('你好');
+      expect(wrapper.emitted('update:value')).toEqual([['你好']]);
+      expect(warnSpy.mock.calls.flat().join(' ')).not.toContain(
+        'Set operation on key "value" failed: target is readonly',
+      );
+    });
+
+    it('forwards rows and string styles to the native textarea', async () => {
+      const wrapper = mount(Textarea, {
+        attrs: { rows: 4, style: 'height: 80px; color: red;' },
+      });
+      const textarea = wrapper.get('textarea');
+      await nextTick();
+
+      expect(wrapper.attributes('rows')).toBeUndefined();
+      expect(wrapper.attributes('style')).toBeUndefined();
+      expect(textarea.attributes('rows')).toBe('4');
+      expect(textarea.element.style.height).toBe('80px');
+      expect(textarea.element.style.color).toBe('red');
+    });
+
+    it('clears calculated height when autosize is disabled', async () => {
+      const wrapper = mount(Textarea, { props: { autosize: true, defaultValue: 'content' } });
+      const textarea = wrapper.get('textarea');
+      await nextTick();
+      await nextTick();
+
+      expect(textarea.element.style.height).not.toBe('');
+
+      await wrapper.setProps({ autosize: false });
+      await nextTick();
+
+      expect(textarea.classes()).not.toContain('t-hide-scrollbar');
+      expect(textarea.element.style.height).toBe('');
+      expect(textarea.element.style.minHeight).toBe('');
+    });
+
+    it('uses Unicode length for the maxlength counter', async () => {
+      const onValidate = vi.fn();
+      const wrapper = mount(Textarea, {
+        props: { value: '😊', maxlength: 1, allowInputOverMax: true, onValidate },
+      });
+      await nextTick();
+
+      expect(wrapper.get('.t-textarea__limit').text()).toBe('1/1');
+      expect(onValidate).not.toHaveBeenCalled();
+    });
   });
 
   describe(':events', () => {

--- a/packages/components/textarea/textarea.tsx
+++ b/packages/components/textarea/textarea.tsx
@@ -10,11 +10,10 @@ import {
   StyleValue,
   CSSProperties,
 } from 'vue';
-import { isObject, merge, omit } from 'lodash-es';
+import { omit } from 'lodash-es';
 
 import { FormItemInjectionKey } from '../form/constants';
-import setStyle from '@tdesign/common-js/utils/setStyle';
-import { getCharacterLength, getValidAttrs } from '@tdesign/common-js/utils/helper';
+import { getCharacterLength, getUnicodeLength, getValidAttrs } from '@tdesign/common-js/utils/helper';
 
 // hooks
 import {
@@ -60,17 +59,17 @@ export default defineComponent({
     const adjustTextareaHeight = () => {
       if (props.autosize === true) {
         nextTick(() => {
+          if (props.autosize !== true) return;
           textareaStyle.value = calcTextareaHeight(refTextareaElem.value);
         });
       } else if (props.autosize && typeof props.autosize === 'object') {
         const { minRows, maxRows } = props.autosize;
         nextTick(() => {
+          if (!props.autosize || typeof props.autosize !== 'object') return;
           textareaStyle.value = calcTextareaHeight(refTextareaElem.value, minRows, maxRows);
         });
-      } else if (attrs.rows) {
-        textareaStyle.value = { height: 'auto', minHeight: 'auto' };
-      } else if (attrs.style && (attrs.style as CSSProperties)?.height) {
-        textareaStyle.value = { height: (attrs.style as CSSProperties)?.height };
+      } else {
+        textareaStyle.value = {};
       }
     };
 
@@ -83,7 +82,6 @@ export default defineComponent({
 
       if (textareaElem.value !== sV) {
         textareaElem.value = sV;
-        innerValue.value = sV;
       }
     };
     const inputValueChangeHandle = (e: InputEvent) => {
@@ -164,7 +162,7 @@ export default defineComponent({
       });
     });
     const characterNumber = computed(() => {
-      const characterInfo = getCharacterLength(String(innerValue.value || ''));
+      const characterInfo = getCharacterLength(String(innerValue.value ?? ''));
       if (typeof characterInfo === 'object') {
         // @ts-ignore
         // TODO: 这里的写法本身就有问题，因为 getCharacterLength(String(innerValue.value || '')) 一定会返回 number，所以这个分支肯定是进不了的，除非 getCharacterLength 写得有问题
@@ -194,15 +192,6 @@ export default defineComponent({
       adjustTextareaHeight();
       if (props.autofocus) {
         el.focus();
-      }
-    });
-
-    watch(textareaStyle, (val) => {
-      const { style } = attrs as { style: StyleValue };
-      if (isObject(style)) {
-        setStyle(refTextareaElem.value, merge(style, val) as Record<string, any>);
-      } else {
-        setStyle(refTextareaElem.value, val);
       }
     });
 
@@ -249,13 +238,13 @@ export default defineComponent({
           <span class={TEXTAREA_LIMIT.value}>{`${characterNumber.value}/${props.maxcharacter}`}</span>
         )) ||
         (!props.maxcharacter && props.maxlength && (
-          <span class={TEXTAREA_LIMIT.value}>{`${innerValue.value ? String(innerValue.value)?.length : 0}/${
+          <span class={TEXTAREA_LIMIT.value}>{`${getUnicodeLength(String(innerValue.value ?? ''))}/${
             props.maxlength
           }`}</span>
         ));
 
       return (
-        <div class={textareaClasses.value} {...omit(attrs, ['style'])}>
+        <div class={textareaClasses.value} {...omit(attrs, ['style', 'rows'])}>
           <textarea
             onInput={handleInput}
             onCompositionstart={onCompositionstart}
@@ -263,6 +252,8 @@ export default defineComponent({
             ref={refTextareaElem}
             value={innerValue.value}
             class={classes.value}
+            rows={attrs.rows as string | number}
+            style={[attrs.style as StyleValue, textareaStyle.value]}
             {...inputEvents}
             {...inputAttrs.value}
           ></textarea>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 测试用例

### 🔗 相关 Issue

- Fixes #6846

### 💡 需求背景和解决方案

This PR fixes the five Textarea inconsistencies reported in #6846:

1. Controlled maxcharacter reconciliation now updates only the native DOM value and no longer writes to a readonly prop-backed ref.
2. `rows` is forwarded to the native textarea instead of the wrapper.
3. Both string and object `style` values are applied to the native textarea through Vue style merging.
4. Disabling autosize clears its calculated height/min-height layer and guards against stale queued calculations.
5. The maxlength counter uses Unicode character length, matching validation for emoji and other surrogate pairs.

Regression tests cover each behavior, including the absence of the readonly warning and preservation of explicit user height styles.

Validation:

- Textarea tests: 21 passed
- Repository TypeScript check: passed
- Targeted ESLint
- `git diff --check`

### 📝 更新日志

#### tdesign-vue-next

- fix(Textarea): 修复受控限长、原生属性、autosize 与字符计数不一致的问题

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供