### PR TITLE
fix(Icon): fix multiple alpha color overlap

### DIFF
--- a/internal/utils/src/catalogs.ts
+++ b/internal/utils/src/catalogs.ts
@@ -90,7 +90,7 @@ export const catalogs = {
   tdesign: {
     '@tdesign/site-components': '^0.19.2',
     '@tdesign/theme-generator': '^1.2.4',
-    'tdesign-icons-vue-next': '~0.4.7',
+    'tdesign-icons-vue-next': '^0.4.8',
     'tdesign-publish-cli': '^0.0.12',
   },
   test: {

--- a/internal/utils/src/catalogs.ts
+++ b/internal/utils/src/catalogs.ts
@@ -90,7 +90,7 @@ export const catalogs = {
   tdesign: {
     '@tdesign/site-components': '^0.19.2',
     '@tdesign/theme-generator': '^1.2.4',
-    'tdesign-icons-vue-next': '^0.4.8',
+    'tdesign-icons-vue-next': 'https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b',
     'tdesign-publish-cli': '^0.0.12',
   },
   test: {

--- a/internal/utils/src/catalogs.ts
+++ b/internal/utils/src/catalogs.ts
@@ -90,7 +90,7 @@ export const catalogs = {
   tdesign: {
     '@tdesign/site-components': '^0.19.2',
     '@tdesign/theme-generator': '^1.2.4',
-    'tdesign-icons-vue-next': 'https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b',
+    'tdesign-icons-vue-next': '^0.4.9',
     'tdesign-publish-cli': '^0.0.12',
   },
   test: {

--- a/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Avatar > props > :content[string/function] 2`] = `
               <defs>
                 <mask
                   height="24"
-                  id="t-icon-overlap-15-0"
+                  id="t-icon-image-instance-v0-overlap-fill1"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -107,7 +107,7 @@ exports[`Avatar > props > :content[string/function] 2`] = `
                 </mask>
                 <mask
                   height="24"
-                  id="t-icon-overlap-15-1"
+                  id="t-icon-image-instance-v0-overlap-fill2"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -145,14 +145,14 @@ exports[`Avatar > props > :content[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
-                  mask="url(#t-icon-overlap-15-0)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
-                  mask="url(#t-icon-overlap-15-1)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                   r="2"
                 />
                 <path
@@ -260,7 +260,7 @@ exports[`Avatar > props > :default[string/function] 2`] = `
               <defs>
                 <mask
                   height="24"
-                  id="t-icon-overlap-28-0"
+                  id="t-icon-image-instance-v0-overlap-fill1"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -299,7 +299,7 @@ exports[`Avatar > props > :default[string/function] 2`] = `
                 </mask>
                 <mask
                   height="24"
-                  id="t-icon-overlap-28-1"
+                  id="t-icon-image-instance-v0-overlap-fill2"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -337,14 +337,14 @@ exports[`Avatar > props > :default[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
-                  mask="url(#t-icon-overlap-28-0)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
-                  mask="url(#t-icon-overlap-28-1)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                   r="2"
                 />
                 <path
@@ -482,7 +482,7 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
               <defs>
                 <mask
                   height="24"
-                  id="t-icon-overlap-135-0"
+                  id="t-icon-image-instance-v0-overlap-fill1"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -521,7 +521,7 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
                 </mask>
                 <mask
                   height="24"
-                  id="t-icon-overlap-135-1"
+                  id="t-icon-image-instance-v0-overlap-fill2"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -559,14 +559,14 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
-                  mask="url(#t-icon-overlap-135-0)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
-                  mask="url(#t-icon-overlap-135-1)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                   r="2"
                 />
                 <path
@@ -680,7 +680,7 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
               <defs>
                 <mask
                   height="24"
-                  id="t-icon-overlap-116-0"
+                  id="t-icon-image-instance-v0-overlap-fill1"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -719,7 +719,7 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
                 </mask>
                 <mask
                   height="24"
-                  id="t-icon-overlap-116-1"
+                  id="t-icon-image-instance-v0-overlap-fill2"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -757,14 +757,14 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
-                  mask="url(#t-icon-overlap-116-0)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
-                  mask="url(#t-icon-overlap-116-1)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                   r="2"
                 />
                 <path
@@ -872,7 +872,7 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
               <defs>
                 <mask
                   height="24"
-                  id="t-icon-overlap-125-0"
+                  id="t-icon-image-instance-v0-overlap-fill1"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -911,7 +911,7 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
                 </mask>
                 <mask
                   height="24"
-                  id="t-icon-overlap-125-1"
+                  id="t-icon-image-instance-v0-overlap-fill2"
                   mask-type="luminance"
                   maskContentUnits="userSpaceOnUse"
                   maskUnits="userSpaceOnUse"
@@ -949,14 +949,14 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
-                  mask="url(#t-icon-overlap-125-0)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
-                  mask="url(#t-icon-overlap-125-1)"
+                  mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                   r="2"
                 />
                 <path

--- a/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -65,6 +65,79 @@ exports[`Avatar > props > :content[string/function] 2`] = `
               viewBox="0 0 24 24"
               width="1em"
             >
+              <defs>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-15-0"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="#000"
+                    r="2"
+                    stroke="none"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-15-1"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+              </defs>
               <g
                 id="image"
               >
@@ -72,12 +145,14 @@ exports[`Avatar > props > :content[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
+                  mask="url(#t-icon-overlap-15-0)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
+                  mask="url(#t-icon-overlap-15-1)"
                   r="2"
                 />
                 <path
@@ -182,6 +257,79 @@ exports[`Avatar > props > :default[string/function] 2`] = `
               viewBox="0 0 24 24"
               width="1em"
             >
+              <defs>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-28-0"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="#000"
+                    r="2"
+                    stroke="none"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-28-1"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+              </defs>
               <g
                 id="image"
               >
@@ -189,12 +337,14 @@ exports[`Avatar > props > :default[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
+                  mask="url(#t-icon-overlap-28-0)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
+                  mask="url(#t-icon-overlap-28-1)"
                   r="2"
                 />
                 <path
@@ -329,6 +479,79 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
               viewBox="0 0 24 24"
               width="1em"
             >
+              <defs>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-135-0"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="#000"
+                    r="2"
+                    stroke="none"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-135-1"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+              </defs>
               <g
                 id="image"
               >
@@ -336,12 +559,14 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
+                  mask="url(#t-icon-overlap-135-0)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
+                  mask="url(#t-icon-overlap-135-1)"
                   r="2"
                 />
                 <path
@@ -452,6 +677,79 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
               viewBox="0 0 24 24"
               width="1em"
             >
+              <defs>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-116-0"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="#000"
+                    r="2"
+                    stroke="none"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-116-1"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+              </defs>
               <g
                 id="image"
               >
@@ -459,12 +757,14 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
+                  mask="url(#t-icon-overlap-116-0)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
+                  mask="url(#t-icon-overlap-116-1)"
                   r="2"
                 />
                 <path
@@ -569,6 +869,79 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
               viewBox="0 0 24 24"
               width="1em"
             >
+              <defs>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-125-0"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="#000"
+                    r="2"
+                    stroke="none"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+                <mask
+                  height="24"
+                  id="t-icon-overlap-125-1"
+                  mask-type="luminance"
+                  maskContentUnits="userSpaceOnUse"
+                  maskUnits="userSpaceOnUse"
+                  width="24"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#fff"
+                    height="24"
+                    width="24"
+                    x="0"
+                    y="0"
+                  />
+                  <path
+                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                    fill="none"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                  <circle
+                    cx="15.75"
+                    cy="8.25"
+                    fill="none"
+                    r="2"
+                    stroke="#000"
+                    stroke-width="2"
+                  />
+                </mask>
+              </defs>
               <g
                 id="image"
               >
@@ -576,12 +949,14 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
                   d="M3 21H20L9 10L3 16V21Z"
                   fill="transparent"
                   id="fill1"
+                  mask="url(#t-icon-overlap-125-0)"
                 />
                 <circle
                   cx="15.75"
                   cy="8.25"
                   fill="transparent"
                   id="fill2"
+                  mask="url(#t-icon-overlap-125-1)"
                   r="2"
                 />
                 <path

--- a/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
+++ b/packages/components/avatar/__tests__/__snapshots__/avatar.test.tsx.snap
@@ -83,24 +83,9 @@ exports[`Avatar > props > :content[string/function] 2`] = `
                     x="0"
                     y="0"
                   />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="#000"
-                    r="2"
-                    stroke="none"
-                  />
                   <path
                     d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                     fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="none"
-                    r="2"
                     stroke="#000"
                     stroke-width="2"
                   />
@@ -121,12 +106,6 @@ exports[`Avatar > props > :content[string/function] 2`] = `
                     width="24"
                     x="0"
                     y="0"
-                  />
-                  <path
-                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
                   />
                   <circle
                     cx="15.75"
@@ -275,24 +254,9 @@ exports[`Avatar > props > :default[string/function] 2`] = `
                     x="0"
                     y="0"
                   />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="#000"
-                    r="2"
-                    stroke="none"
-                  />
                   <path
                     d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                     fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="none"
-                    r="2"
                     stroke="#000"
                     stroke-width="2"
                   />
@@ -313,12 +277,6 @@ exports[`Avatar > props > :default[string/function] 2`] = `
                     width="24"
                     x="0"
                     y="0"
-                  />
-                  <path
-                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
                   />
                   <circle
                     cx="15.75"
@@ -497,24 +455,9 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
                     x="0"
                     y="0"
                   />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="#000"
-                    r="2"
-                    stroke="none"
-                  />
                   <path
                     d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                     fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="none"
-                    r="2"
                     stroke="#000"
                     stroke-width="2"
                   />
@@ -535,12 +478,6 @@ exports[`AvatarGroup > props > :collapseAvatar[slot] 1`] = `
                     width="24"
                     x="0"
                     y="0"
-                  />
-                  <path
-                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
                   />
                   <circle
                     cx="15.75"
@@ -695,24 +632,9 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
                     x="0"
                     y="0"
                   />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="#000"
-                    r="2"
-                    stroke="none"
-                  />
                   <path
                     d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                     fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="none"
-                    r="2"
                     stroke="#000"
                     stroke-width="2"
                   />
@@ -733,12 +655,6 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 1`] = `
                     width="24"
                     x="0"
                     y="0"
-                  />
-                  <path
-                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
                   />
                   <circle
                     cx="15.75"
@@ -887,24 +803,9 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
                     x="0"
                     y="0"
                   />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="#000"
-                    r="2"
-                    stroke="none"
-                  />
                   <path
                     d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                     fill="none"
-                    stroke="#000"
-                    stroke-width="2"
-                  />
-                  <circle
-                    cx="15.75"
-                    cy="8.25"
-                    fill="none"
-                    r="2"
                     stroke="#000"
                     stroke-width="2"
                   />
@@ -925,12 +826,6 @@ exports[`AvatarGroup > props > :collapseAvatar[string/function] 2`] = `
                     width="24"
                     x="0"
                     y="0"
-                  />
-                  <path
-                    d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                    fill="none"
-                    stroke="#000"
-                    stroke-width="2"
                   />
                   <circle
                     cx="15.75"

--- a/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`DatePicker > :mode 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-26-0"
+                id="t-icon-calendar-instance-v0-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -72,7 +72,7 @@ exports[`DatePicker > :mode 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-26-1"
+                id="t-icon-calendar-instance-v0-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -102,13 +102,13 @@ exports[`DatePicker > :mode 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-26-0)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill1)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-26-1)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill2)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
@@ -214,7 +214,7 @@ exports[`DatePicker > :range 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-37-0"
+                id="t-icon-calendar-instance-v0-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -243,7 +243,7 @@ exports[`DatePicker > :range 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-37-1"
+                id="t-icon-calendar-instance-v0-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -273,13 +273,13 @@ exports[`DatePicker > :range 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-37-0)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill1)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-37-1)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill2)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
@@ -343,7 +343,7 @@ exports[`DatePicker > :value 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-17-0"
+                id="t-icon-calendar-instance-v0-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -372,7 +372,7 @@ exports[`DatePicker > :value 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-17-1"
+                id="t-icon-calendar-instance-v0-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -402,13 +402,13 @@ exports[`DatePicker > :value 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-17-0)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill1)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-17-1)"
+                mask="url(#t-icon-calendar-instance-v0-overlap-fill2)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"

--- a/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -59,11 +59,6 @@ exports[`DatePicker > :mode 1`] = `
                   y="0"
                 />
                 <path
-                  d="M21 10H3V5H21V10Z"
-                  fill="#000"
-                  stroke="none"
-                />
-                <path
                   d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
                   fill="none"
                   stroke="#000"
@@ -230,11 +225,6 @@ exports[`DatePicker > :range 1`] = `
                   y="0"
                 />
                 <path
-                  d="M21 10H3V5H21V10Z"
-                  fill="#000"
-                  stroke="none"
-                />
-                <path
                   d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
                   fill="none"
                   stroke="#000"
@@ -357,11 +347,6 @@ exports[`DatePicker > :value 1`] = `
                   width="24"
                   x="0"
                   y="0"
-                />
-                <path
-                  d="M21 10H3V5H21V10Z"
-                  fill="#000"
-                  stroke="none"
                 />
                 <path
                   d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"

--- a/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/packages/components/date-picker/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -40,6 +40,61 @@ exports[`DatePicker > :mode 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-26-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M21 10H3V5H21V10Z"
+                  fill="#000"
+                  stroke="none"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-26-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               id="calendar"
             >
@@ -47,11 +102,13 @@ exports[`DatePicker > :mode 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-26-0)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-26-1)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
@@ -154,6 +211,61 @@ exports[`DatePicker > :range 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-37-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M21 10H3V5H21V10Z"
+                  fill="#000"
+                  stroke="none"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-37-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               id="calendar"
             >
@@ -161,11 +273,13 @@ exports[`DatePicker > :range 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-37-0)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-37-1)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
@@ -226,6 +340,61 @@ exports[`DatePicker > :value 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-17-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M21 10H3V5H21V10Z"
+                  fill="#000"
+                  stroke="none"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-17-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               id="calendar"
             >
@@ -233,11 +402,13 @@ exports[`DatePicker > :value 1`] = `
                 d="M21 10H3V21H21V10Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-17-0)"
               />
               <path
                 d="M21 10H3V5H21V10Z"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-17-1)"
               />
               <path
                 d="M3 10H21M3 10V5H21V10M3 10V21H21V10M7 5V1.5M17 5V1.5"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-modal-icon.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-modal-icon.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`ImageModalIcon > props > :icon[function] 1`] = `
     <defs>
       <mask
         height="24"
-        id="t-icon-overlap-2-0"
+        id="t-icon-zoom-in-instance-v0-overlap-fill1"
         mask-type="luminance"
         maskContentUnits="userSpaceOnUse"
         maskUnits="userSpaceOnUse"
@@ -53,7 +53,7 @@ exports[`ImageModalIcon > props > :icon[function] 1`] = `
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
         fill="transparent"
         id="fill1"
-        mask="url(#t-icon-overlap-2-0)"
+        mask="url(#t-icon-zoom-in-instance-v0-overlap-fill1)"
       />
       <path
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -90,7 +90,7 @@ exports[`ImageModalIcon > props > :label[string] 1`] = `
     <defs>
       <mask
         height="24"
-        id="t-icon-overlap-31-0"
+        id="t-icon-zoom-in-instance-v0-overlap-fill1"
         mask-type="luminance"
         maskContentUnits="userSpaceOnUse"
         maskUnits="userSpaceOnUse"
@@ -128,7 +128,7 @@ exports[`ImageModalIcon > props > :label[string] 1`] = `
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
         fill="transparent"
         id="fill1"
-        mask="url(#t-icon-overlap-31-0)"
+        mask="url(#t-icon-zoom-in-instance-v0-overlap-fill1)"
       />
       <path
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-modal-icon.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-modal-icon.test.tsx.snap
@@ -12,6 +12,40 @@ exports[`ImageModalIcon > props > :icon[function] 1`] = `
     viewBox="0 0 24 24"
     width="1em"
   >
+    <defs>
+      <mask
+        height="24"
+        id="t-icon-overlap-2-0"
+        mask-type="luminance"
+        maskContentUnits="userSpaceOnUse"
+        maskUnits="userSpaceOnUse"
+        width="24"
+        x="0"
+        y="0"
+      >
+        <rect
+          fill="#fff"
+          height="24"
+          width="24"
+          x="0"
+          y="0"
+        />
+        <path
+          d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+          fill="none"
+          stroke="#000"
+          stroke-linecap="square"
+          stroke-width="2"
+        />
+        <path
+          d="M10.5 13.5V10.5M10.5 10.5L10.5 7.5M10.5 10.5H7.5M10.5 10.5H13.5"
+          fill="none"
+          stroke="#000"
+          stroke-linecap="square"
+          stroke-width="2"
+        />
+      </mask>
+    </defs>
     <g
       id="zoom-in"
     >
@@ -19,6 +53,7 @@ exports[`ImageModalIcon > props > :icon[function] 1`] = `
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
         fill="transparent"
         id="fill1"
+        mask="url(#t-icon-overlap-2-0)"
       />
       <path
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -52,6 +87,40 @@ exports[`ImageModalIcon > props > :label[string] 1`] = `
     viewBox="0 0 24 24"
     width="1em"
   >
+    <defs>
+      <mask
+        height="24"
+        id="t-icon-overlap-31-0"
+        mask-type="luminance"
+        maskContentUnits="userSpaceOnUse"
+        maskUnits="userSpaceOnUse"
+        width="24"
+        x="0"
+        y="0"
+      >
+        <rect
+          fill="#fff"
+          height="24"
+          width="24"
+          x="0"
+          y="0"
+        />
+        <path
+          d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+          fill="none"
+          stroke="#000"
+          stroke-linecap="square"
+          stroke-width="2"
+        />
+        <path
+          d="M10.5 13.5V10.5M10.5 10.5L10.5 7.5M10.5 10.5H7.5M10.5 10.5H13.5"
+          fill="none"
+          stroke="#000"
+          stroke-linecap="square"
+          stroke-width="2"
+        />
+      </mask>
+    </defs>
     <g
       id="zoom-in"
     >
@@ -59,6 +128,7 @@ exports[`ImageModalIcon > props > :label[string] 1`] = `
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
         fill="transparent"
         id="fill1"
+        mask="url(#t-icon-overlap-31-0)"
       />
       <path
         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
@@ -116,30 +116,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-13-0"
-                        mask-type="luminance"
-                        maskContentUnits="userSpaceOnUse"
-                        maskUnits="userSpaceOnUse"
-                        width="24"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#fff"
-                          height="24"
-                          width="24"
-                          x="0"
-                          y="0"
-                        />
-                        <path
-                          d="M16 8.5V17.5H21L16 8.5Z"
-                          fill="#000"
-                          stroke="none"
-                        />
-                      </mask>
-                      <mask
-                        height="24"
-                        id="t-icon-overlap-13-1"
+                        id="t-icon-mirror-instance-v1-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -177,12 +154,11 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     >
                       <g
                         id="fill1"
-                        mask="url(#t-icon-overlap-13-1)"
+                        mask="url(#t-icon-mirror-instance-v1-overlap-fill1)"
                       >
                         <path
                           d="M8 8.5V17.5H3L8 8.5Z"
                           fill="transparent"
-                          mask="url(#t-icon-overlap-13-0)"
                         />
                         <path
                           d="M16 8.5V17.5H21L16 8.5Z"
@@ -254,7 +230,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-21-0"
+                        id="t-icon-zoom-out-instance-v3-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -292,7 +268,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-21-0)"
+                        mask="url(#t-icon-zoom-out-instance-v3-overlap-fill1)"
                       />
                       <path
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -336,7 +312,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-24-0"
+                        id="t-icon-zoom-in-instance-v4-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -374,7 +350,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-24-0)"
+                        mask="url(#t-icon-zoom-in-instance-v4-overlap-fill1)"
                       />
                       <path
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -412,7 +388,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                       <defs>
                         <mask
                           height="24"
-                          id="t-icon-overlap-30-0"
+                          id="t-icon-image-instance-v5-overlap-fill1"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -451,7 +427,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         </mask>
                         <mask
                           height="24"
-                          id="t-icon-overlap-30-1"
+                          id="t-icon-image-instance-v5-overlap-fill2"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -489,14 +465,14 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
-                          mask="url(#t-icon-overlap-30-0)"
+                          mask="url(#t-icon-image-instance-v5-overlap-fill1)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
-                          mask="url(#t-icon-overlap-30-1)"
+                          mask="url(#t-icon-image-instance-v5-overlap-fill2)"
                           r="2"
                         />
                         <path

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
@@ -113,15 +113,76 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-13-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M16 8.5V17.5H21L16 8.5Z"
+                          fill="#000"
+                          stroke="none"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-13-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M12 3L12 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-linecap="square"
+                          stroke-width="2"
+                        />
+                        <g>
+                          <path
+                            d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
+                            fill="none"
+                            stroke="#000"
+                            stroke-linecap="square"
+                            stroke-width="2"
+                          />
+                        </g>
+                      </mask>
+                    </defs>
                     <g
                       id="mirror"
                     >
                       <g
                         id="fill1"
+                        mask="url(#t-icon-overlap-13-1)"
                       >
                         <path
                           d="M8 8.5V17.5H3L8 8.5Z"
                           fill="transparent"
+                          mask="url(#t-icon-overlap-13-0)"
                         />
                         <path
                           d="M16 8.5V17.5H21L16 8.5Z"
@@ -139,13 +200,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         id="stroke1"
                       >
                         <path
-                          d="M8 8.5V17.5H3L8 8.5Z"
-                          stroke="currentColor"
-                          stroke-linecap="square"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M16 8.5V17.5H21L16 8.5Z"
+                          d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
                           stroke="currentColor"
                           stroke-linecap="square"
                           stroke-width="2"
@@ -196,6 +251,40 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-21-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+                          fill="none"
+                          stroke="#000"
+                          stroke-linecap="square"
+                          stroke-width="2"
+                        />
+                        <path
+                          d="M7.5 10.5H10.5L13.5 10.5"
+                          fill="none"
+                          stroke="#000"
+                          stroke-linecap="square"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="zoom-out"
                     >
@@ -203,6 +292,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-21-0)"
                       />
                       <path
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -243,6 +333,40 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-24-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+                          fill="none"
+                          stroke="#000"
+                          stroke-linecap="square"
+                          stroke-width="2"
+                        />
+                        <path
+                          d="M10.5 13.5V10.5M10.5 10.5L10.5 7.5M10.5 10.5H7.5M10.5 10.5H13.5"
+                          fill="none"
+                          stroke="#000"
+                          stroke-linecap="square"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="zoom-in"
                     >
@@ -250,6 +374,7 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-24-0)"
                       />
                       <path
                         d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -284,6 +409,79 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                       viewBox="0 0 24 24"
                       width="1em"
                     >
+                      <defs>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-30-0"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="#000"
+                            r="2"
+                            stroke="none"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-30-1"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                      </defs>
                       <g
                         id="image"
                       >
@@ -291,12 +489,14 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
+                          mask="url(#t-icon-overlap-30-0)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
+                          mask="url(#t-icon-overlap-30-1)"
                           r="2"
                         />
                         <path

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-modal.test.tsx.snap
@@ -131,13 +131,6 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                           x="0"
                           y="0"
                         />
-                        <path
-                          d="M12 3L12 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-linecap="square"
-                          stroke-width="2"
-                        />
                         <g>
                           <path
                             d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
@@ -403,24 +396,9 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                             x="0"
                             y="0"
                           />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="#000"
-                            r="2"
-                            stroke="none"
-                          />
                           <path
                             d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                             fill="none"
-                            stroke="#000"
-                            stroke-width="2"
-                          />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="none"
-                            r="2"
                             stroke="#000"
                             stroke-width="2"
                           />
@@ -441,12 +419,6 @@ exports[`ImageViewerModal > props > :visible[boolean] 1`] = `
                             width="24"
                             x="0"
                             y="0"
-                          />
-                          <path
-                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                            fill="none"
-                            stroke="#000"
-                            stroke-width="2"
                           />
                           <circle
                             cx="15.75"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
@@ -19,15 +19,76 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         viewBox="0 0 24 24"
         width="1em"
       >
+        <defs>
+          <mask
+            height="24"
+            id="t-icon-overlap-7-0"
+            mask-type="luminance"
+            maskContentUnits="userSpaceOnUse"
+            maskUnits="userSpaceOnUse"
+            width="24"
+            x="0"
+            y="0"
+          >
+            <rect
+              fill="#fff"
+              height="24"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <path
+              d="M16 8.5V17.5H21L16 8.5Z"
+              fill="#000"
+              stroke="none"
+            />
+          </mask>
+          <mask
+            height="24"
+            id="t-icon-overlap-7-1"
+            mask-type="luminance"
+            maskContentUnits="userSpaceOnUse"
+            maskUnits="userSpaceOnUse"
+            width="24"
+            x="0"
+            y="0"
+          >
+            <rect
+              fill="#fff"
+              height="24"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <path
+              d="M12 3L12 21"
+              fill="none"
+              stroke="#000"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+            <g>
+              <path
+                d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+            </g>
+          </mask>
+        </defs>
         <g
           id="mirror"
         >
           <g
             id="fill1"
+            mask="url(#t-icon-overlap-7-1)"
           >
             <path
               d="M8 8.5V17.5H3L8 8.5Z"
               fill="transparent"
+              mask="url(#t-icon-overlap-7-0)"
             />
             <path
               d="M16 8.5V17.5H21L16 8.5Z"
@@ -45,13 +106,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             id="stroke1"
           >
             <path
-              d="M8 8.5V17.5H3L8 8.5Z"
-              stroke="currentColor"
-              stroke-linecap="square"
-              stroke-width="2"
-            />
-            <path
-              d="M16 8.5V17.5H21L16 8.5Z"
+              d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
               stroke="currentColor"
               stroke-linecap="square"
               stroke-width="2"
@@ -102,6 +157,40 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         viewBox="0 0 24 24"
         width="1em"
       >
+        <defs>
+          <mask
+            height="24"
+            id="t-icon-overlap-15-0"
+            mask-type="luminance"
+            maskContentUnits="userSpaceOnUse"
+            maskUnits="userSpaceOnUse"
+            width="24"
+            x="0"
+            y="0"
+          >
+            <rect
+              fill="#fff"
+              height="24"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <path
+              d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+              fill="none"
+              stroke="#000"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+            <path
+              d="M7.5 10.5H10.5L13.5 10.5"
+              fill="none"
+              stroke="#000"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+          </mask>
+        </defs>
         <g
           id="zoom-out"
         >
@@ -109,6 +198,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
             fill="transparent"
             id="fill1"
+            mask="url(#t-icon-overlap-15-0)"
           />
           <path
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -149,6 +239,40 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         viewBox="0 0 24 24"
         width="1em"
       >
+        <defs>
+          <mask
+            height="24"
+            id="t-icon-overlap-18-0"
+            mask-type="luminance"
+            maskContentUnits="userSpaceOnUse"
+            maskUnits="userSpaceOnUse"
+            width="24"
+            x="0"
+            y="0"
+          >
+            <rect
+              fill="#fff"
+              height="24"
+              width="24"
+              x="0"
+              y="0"
+            />
+            <path
+              d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+              fill="none"
+              stroke="#000"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+            <path
+              d="M10.5 13.5V10.5M10.5 10.5L10.5 7.5M10.5 10.5H7.5M10.5 10.5H13.5"
+              fill="none"
+              stroke="#000"
+              stroke-linecap="square"
+              stroke-width="2"
+            />
+          </mask>
+        </defs>
         <g
           id="zoom-in"
         >
@@ -156,6 +280,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
             fill="transparent"
             id="fill1"
+            mask="url(#t-icon-overlap-18-0)"
           />
           <path
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -190,6 +315,79 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
           viewBox="0 0 24 24"
           width="1em"
         >
+          <defs>
+            <mask
+              height="24"
+              id="t-icon-overlap-24-0"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <circle
+                cx="15.75"
+                cy="8.25"
+                fill="#000"
+                r="2"
+                stroke="none"
+              />
+              <path
+                d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+              <circle
+                cx="15.75"
+                cy="8.25"
+                fill="none"
+                r="2"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </mask>
+            <mask
+              height="24"
+              id="t-icon-overlap-24-1"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <path
+                d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                fill="none"
+                stroke="#000"
+                stroke-width="2"
+              />
+              <circle
+                cx="15.75"
+                cy="8.25"
+                fill="none"
+                r="2"
+                stroke="#000"
+                stroke-width="2"
+              />
+            </mask>
+          </defs>
           <g
             id="image"
           >
@@ -197,12 +395,14 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
               d="M3 21H20L9 10L3 16V21Z"
               fill="transparent"
               id="fill1"
+              mask="url(#t-icon-overlap-24-0)"
             />
             <circle
               cx="15.75"
               cy="8.25"
               fill="transparent"
               id="fill2"
+              mask="url(#t-icon-overlap-24-1)"
               r="2"
             />
             <path

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
@@ -37,13 +37,6 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
               x="0"
               y="0"
             />
-            <path
-              d="M12 3L12 21"
-              fill="none"
-              stroke="#000"
-              stroke-linecap="square"
-              stroke-width="2"
-            />
             <g>
               <path
                 d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
@@ -309,24 +302,9 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
                 x="0"
                 y="0"
               />
-              <circle
-                cx="15.75"
-                cy="8.25"
-                fill="#000"
-                r="2"
-                stroke="none"
-              />
               <path
                 d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                 fill="none"
-                stroke="#000"
-                stroke-width="2"
-              />
-              <circle
-                cx="15.75"
-                cy="8.25"
-                fill="none"
-                r="2"
                 stroke="#000"
                 stroke-width="2"
               />
@@ -347,12 +325,6 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
                 width="24"
                 x="0"
                 y="0"
-              />
-              <path
-                d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                fill="none"
-                stroke="#000"
-                stroke-width="2"
               />
               <circle
                 cx="15.75"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer-utils.test.tsx.snap
@@ -22,30 +22,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         <defs>
           <mask
             height="24"
-            id="t-icon-overlap-7-0"
-            mask-type="luminance"
-            maskContentUnits="userSpaceOnUse"
-            maskUnits="userSpaceOnUse"
-            width="24"
-            x="0"
-            y="0"
-          >
-            <rect
-              fill="#fff"
-              height="24"
-              width="24"
-              x="0"
-              y="0"
-            />
-            <path
-              d="M16 8.5V17.5H21L16 8.5Z"
-              fill="#000"
-              stroke="none"
-            />
-          </mask>
-          <mask
-            height="24"
-            id="t-icon-overlap-7-1"
+            id="t-icon-mirror-instance-v0-overlap-fill1"
             mask-type="luminance"
             maskContentUnits="userSpaceOnUse"
             maskUnits="userSpaceOnUse"
@@ -83,12 +60,11 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         >
           <g
             id="fill1"
-            mask="url(#t-icon-overlap-7-1)"
+            mask="url(#t-icon-mirror-instance-v0-overlap-fill1)"
           >
             <path
               d="M8 8.5V17.5H3L8 8.5Z"
               fill="transparent"
-              mask="url(#t-icon-overlap-7-0)"
             />
             <path
               d="M16 8.5V17.5H21L16 8.5Z"
@@ -160,7 +136,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         <defs>
           <mask
             height="24"
-            id="t-icon-overlap-15-0"
+            id="t-icon-zoom-out-instance-v2-overlap-fill1"
             mask-type="luminance"
             maskContentUnits="userSpaceOnUse"
             maskUnits="userSpaceOnUse"
@@ -198,7 +174,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
             fill="transparent"
             id="fill1"
-            mask="url(#t-icon-overlap-15-0)"
+            mask="url(#t-icon-zoom-out-instance-v2-overlap-fill1)"
           />
           <path
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -242,7 +218,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
         <defs>
           <mask
             height="24"
-            id="t-icon-overlap-18-0"
+            id="t-icon-zoom-in-instance-v3-overlap-fill1"
             mask-type="luminance"
             maskContentUnits="userSpaceOnUse"
             maskUnits="userSpaceOnUse"
@@ -280,7 +256,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
             fill="transparent"
             id="fill1"
-            mask="url(#t-icon-overlap-18-0)"
+            mask="url(#t-icon-zoom-in-instance-v3-overlap-fill1)"
           />
           <path
             d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -318,7 +294,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
           <defs>
             <mask
               height="24"
-              id="t-icon-overlap-24-0"
+              id="t-icon-image-instance-v4-overlap-fill1"
               mask-type="luminance"
               maskContentUnits="userSpaceOnUse"
               maskUnits="userSpaceOnUse"
@@ -357,7 +333,7 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
             </mask>
             <mask
               height="24"
-              id="t-icon-overlap-24-1"
+              id="t-icon-image-instance-v4-overlap-fill2"
               mask-type="luminance"
               maskContentUnits="userSpaceOnUse"
               maskUnits="userSpaceOnUse"
@@ -395,14 +371,14 @@ exports[`ImageViewerUtils > props > :scale[number] renders utils container and i
               d="M3 21H20L9 10L3 16V21Z"
               fill="transparent"
               id="fill1"
-              mask="url(#t-icon-overlap-24-0)"
+              mask="url(#t-icon-image-instance-v4-overlap-fill1)"
             />
             <circle
               cx="15.75"
               cy="8.25"
               fill="transparent"
               id="fill2"
-              mask="url(#t-icon-overlap-24-1)"
+              mask="url(#t-icon-image-instance-v4-overlap-fill2)"
               r="2"
             />
             <path

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
@@ -105,24 +105,9 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -143,12 +128,6 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -266,24 +245,9 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -304,12 +268,6 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -427,24 +385,9 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -465,12 +408,6 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -652,13 +589,6 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                 width="24"
                 x="0"
                 y="0"
-              />
-              <path
-                d="M12 3L12 21"
-                fill="none"
-                stroke="#000"
-                stroke-linecap="square"
-                stroke-width="2"
               />
               <g>
                 <path
@@ -925,24 +855,9 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                   x="0"
                   y="0"
                 />
-                <circle
-                  cx="15.75"
-                  cy="8.25"
-                  fill="#000"
-                  r="2"
-                  stroke="none"
-                />
                 <path
                   d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                   fill="none"
-                  stroke="#000"
-                  stroke-width="2"
-                />
-                <circle
-                  cx="15.75"
-                  cy="8.25"
-                  fill="none"
-                  r="2"
                   stroke="#000"
                   stroke-width="2"
                 />
@@ -963,12 +878,6 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                   width="24"
                   x="0"
                   y="0"
-                />
-                <path
-                  d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                  fill="none"
-                  stroke="#000"
-                  stroke-width="2"
                 />
                 <circle
                   cx="15.75"

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
@@ -87,6 +87,79 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1172-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1172-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -94,12 +167,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-1172-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-1172-1)"
                         r="2"
                       />
                       <path
@@ -173,6 +248,79 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1175-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1175-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -180,12 +328,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-1175-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-1175-1)"
                         r="2"
                       />
                       <path
@@ -259,6 +409,79 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1178-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-1178-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -266,12 +489,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-1178-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-1178-1)"
                         r="2"
                       />
                       <path
@@ -410,15 +635,76 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           viewBox="0 0 24 24"
           width="1em"
         >
+          <defs>
+            <mask
+              height="24"
+              id="t-icon-overlap-1190-0"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <path
+                d="M16 8.5V17.5H21L16 8.5Z"
+                fill="#000"
+                stroke="none"
+              />
+            </mask>
+            <mask
+              height="24"
+              id="t-icon-overlap-1190-1"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <path
+                d="M12 3L12 21"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+              <g>
+                <path
+                  d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+              </g>
+            </mask>
+          </defs>
           <g
             id="mirror"
           >
             <g
               id="fill1"
+              mask="url(#t-icon-overlap-1190-1)"
             >
               <path
                 d="M8 8.5V17.5H3L8 8.5Z"
                 fill="transparent"
+                mask="url(#t-icon-overlap-1190-0)"
               />
               <path
                 d="M16 8.5V17.5H21L16 8.5Z"
@@ -436,13 +722,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               id="stroke1"
             >
               <path
-                d="M8 8.5V17.5H3L8 8.5Z"
-                stroke="currentColor"
-                stroke-linecap="square"
-                stroke-width="2"
-              />
-              <path
-                d="M16 8.5V17.5H21L16 8.5Z"
+                d="M8 8.5V17.5H3L8 8.5Z M16 8.5V17.5H21L16 8.5Z"
                 stroke="currentColor"
                 stroke-linecap="square"
                 stroke-width="2"
@@ -493,6 +773,40 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           viewBox="0 0 24 24"
           width="1em"
         >
+          <defs>
+            <mask
+              height="24"
+              id="t-icon-overlap-1198-0"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <path
+                d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+              <path
+                d="M7.5 10.5H10.5L13.5 10.5"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+            </mask>
+          </defs>
           <g
             id="zoom-out"
           >
@@ -500,6 +814,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
               fill="transparent"
               id="fill1"
+              mask="url(#t-icon-overlap-1198-0)"
             />
             <path
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -540,6 +855,40 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           viewBox="0 0 24 24"
           width="1em"
         >
+          <defs>
+            <mask
+              height="24"
+              id="t-icon-overlap-1201-0"
+              mask-type="luminance"
+              maskContentUnits="userSpaceOnUse"
+              maskUnits="userSpaceOnUse"
+              width="24"
+              x="0"
+              y="0"
+            >
+              <rect
+                fill="#fff"
+                height="24"
+                width="24"
+                x="0"
+                y="0"
+              />
+              <path
+                d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+              <path
+                d="M10.5 13.5V10.5M10.5 10.5L10.5 7.5M10.5 10.5H7.5M10.5 10.5H13.5"
+                fill="none"
+                stroke="#000"
+                stroke-linecap="square"
+                stroke-width="2"
+              />
+            </mask>
+          </defs>
           <g
             id="zoom-in"
           >
@@ -547,6 +896,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
               fill="transparent"
               id="fill1"
+              mask="url(#t-icon-overlap-1201-0)"
             />
             <path
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -581,6 +931,79 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-1207-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <circle
+                  cx="15.75"
+                  cy="8.25"
+                  fill="#000"
+                  r="2"
+                  stroke="none"
+                />
+                <path
+                  d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+                <circle
+                  cx="15.75"
+                  cy="8.25"
+                  fill="none"
+                  r="2"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-1207-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                  fill="none"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+                <circle
+                  cx="15.75"
+                  cy="8.25"
+                  fill="none"
+                  r="2"
+                  stroke="#000"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               id="image"
             >
@@ -588,12 +1011,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                 d="M3 21H20L9 10L3 16V21Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-1207-0)"
               />
               <circle
                 cx="15.75"
                 cy="8.25"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-1207-1)"
                 r="2"
               />
               <path

--- a/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
+++ b/packages/components/image-viewer/__tests__/__snapshots__/image-viewer.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1172-0"
+                        id="t-icon-image-instance-v3-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -129,7 +129,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1172-1"
+                        id="t-icon-image-instance-v3-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -167,14 +167,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-1172-0)"
+                        mask="url(#t-icon-image-instance-v3-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-1172-1)"
+                        mask="url(#t-icon-image-instance-v3-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -251,7 +251,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1175-0"
+                        id="t-icon-image-instance-v4-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -290,7 +290,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1175-1"
+                        id="t-icon-image-instance-v4-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -328,14 +328,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-1175-0)"
+                        mask="url(#t-icon-image-instance-v4-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-1175-1)"
+                        mask="url(#t-icon-image-instance-v4-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -412,7 +412,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1178-0"
+                        id="t-icon-image-instance-v5-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -451,7 +451,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-1178-1"
+                        id="t-icon-image-instance-v5-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -489,14 +489,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-1178-0)"
+                        mask="url(#t-icon-image-instance-v5-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-1178-1)"
+                        mask="url(#t-icon-image-instance-v5-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -638,30 +638,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           <defs>
             <mask
               height="24"
-              id="t-icon-overlap-1190-0"
-              mask-type="luminance"
-              maskContentUnits="userSpaceOnUse"
-              maskUnits="userSpaceOnUse"
-              width="24"
-              x="0"
-              y="0"
-            >
-              <rect
-                fill="#fff"
-                height="24"
-                width="24"
-                x="0"
-                y="0"
-              />
-              <path
-                d="M16 8.5V17.5H21L16 8.5Z"
-                fill="#000"
-                stroke="none"
-              />
-            </mask>
-            <mask
-              height="24"
-              id="t-icon-overlap-1190-1"
+              id="t-icon-mirror-instance-v9-overlap-fill1"
               mask-type="luminance"
               maskContentUnits="userSpaceOnUse"
               maskUnits="userSpaceOnUse"
@@ -699,12 +676,11 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           >
             <g
               id="fill1"
-              mask="url(#t-icon-overlap-1190-1)"
+              mask="url(#t-icon-mirror-instance-v9-overlap-fill1)"
             >
               <path
                 d="M8 8.5V17.5H3L8 8.5Z"
                 fill="transparent"
-                mask="url(#t-icon-overlap-1190-0)"
               />
               <path
                 d="M16 8.5V17.5H21L16 8.5Z"
@@ -776,7 +752,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           <defs>
             <mask
               height="24"
-              id="t-icon-overlap-1198-0"
+              id="t-icon-zoom-out-instance-v11-overlap-fill1"
               mask-type="luminance"
               maskContentUnits="userSpaceOnUse"
               maskUnits="userSpaceOnUse"
@@ -814,7 +790,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
               fill="transparent"
               id="fill1"
-              mask="url(#t-icon-overlap-1198-0)"
+              mask="url(#t-icon-zoom-out-instance-v11-overlap-fill1)"
             />
             <path
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -858,7 +834,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
           <defs>
             <mask
               height="24"
-              id="t-icon-overlap-1201-0"
+              id="t-icon-zoom-in-instance-v12-overlap-fill1"
               mask-type="luminance"
               maskContentUnits="userSpaceOnUse"
               maskUnits="userSpaceOnUse"
@@ -896,7 +872,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033Z"
               fill="transparent"
               id="fill1"
-              mask="url(#t-icon-overlap-1201-0)"
+              mask="url(#t-icon-zoom-in-instance-v12-overlap-fill1)"
             />
             <path
               d="M15.8033 15.8033C12.8744 18.7322 8.12563 18.7322 5.1967 15.8033C2.26777 12.8744 2.26777 8.12563 5.1967 5.1967C8.12563 2.26777 12.8744 2.26777 15.8033 5.1967C18.7322 8.12563 18.7322 12.8744 15.8033 15.8033ZM15.8033 15.8033L21.1066 21.1066"
@@ -934,7 +910,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-1207-0"
+                id="t-icon-image-instance-v13-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -973,7 +949,7 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-1207-1"
+                id="t-icon-image-instance-v13-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -1011,14 +987,14 @@ exports[`ImageViewer > props > :mode[modal/modeless] 1`] = `
                 d="M3 21H20L9 10L3 16V21Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-1207-0)"
+                mask="url(#t-icon-image-instance-v13-overlap-fill1)"
               />
               <circle
                 cx="15.75"
                 cy="8.25"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-1207-1)"
+                mask="url(#t-icon-image-instance-v13-overlap-fill2)"
                 r="2"
               />
               <path

--- a/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
+++ b/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
@@ -73,24 +73,9 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -111,12 +96,6 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -347,24 +326,9 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -385,12 +349,6 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -624,24 +582,9 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -662,12 +605,6 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -898,24 +835,9 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -936,12 +858,6 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -1172,24 +1088,9 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                           x="0"
                           y="0"
                         />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="#000"
-                          r="2"
-                          stroke="none"
-                        />
                         <path
                           d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                           fill="none"
-                          stroke="#000"
-                          stroke-width="2"
-                        />
-                        <circle
-                          cx="15.75"
-                          cy="8.25"
-                          fill="none"
-                          r="2"
                           stroke="#000"
                           stroke-width="2"
                         />
@@ -1210,12 +1111,6 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                           width="24"
                           x="0"
                           y="0"
-                        />
-                        <path
-                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                          fill="none"
-                          stroke="#000"
-                          stroke-width="2"
                         />
                         <circle
                           cx="15.75"
@@ -1706,24 +1601,9 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                       x="0"
                       y="0"
                     />
-                    <circle
-                      cx="15.75"
-                      cy="8.25"
-                      fill="#000"
-                      r="2"
-                      stroke="none"
-                    />
                     <path
                       d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                       fill="none"
-                      stroke="#000"
-                      stroke-width="2"
-                    />
-                    <circle
-                      cx="15.75"
-                      cy="8.25"
-                      fill="none"
-                      r="2"
                       stroke="#000"
                       stroke-width="2"
                     />
@@ -1744,12 +1624,6 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                       width="24"
                       x="0"
                       y="0"
-                    />
-                    <path
-                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                      fill="none"
-                      stroke="#000"
-                      stroke-width="2"
                     />
                     <circle
                       cx="15.75"
@@ -1877,13 +1751,6 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                   width="24"
                   x="0"
                   y="0"
-                />
-                <path
-                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-linecap="square"
-                  stroke-width="2"
                 />
                 <path
                   d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
@@ -2083,24 +1950,9 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             x="0"
                             y="0"
                           />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="#000"
-                            r="2"
-                            stroke="none"
-                          />
                           <path
                             d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                             fill="none"
-                            stroke="#000"
-                            stroke-width="2"
-                          />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="none"
-                            r="2"
                             stroke="#000"
                             stroke-width="2"
                           />
@@ -2121,12 +1973,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             width="24"
                             x="0"
                             y="0"
-                          />
-                          <path
-                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                            fill="none"
-                            stroke="#000"
-                            stroke-width="2"
                           />
                           <circle
                             cx="15.75"
@@ -2336,24 +2182,9 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             x="0"
                             y="0"
                           />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="#000"
-                            r="2"
-                            stroke="none"
-                          />
                           <path
                             d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                             fill="none"
-                            stroke="#000"
-                            stroke-width="2"
-                          />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="none"
-                            r="2"
                             stroke="#000"
                             stroke-width="2"
                           />
@@ -2374,12 +2205,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             width="24"
                             x="0"
                             y="0"
-                          />
-                          <path
-                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                            fill="none"
-                            stroke="#000"
-                            stroke-width="2"
                           />
                           <circle
                             cx="15.75"
@@ -2501,13 +2326,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                         width="24"
                         x="0"
                         y="0"
-                      />
-                      <path
-                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-linecap="square"
-                        stroke-width="2"
                       />
                       <path
                         d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
@@ -2706,24 +2524,9 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             x="0"
                             y="0"
                           />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="#000"
-                            r="2"
-                            stroke="none"
-                          />
                           <path
                             d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                             fill="none"
-                            stroke="#000"
-                            stroke-width="2"
-                          />
-                          <circle
-                            cx="15.75"
-                            cy="8.25"
-                            fill="none"
-                            r="2"
                             stroke="#000"
                             stroke-width="2"
                           />
@@ -2744,12 +2547,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                             width="24"
                             x="0"
                             y="0"
-                          />
-                          <path
-                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                            fill="none"
-                            stroke="#000"
-                            stroke-width="2"
                           />
                           <circle
                             cx="15.75"
@@ -2871,13 +2668,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                         width="24"
                         x="0"
                         y="0"
-                      />
-                      <path
-                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
-                        fill="none"
-                        stroke="#000"
-                        stroke-linecap="square"
-                        stroke-width="2"
                       />
                       <path
                         d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
@@ -3313,24 +3103,9 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       x="0"
                       y="0"
                     />
-                    <circle
-                      cx="15.75"
-                      cy="8.25"
-                      fill="#000"
-                      r="2"
-                      stroke="none"
-                    />
                     <path
                       d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
                       fill="none"
-                      stroke="#000"
-                      stroke-width="2"
-                    />
-                    <circle
-                      cx="15.75"
-                      cy="8.25"
-                      fill="none"
-                      r="2"
                       stroke="#000"
                       stroke-width="2"
                     />
@@ -3351,12 +3126,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       width="24"
                       x="0"
                       y="0"
-                    />
-                    <path
-                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
-                      fill="none"
-                      stroke="#000"
-                      stroke-width="2"
                     />
                     <circle
                       cx="15.75"
@@ -3484,13 +3253,6 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   width="24"
                   x="0"
                   y="0"
-                />
-                <path
-                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
-                  fill="none"
-                  stroke="#000"
-                  stroke-linecap="square"
-                  stroke-width="2"
                 />
                 <path
                   d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"

--- a/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
+++ b/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
@@ -55,6 +55,79 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-281-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-281-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -62,12 +135,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-281-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-281-1)"
                         r="2"
                       />
                       <path
@@ -254,6 +329,79 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-292-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-292-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -261,12 +409,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-292-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-292-1)"
                         r="2"
                       />
                       <path
@@ -456,6 +606,79 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-259-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-259-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -463,12 +686,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-259-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-259-1)"
                         r="2"
                       />
                       <path
@@ -655,6 +880,79 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-270-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-270-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -662,12 +960,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-270-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-270-1)"
                         r="2"
                       />
                       <path
@@ -854,6 +1154,79 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                     viewBox="0 0 24 24"
                     width="1em"
                   >
+                    <defs>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-303-0"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="#000"
+                          r="2"
+                          stroke="none"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                      <mask
+                        height="24"
+                        id="t-icon-overlap-303-1"
+                        mask-type="luminance"
+                        maskContentUnits="userSpaceOnUse"
+                        maskUnits="userSpaceOnUse"
+                        width="24"
+                        x="0"
+                        y="0"
+                      >
+                        <rect
+                          fill="#fff"
+                          height="24"
+                          width="24"
+                          x="0"
+                          y="0"
+                        />
+                        <path
+                          d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                          fill="none"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                        <circle
+                          cx="15.75"
+                          cy="8.25"
+                          fill="none"
+                          r="2"
+                          stroke="#000"
+                          stroke-width="2"
+                        />
+                      </mask>
+                    </defs>
                     <g
                       id="image"
                     >
@@ -861,12 +1234,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
+                        mask="url(#t-icon-overlap-303-0)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
+                        mask="url(#t-icon-overlap-303-1)"
                         r="2"
                       />
                       <path
@@ -1313,6 +1688,79 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                 viewBox="0 0 24 24"
                 width="1em"
               >
+                <defs>
+                  <mask
+                    height="24"
+                    id="t-icon-overlap-841-0"
+                    mask-type="luminance"
+                    maskContentUnits="userSpaceOnUse"
+                    maskUnits="userSpaceOnUse"
+                    width="24"
+                    x="0"
+                    y="0"
+                  >
+                    <rect
+                      fill="#fff"
+                      height="24"
+                      width="24"
+                      x="0"
+                      y="0"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="#000"
+                      r="2"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="none"
+                      r="2"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </mask>
+                  <mask
+                    height="24"
+                    id="t-icon-overlap-841-1"
+                    mask-type="luminance"
+                    maskContentUnits="userSpaceOnUse"
+                    maskUnits="userSpaceOnUse"
+                    width="24"
+                    x="0"
+                    y="0"
+                  >
+                    <rect
+                      fill="#fff"
+                      height="24"
+                      width="24"
+                      x="0"
+                      y="0"
+                    />
+                    <path
+                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="none"
+                      r="2"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </mask>
+                </defs>
                 <g
                   id="image"
                 >
@@ -1320,12 +1768,14 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                     d="M3 21H20L9 10L3 16V21Z"
                     fill="transparent"
                     id="fill1"
+                    mask="url(#t-icon-overlap-841-0)"
                   />
                   <circle
                     cx="15.75"
                     cy="8.25"
                     fill="transparent"
                     id="fill2"
+                    mask="url(#t-icon-overlap-841-1)"
                     r="2"
                   />
                   <path
@@ -1373,6 +1823,77 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-842-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="#000"
+                  stroke="none"
+                />
+                <path
+                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-842-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               clipPath="url(#clip0_543_7945)"
               id="browse"
@@ -1381,11 +1902,13 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-842-0)"
               />
               <path
                 d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-842-1)"
               />
               <path
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -1542,6 +2065,79 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       viewBox="0 0 24 24"
                       width="1em"
                     >
+                      <defs>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-851-0"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="#000"
+                            r="2"
+                            stroke="none"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-851-1"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                      </defs>
                       <g
                         id="image"
                       >
@@ -1549,12 +2145,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
+                          mask="url(#t-icon-overlap-851-0)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
+                          mask="url(#t-icon-overlap-851-1)"
                           r="2"
                         />
                         <path
@@ -1597,6 +2195,40 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-852-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M12 9V18"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     id="delete"
                   >
@@ -1604,6 +2236,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-852-0)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -1685,6 +2318,79 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       viewBox="0 0 24 24"
                       width="1em"
                     >
+                      <defs>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-856-0"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="#000"
+                            r="2"
+                            stroke="none"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-856-1"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                      </defs>
                       <g
                         id="image"
                       >
@@ -1692,12 +2398,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
+                          mask="url(#t-icon-overlap-856-0)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
+                          mask="url(#t-icon-overlap-856-1)"
                           r="2"
                         />
                         <path
@@ -1739,6 +2447,77 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-857-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="#000"
+                        stroke="none"
+                      />
+                      <path
+                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-857-1"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     clipPath="url(#clip0_543_7945)"
                     id="browse"
@@ -1747,11 +2526,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-857-0)"
                     />
                     <path
                       d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                       fill="transparent"
                       id="fill2"
+                      mask="url(#t-icon-overlap-857-1)"
                     />
                     <path
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -1784,6 +2565,40 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-858-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M12 9V18"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     id="delete"
                   >
@@ -1791,6 +2606,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-858-0)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -1872,6 +2688,79 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       viewBox="0 0 24 24"
                       width="1em"
                     >
+                      <defs>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-862-0"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="#000"
+                            r="2"
+                            stroke="none"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                        <mask
+                          height="24"
+                          id="t-icon-overlap-862-1"
+                          mask-type="luminance"
+                          maskContentUnits="userSpaceOnUse"
+                          maskUnits="userSpaceOnUse"
+                          width="24"
+                          x="0"
+                          y="0"
+                        >
+                          <rect
+                            fill="#fff"
+                            height="24"
+                            width="24"
+                            x="0"
+                            y="0"
+                          />
+                          <path
+                            d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                            fill="none"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                          <circle
+                            cx="15.75"
+                            cy="8.25"
+                            fill="none"
+                            r="2"
+                            stroke="#000"
+                            stroke-width="2"
+                          />
+                        </mask>
+                      </defs>
                       <g
                         id="image"
                       >
@@ -1879,12 +2768,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
+                          mask="url(#t-icon-overlap-862-0)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
+                          mask="url(#t-icon-overlap-862-1)"
                           r="2"
                         />
                         <path
@@ -1926,6 +2817,77 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-863-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="#000"
+                        stroke="none"
+                      />
+                      <path
+                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-863-1"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     clipPath="url(#clip0_543_7945)"
                     id="browse"
@@ -1934,11 +2896,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-863-0)"
                     />
                     <path
                       d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                       fill="transparent"
                       id="fill2"
+                      mask="url(#t-icon-overlap-863-1)"
                     />
                     <path
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -1971,6 +2935,40 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-864-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M12 9V18"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     id="delete"
                   >
@@ -1978,6 +2976,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-864-0)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -2060,6 +3059,40 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-867-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M12 9V18"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     id="delete"
                   >
@@ -2067,6 +3100,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-867-0)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -2149,6 +3183,40 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   viewBox="0 0 24 24"
                   width="1em"
                 >
+                  <defs>
+                    <mask
+                      height="24"
+                      id="t-icon-overlap-870-0"
+                      mask-type="luminance"
+                      maskContentUnits="userSpaceOnUse"
+                      maskUnits="userSpaceOnUse"
+                      width="24"
+                      x="0"
+                      y="0"
+                    >
+                      <rect
+                        fill="#fff"
+                        height="24"
+                        width="24"
+                        x="0"
+                        y="0"
+                      />
+                      <path
+                        d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M12 9V18"
+                        fill="none"
+                        stroke="#000"
+                        stroke-linecap="square"
+                        stroke-width="2"
+                      />
+                    </mask>
+                  </defs>
                   <g
                     id="delete"
                   >
@@ -2156,6 +3224,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
+                      mask="url(#t-icon-overlap-870-0)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -2226,6 +3295,79 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                 viewBox="0 0 24 24"
                 width="1em"
               >
+                <defs>
+                  <mask
+                    height="24"
+                    id="t-icon-overlap-874-0"
+                    mask-type="luminance"
+                    maskContentUnits="userSpaceOnUse"
+                    maskUnits="userSpaceOnUse"
+                    width="24"
+                    x="0"
+                    y="0"
+                  >
+                    <rect
+                      fill="#fff"
+                      height="24"
+                      width="24"
+                      x="0"
+                      y="0"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="#000"
+                      r="2"
+                      stroke="none"
+                    />
+                    <path
+                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="none"
+                      r="2"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </mask>
+                  <mask
+                    height="24"
+                    id="t-icon-overlap-874-1"
+                    mask-type="luminance"
+                    maskContentUnits="userSpaceOnUse"
+                    maskUnits="userSpaceOnUse"
+                    width="24"
+                    x="0"
+                    y="0"
+                  >
+                    <rect
+                      fill="#fff"
+                      height="24"
+                      width="24"
+                      x="0"
+                      y="0"
+                    />
+                    <path
+                      d="M3 16V3H21V21H20M3 16V21H20M3 16L9 10L20 21"
+                      fill="none"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                    <circle
+                      cx="15.75"
+                      cy="8.25"
+                      fill="none"
+                      r="2"
+                      stroke="#000"
+                      stroke-width="2"
+                    />
+                  </mask>
+                </defs>
                 <g
                   id="image"
                 >
@@ -2233,12 +3375,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                     d="M3 21H20L9 10L3 16V21Z"
                     fill="transparent"
                     id="fill1"
+                    mask="url(#t-icon-overlap-874-0)"
                   />
                   <circle
                     cx="15.75"
                     cy="8.25"
                     fill="transparent"
                     id="fill2"
+                    mask="url(#t-icon-overlap-874-1)"
                     r="2"
                   />
                   <path
@@ -2286,6 +3430,77 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
             viewBox="0 0 24 24"
             width="1em"
           >
+            <defs>
+              <mask
+                height="24"
+                id="t-icon-overlap-875-0"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="#000"
+                  stroke="none"
+                />
+                <path
+                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+              </mask>
+              <mask
+                height="24"
+                id="t-icon-overlap-875-1"
+                mask-type="luminance"
+                maskContentUnits="userSpaceOnUse"
+                maskUnits="userSpaceOnUse"
+                width="24"
+                x="0"
+                y="0"
+              >
+                <rect
+                  fill="#fff"
+                  height="24"
+                  width="24"
+                  x="0"
+                  y="0"
+                />
+                <path
+                  d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+                <path
+                  d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
+                  fill="none"
+                  stroke="#000"
+                  stroke-linecap="square"
+                  stroke-width="2"
+                />
+              </mask>
+            </defs>
             <g
               clipPath="url(#clip0_543_7945)"
               id="browse"
@@ -2294,11 +3509,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                 fill="transparent"
                 id="fill1"
+                mask="url(#t-icon-overlap-875-0)"
               />
               <path
                 d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                 fill="transparent"
                 id="fill2"
+                mask="url(#t-icon-overlap-875-1)"
               />
               <path
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"

--- a/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
+++ b/packages/components/upload/__tests__/__snapshots__/upload.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-281-0"
+                        id="t-icon-image-instance-v0-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -97,7 +97,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-281-1"
+                        id="t-icon-image-instance-v0-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -135,14 +135,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, fail 
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-281-0)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-281-1)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -332,7 +332,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-292-0"
+                        id="t-icon-image-instance-v0-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -371,7 +371,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-292-1"
+                        id="t-icon-image-instance-v0-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -409,14 +409,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, progr
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-292-0)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-292-1)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -609,7 +609,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-259-0"
+                        id="t-icon-image-instance-v0-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -648,7 +648,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-259-1"
+                        id="t-icon-image-instance-v0-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -686,14 +686,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-259-0)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-259-1)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -883,7 +883,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-270-0"
+                        id="t-icon-image-instance-v0-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -922,7 +922,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-270-1"
+                        id="t-icon-image-instance-v0-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -960,14 +960,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, succe
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-270-0)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-270-1)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -1157,7 +1157,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                     <defs>
                       <mask
                         height="24"
-                        id="t-icon-overlap-303-0"
+                        id="t-icon-image-instance-v0-overlap-fill1"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -1196,7 +1196,7 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                       </mask>
                       <mask
                         height="24"
-                        id="t-icon-overlap-303-1"
+                        id="t-icon-image-instance-v0-overlap-fill2"
                         mask-type="luminance"
                         maskContentUnits="userSpaceOnUse"
                         maskUnits="userSpaceOnUse"
@@ -1234,14 +1234,14 @@ exports[`Upload Component > props.draggable: theme=image & draggable=true, waiti
                         d="M3 21H20L9 10L3 16V21Z"
                         fill="transparent"
                         id="fill1"
-                        mask="url(#t-icon-overlap-303-0)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill1)"
                       />
                       <circle
                         cx="15.75"
                         cy="8.25"
                         fill="transparent"
                         id="fill2"
-                        mask="url(#t-icon-overlap-303-1)"
+                        mask="url(#t-icon-image-instance-v0-overlap-fill2)"
                         r="2"
                       />
                       <path
@@ -1691,7 +1691,7 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                 <defs>
                   <mask
                     height="24"
-                    id="t-icon-overlap-841-0"
+                    id="t-icon-image-instance-v4-overlap-fill1"
                     mask-type="luminance"
                     maskContentUnits="userSpaceOnUse"
                     maskUnits="userSpaceOnUse"
@@ -1730,7 +1730,7 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                   </mask>
                   <mask
                     height="24"
-                    id="t-icon-overlap-841-1"
+                    id="t-icon-image-instance-v4-overlap-fill2"
                     mask-type="luminance"
                     maskContentUnits="userSpaceOnUse"
                     maskUnits="userSpaceOnUse"
@@ -1768,14 +1768,14 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                     d="M3 21H20L9 10L3 16V21Z"
                     fill="transparent"
                     id="fill1"
-                    mask="url(#t-icon-overlap-841-0)"
+                    mask="url(#t-icon-image-instance-v4-overlap-fill1)"
                   />
                   <circle
                     cx="15.75"
                     cy="8.25"
                     fill="transparent"
                     id="fill2"
-                    mask="url(#t-icon-overlap-841-1)"
+                    mask="url(#t-icon-image-instance-v4-overlap-fill2)"
                     r="2"
                   />
                   <path
@@ -1826,7 +1826,7 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-842-0"
+                id="t-icon-browse-instance-v5-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -1863,7 +1863,7 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-842-1"
+                id="t-icon-browse-instance-v5-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -1902,13 +1902,13 @@ exports[`Upload Component > props.theme: theme=file-flow works fine 1`] = `
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-842-0)"
+                mask="url(#t-icon-browse-instance-v5-overlap-fill1)"
               />
               <path
                 d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-842-1)"
+                mask="url(#t-icon-browse-instance-v5-overlap-fill2)"
               />
               <path
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -2068,7 +2068,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       <defs>
                         <mask
                           height="24"
-                          id="t-icon-overlap-851-0"
+                          id="t-icon-image-instance-v1-overlap-fill1"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2107,7 +2107,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                         </mask>
                         <mask
                           height="24"
-                          id="t-icon-overlap-851-1"
+                          id="t-icon-image-instance-v1-overlap-fill2"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2145,14 +2145,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
-                          mask="url(#t-icon-overlap-851-0)"
+                          mask="url(#t-icon-image-instance-v1-overlap-fill1)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
-                          mask="url(#t-icon-overlap-851-1)"
+                          mask="url(#t-icon-image-instance-v1-overlap-fill2)"
                           r="2"
                         />
                         <path
@@ -2198,7 +2198,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-852-0"
+                      id="t-icon-delete-instance-v2-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2236,7 +2236,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-852-0)"
+                      mask="url(#t-icon-delete-instance-v2-overlap-fill1)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -2321,7 +2321,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       <defs>
                         <mask
                           height="24"
-                          id="t-icon-overlap-856-0"
+                          id="t-icon-image-instance-v4-overlap-fill1"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2360,7 +2360,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                         </mask>
                         <mask
                           height="24"
-                          id="t-icon-overlap-856-1"
+                          id="t-icon-image-instance-v4-overlap-fill2"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2398,14 +2398,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
-                          mask="url(#t-icon-overlap-856-0)"
+                          mask="url(#t-icon-image-instance-v4-overlap-fill1)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
-                          mask="url(#t-icon-overlap-856-1)"
+                          mask="url(#t-icon-image-instance-v4-overlap-fill2)"
                           r="2"
                         />
                         <path
@@ -2450,7 +2450,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-857-0"
+                      id="t-icon-browse-instance-v5-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2487,7 +2487,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                     </mask>
                     <mask
                       height="24"
-                      id="t-icon-overlap-857-1"
+                      id="t-icon-browse-instance-v5-overlap-fill2"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2526,13 +2526,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-857-0)"
+                      mask="url(#t-icon-browse-instance-v5-overlap-fill1)"
                     />
                     <path
                       d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                       fill="transparent"
                       id="fill2"
-                      mask="url(#t-icon-overlap-857-1)"
+                      mask="url(#t-icon-browse-instance-v5-overlap-fill2)"
                     />
                     <path
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -2568,7 +2568,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-858-0"
+                      id="t-icon-delete-instance-v6-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2606,7 +2606,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-858-0)"
+                      mask="url(#t-icon-delete-instance-v6-overlap-fill1)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -2691,7 +2691,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       <defs>
                         <mask
                           height="24"
-                          id="t-icon-overlap-862-0"
+                          id="t-icon-image-instance-v8-overlap-fill1"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2730,7 +2730,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                         </mask>
                         <mask
                           height="24"
-                          id="t-icon-overlap-862-1"
+                          id="t-icon-image-instance-v8-overlap-fill2"
                           mask-type="luminance"
                           maskContentUnits="userSpaceOnUse"
                           maskUnits="userSpaceOnUse"
@@ -2768,14 +2768,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                           d="M3 21H20L9 10L3 16V21Z"
                           fill="transparent"
                           id="fill1"
-                          mask="url(#t-icon-overlap-862-0)"
+                          mask="url(#t-icon-image-instance-v8-overlap-fill1)"
                         />
                         <circle
                           cx="15.75"
                           cy="8.25"
                           fill="transparent"
                           id="fill2"
-                          mask="url(#t-icon-overlap-862-1)"
+                          mask="url(#t-icon-image-instance-v8-overlap-fill2)"
                           r="2"
                         />
                         <path
@@ -2820,7 +2820,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-863-0"
+                      id="t-icon-browse-instance-v9-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2857,7 +2857,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                     </mask>
                     <mask
                       height="24"
-                      id="t-icon-overlap-863-1"
+                      id="t-icon-browse-instance-v9-overlap-fill2"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2896,13 +2896,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-863-0)"
+                      mask="url(#t-icon-browse-instance-v9-overlap-fill1)"
                     />
                     <path
                       d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                       fill="transparent"
                       id="fill2"
-                      mask="url(#t-icon-overlap-863-1)"
+                      mask="url(#t-icon-browse-instance-v9-overlap-fill2)"
                     />
                     <path
                       d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
@@ -2938,7 +2938,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-864-0"
+                      id="t-icon-delete-instance-v10-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -2976,7 +2976,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-864-0)"
+                      mask="url(#t-icon-delete-instance-v10-overlap-fill1)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -3062,7 +3062,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-867-0"
+                      id="t-icon-delete-instance-v13-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -3100,7 +3100,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-867-0)"
+                      mask="url(#t-icon-delete-instance-v13-overlap-fill1)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -3186,7 +3186,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   <defs>
                     <mask
                       height="24"
-                      id="t-icon-overlap-870-0"
+                      id="t-icon-delete-instance-v14-overlap-fill1"
                       mask-type="luminance"
                       maskContentUnits="userSpaceOnUse"
                       maskUnits="userSpaceOnUse"
@@ -3224,7 +3224,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                       d="M5 5H19L18.5 22H5.5L5 5Z"
                       fill="transparent"
                       id="fill1"
-                      mask="url(#t-icon-overlap-870-0)"
+                      mask="url(#t-icon-delete-instance-v14-overlap-fill1)"
                     />
                     <path
                       d="M21 5H3M5 5H19L18.5 22H5.5L5 5ZM8.5 2H15.5V5H8.5V2Z"
@@ -3298,7 +3298,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                 <defs>
                   <mask
                     height="24"
-                    id="t-icon-overlap-874-0"
+                    id="t-icon-image-instance-v15-overlap-fill1"
                     mask-type="luminance"
                     maskContentUnits="userSpaceOnUse"
                     maskUnits="userSpaceOnUse"
@@ -3337,7 +3337,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                   </mask>
                   <mask
                     height="24"
-                    id="t-icon-overlap-874-1"
+                    id="t-icon-image-instance-v15-overlap-fill2"
                     mask-type="luminance"
                     maskContentUnits="userSpaceOnUse"
                     maskUnits="userSpaceOnUse"
@@ -3375,14 +3375,14 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                     d="M3 21H20L9 10L3 16V21Z"
                     fill="transparent"
                     id="fill1"
-                    mask="url(#t-icon-overlap-874-0)"
+                    mask="url(#t-icon-image-instance-v15-overlap-fill1)"
                   />
                   <circle
                     cx="15.75"
                     cy="8.25"
                     fill="transparent"
                     id="fill2"
-                    mask="url(#t-icon-overlap-874-1)"
+                    mask="url(#t-icon-image-instance-v15-overlap-fill2)"
                     r="2"
                   />
                   <path
@@ -3433,7 +3433,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
             <defs>
               <mask
                 height="24"
-                id="t-icon-overlap-875-0"
+                id="t-icon-browse-instance-v16-overlap-fill1"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -3470,7 +3470,7 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
               </mask>
               <mask
                 height="24"
-                id="t-icon-overlap-875-1"
+                id="t-icon-browse-instance-v16-overlap-fill2"
                 mask-type="luminance"
                 maskContentUnits="userSpaceOnUse"
                 maskUnits="userSpaceOnUse"
@@ -3509,13 +3509,13 @@ exports[`Upload Component > props.theme: theme=image-flow works fine 1`] = `
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"
                 fill="transparent"
                 id="fill1"
-                mask="url(#t-icon-overlap-875-0)"
+                mask="url(#t-icon-browse-instance-v16-overlap-fill1)"
               />
               <path
                 d="M16 12C16 14.2091 14.2091 16 12 16C9.79086 16 8 14.2091 8 12C8 9.79086 9.79086 8 12 8C14.2091 8 16 9.79086 16 12Z"
                 fill="transparent"
                 id="fill2"
-                mask="url(#t-icon-overlap-875-1)"
+                mask="url(#t-icon-browse-instance-v16-overlap-fill2)"
               />
               <path
                 d="M11.9997 4C6.86881 4 2.52275 7.36017 1.04199 12C2.52275 16.6398 6.86881 20 11.9997 20C17.1306 20 21.4766 16.6398 22.9574 12C21.4766 7.36017 17.1306 4 11.9997 4Z"

--- a/packages/tdesign-vue-next/.changelog/pr-6878.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6878.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6878
+contributor: uyarn
+---
+
+- fix(Icon): 修复同时使用多个存在 alpha 通道的颜色填充时出现透明度重叠导致渲染不符合预期的问题 @uyarn ([#6878](https://github.com/Tencent/tdesign-vue-next/pull/6878))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,8 +257,8 @@ catalogs:
       specifier: ^1.2.4
       version: 1.2.4
     tdesign-icons-vue-next:
-      specifier: ~0.4.7
-      version: 0.4.7
+      specifier: ^0.4.8
+      version: 0.4.8
     tdesign-publish-cli:
       specifier: ^0.0.12
       version: 0.0.12
@@ -591,7 +591,7 @@ importers:
     devDependencies:
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.7.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.7.3))
       tsdown:
         specifier: catalog:bundle
         version: 0.12.9(publint@0.3.21)(typescript@5.7.3)(vue-tsc@2.2.10(typescript@5.7.3))
@@ -630,7 +630,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -658,7 +658,7 @@ importers:
         version: 4.18.1
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
       vue:
         specifier: '>=3.1.0'
         version: 3.5.34(typescript@5.8.3)
@@ -739,7 +739,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -778,7 +778,7 @@ importers:
         version: 0.0.12(omi@7.7.13)(vue@3.5.34(typescript@5.8.3))
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -895,7 +895,7 @@ importers:
         version: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.0.4(@babel/core@7.29.0)(rollup@4.60.4))(@types/node@22.15.32)(@vitejs/devtools@0.1.24(@pnpm/logger@1001.0.1)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4)(ioredis@5.10.1)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(less@4.3.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-beta.28)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.28)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.15)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.9.0)
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.7(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -10090,8 +10090,8 @@ packages:
   tdesign-icons-svg@0.0.1:
     resolution: {integrity: sha512-4l05CgPXwI33Y6hU8ytKYIIXVznR22x6blhhtB6MntSHj2xrA+Unx4U/qy+Do/lCMtYao9q1wVkaZvxNjuX7jw==}
 
-  tdesign-icons-vue-next@0.4.7:
-    resolution: {integrity: sha512-0TRVH0L9O7vAMQ7j2vU/VYBMzS5FI+OVf7bWjwAVMmWXArsAyJI8mzpNWThZok96B6hsRY+2hK/NSOFZy8hMqA==}
+  tdesign-icons-vue-next@0.4.8:
+    resolution: {integrity: sha512-JLinPtu6Zq/HfUpsTKRnmwOrkBXZhDhwWbFXbA5mRJtiW/hbLq1DKI9bwW8EtNCcXh4BPzPg3TpzVeGTM5tqQw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -22314,12 +22314,12 @@ snapshots:
 
   tdesign-icons-svg@0.0.1: {}
 
-  tdesign-icons-vue-next@0.4.7(vue@3.5.34(typescript@5.7.3)):
+  tdesign-icons-vue-next@0.4.8(vue@3.5.34(typescript@5.7.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.7.3)
 
-  tdesign-icons-vue-next@0.4.7(vue@3.5.34(typescript@5.8.3)):
+  tdesign-icons-vue-next@0.4.8(vue@3.5.34(typescript@5.8.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,8 +257,8 @@ catalogs:
       specifier: ^1.2.4
       version: 1.2.4
     tdesign-icons-vue-next:
-      specifier: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b
-      version: 0.4.8
+      specifier: ^0.4.9
+      version: 0.4.9
     tdesign-publish-cli:
       specifier: ^0.0.12
       version: 0.0.12
@@ -591,7 +591,7 @@ importers:
     devDependencies:
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.7.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.7.3))
       tsdown:
         specifier: catalog:bundle
         version: 0.12.9(publint@0.3.21)(typescript@5.7.3)(vue-tsc@2.2.10(typescript@5.7.3))
@@ -630,7 +630,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -658,7 +658,7 @@ importers:
         version: 4.18.1
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.8.3))
       vue:
         specifier: '>=3.1.0'
         version: 3.5.34(typescript@5.8.3)
@@ -739,7 +739,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -778,7 +778,7 @@ importers:
         version: 0.0.12(omi@7.7.13)(vue@3.5.34(typescript@5.8.3))
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -895,7 +895,7 @@ importers:
         version: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.0.4(@babel/core@7.29.0)(rollup@4.60.4))(@types/node@22.15.32)(@vitejs/devtools@0.1.24(@pnpm/logger@1001.0.1)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4)(ioredis@5.10.1)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(less@4.3.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-beta.28)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.28)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.15)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.9.0)
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
+        version: 0.4.9(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -10090,9 +10090,8 @@ packages:
   tdesign-icons-svg@0.0.1:
     resolution: {integrity: sha512-4l05CgPXwI33Y6hU8ytKYIIXVznR22x6blhhtB6MntSHj2xrA+Unx4U/qy+Do/lCMtYao9q1wVkaZvxNjuX7jw==}
 
-  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b:
-    resolution: {integrity: sha512-rUF2wcf+5Q7wTQOnjay526CIizNBFoTNx09MXkdJSiyQvG8vzLzKZK7OnIIQG/G76KZ7mul/Vay0uqmdF5rWAQ==, tarball: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b}
-    version: 0.4.8
+  tdesign-icons-vue-next@0.4.9:
+    resolution: {integrity: sha512-eKt2hBNejz7sX2dseZKe0WU/tTAZBkqM8lOE6iqyifum0wI7/sKJ51roD2UeWBG9vtYhCOFXQNxADs7xr53HLw==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -22315,12 +22314,12 @@ snapshots:
 
   tdesign-icons-svg@0.0.1: {}
 
-  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.7.3)):
+  tdesign-icons-vue-next@0.4.9(vue@3.5.34(typescript@5.7.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.7.3)
 
-  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3)):
+  tdesign-icons-vue-next@0.4.9(vue@3.5.34(typescript@5.8.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.8.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,7 +257,7 @@ catalogs:
       specifier: ^1.2.4
       version: 1.2.4
     tdesign-icons-vue-next:
-      specifier: ^0.4.8
+      specifier: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b
       version: 0.4.8
     tdesign-publish-cli:
       specifier: ^0.0.12
@@ -591,7 +591,7 @@ importers:
     devDependencies:
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.7.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.7.3))
       tsdown:
         specifier: catalog:bundle
         version: 0.12.9(publint@0.3.21)(typescript@5.7.3)(vue-tsc@2.2.10(typescript@5.7.3))
@@ -630,7 +630,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -658,7 +658,7 @@ importers:
         version: 4.18.1
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
       vue:
         specifier: '>=3.1.0'
         version: 3.5.34(typescript@5.8.3)
@@ -739,7 +739,7 @@ importers:
         version: 1.15.6
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
       tinycolor2:
         specifier: catalog:deps
         version: 1.6.0
@@ -778,7 +778,7 @@ importers:
         version: 0.0.12(omi@7.7.13)(vue@3.5.34(typescript@5.8.3))
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -895,7 +895,7 @@ importers:
         version: 4.4.6(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@rollup/plugin-babel@6.0.4(@babel/core@7.29.0)(rollup@4.60.4))(@types/node@22.15.32)(@vitejs/devtools@0.1.24(@pnpm/logger@1001.0.1)(crossws@0.4.5(srvx@0.11.15))(db0@0.3.4)(ioredis@5.10.1)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.34)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(less@4.3.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-beta.28)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-beta.28)(rollup@4.60.4))(rollup@4.60.4)(srvx@0.11.15)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(vite@7.3.3(@types/node@22.15.32)(jiti@2.7.0)(less@4.3.0)(terser@5.43.1)(tsx@4.20.3)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.9.0)
       tdesign-icons-vue-next:
         specifier: catalog:tdesign
-        version: 0.4.8(vue@3.5.34(typescript@5.8.3))
+        version: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3))
       tdesign-vue-next:
         specifier: workspace:^
         version: link:../tdesign-vue-next
@@ -10090,8 +10090,9 @@ packages:
   tdesign-icons-svg@0.0.1:
     resolution: {integrity: sha512-4l05CgPXwI33Y6hU8ytKYIIXVznR22x6blhhtB6MntSHj2xrA+Unx4U/qy+Do/lCMtYao9q1wVkaZvxNjuX7jw==}
 
-  tdesign-icons-vue-next@0.4.8:
-    resolution: {integrity: sha512-JLinPtu6Zq/HfUpsTKRnmwOrkBXZhDhwWbFXbA5mRJtiW/hbLq1DKI9bwW8EtNCcXh4BPzPg3TpzVeGTM5tqQw==}
+  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b:
+    resolution: {integrity: sha512-rUF2wcf+5Q7wTQOnjay526CIizNBFoTNx09MXkdJSiyQvG8vzLzKZK7OnIIQG/G76KZ7mul/Vay0uqmdF5rWAQ==, tarball: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b}
+    version: 0.4.8
     peerDependencies:
       vue: ^3.0.0
 
@@ -22314,12 +22315,12 @@ snapshots:
 
   tdesign-icons-svg@0.0.1: {}
 
-  tdesign-icons-vue-next@0.4.8(vue@3.5.34(typescript@5.7.3)):
+  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.7.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.7.3)
 
-  tdesign-icons-vue-next@0.4.8(vue@3.5.34(typescript@5.8.3)):
+  tdesign-icons-vue-next@https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b(vue@3.5.34(typescript@5.8.3)):
     dependencies:
       '@babel/runtime': 7.27.6
       vue: 3.5.34(typescript@5.8.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalogs:
   tdesign:
     '@tdesign/site-components': ^0.19.2
     '@tdesign/theme-generator': ^1.2.4
-    tdesign-icons-vue-next: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b
+    tdesign-icons-vue-next: ^0.4.9
     tdesign-publish-cli: ^0.0.12
   test:
     '@testing-library/dom': ^9.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalogs:
   tdesign:
     '@tdesign/site-components': ^0.19.2
     '@tdesign/theme-generator': ^1.2.4
-    tdesign-icons-vue-next: ^0.4.8
+    tdesign-icons-vue-next: https://pkg.pr.new/Tencent/tdesign-icons/tdesign-icons-vue-next@ad06b1b
     tdesign-publish-cli: ^0.0.12
   test:
     '@testing-library/dom': ^9.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalogs:
   tdesign:
     '@tdesign/site-components': ^0.19.2
     '@tdesign/theme-generator': ^1.2.4
-    tdesign-icons-vue-next: ~0.4.7
+    tdesign-icons-vue-next: ^0.4.8
     tdesign-publish-cli: ^0.0.12
   test:
     '@testing-library/dom': ^9.3.1


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- https://github.com/Tencent/tdesign-icons/pull/276

 - 使用 mask 标签，在存在多路径且重叠的场景下针对其中一个路径 pathA 增加 luminance mask ，内部路径为 pathB 的绘制路径并填充深色覆盖，交叉部分路径不展示，达到透明度不重叠的效果，多重叠加的场景同理，在 mask 内部叠加多个其他下层填充、描边路径隐藏
- 修复前
<img width="187" height="193" alt="image" src="https://github.com/user-attachments/assets/392bf416-7c2b-4fc7-b94b-91a82ac39301" />
<img width="262" height="260" alt="image" src="https://github.com/user-attachments/assets/e7b57c5c-8d3e-42ea-a726-f6ceef7e599b" />

- 修复后
<img width="160" height="133" alt="image" src="https://github.com/user-attachments/assets/a732729f-50e3-46a5-8ff5-b2fcd51078a9" />
<img width="263" height="268" alt="image" src="https://github.com/user-attachments/assets/ba6c1365-4309-4575-a0e2-b1d4d1c3e856" />

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Icon): 修复同时使用多个存在 alpha 通道的颜色填充时出现透明度重叠导致渲染不符合预期的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
