### PR TITLE
test(chat): 验证响应式附件边界

### DIFF
--- a/packages/pro-components/chat/chatbot/_example/proxy-invariant.vue
+++ b/packages/pro-components/chat/chatbot/_example/proxy-invariant.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="proxy-invariant-demo">
+    <p>
+      附件使用普通 <code>ref</code>，不使用 <code>shallowRef</code> 或 <code>markRaw</code>。Web Component 可以接收
+      Proxy，但写入 ChatEngine 消息状态时必须创建非 Proxy 的独立快照。
+    </p>
+
+    <section class="case-card">
+      <p data-testid="input-proxy">Web Component 输入附件：{{ formatProxyState(inputProxy) }}</p>
+      <p data-testid="message-proxy">ChatEngine 消息附件：{{ formatProxyState(messageProxy) }}</p>
+      <p data-testid="send-status">发送状态：{{ sendStatus }}</p>
+      <t-button @click="addAttachment">添加响应式附件</t-button>
+      <t-chatbot
+        id="proxy-boundary-chatbot"
+        :default-messages="defaultMessages"
+        :message-props="messageProps"
+        :sender-props="senderProps"
+        :chat-service-config="serviceConfig"
+      />
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, isProxy, nextTick, ref } from 'vue';
+import type {
+  AIMessageContent,
+  ChatMessagesData,
+  ChatRequestParams,
+  ChatServiceConfig,
+  SSEChunkData,
+  TdAttachmentItem,
+  TdChatMessageConfigItem,
+} from '@tdesign-vue-next/chat';
+
+type ProxyState = boolean | null;
+
+type ChatbotElement = HTMLElement & {
+  props?: {
+    senderProps?: {
+      attachmentsProps?: {
+        items?: TdAttachmentItem[];
+      };
+    };
+  };
+  chatMessageValue?: ChatMessagesData[];
+};
+
+const files = ref<TdAttachmentItem[]>([]);
+const inputProxy = ref<ProxyState>(null);
+const messageProxy = ref<ProxyState>(null);
+const sendStatus = ref('等待发送');
+
+const defaultMessages: ChatMessagesData[] = [
+  {
+    id: crypto.randomUUID(),
+    role: 'assistant',
+    status: 'complete',
+    content: [{ type: 'text', status: 'complete', data: '添加附件后点击输入框右侧发送按钮。' }],
+  },
+];
+
+const getChatbot = () => document.querySelector('#proxy-boundary-chatbot') as ChatbotElement | null;
+
+const inspectInputBoundary = async () => {
+  await nextTick();
+  await nextTick();
+  const items = getChatbot()?.props?.senderProps?.attachmentsProps?.items;
+  inputProxy.value = items ? isProxy(items) || isProxy(items[0]) : null;
+};
+
+const inspectMessageBoundary = async () => {
+  await nextTick();
+  const userMessage = getChatbot()?.chatMessageValue?.find((message) => message.role === 'user');
+  const attachmentContent = userMessage?.content?.find((content) => content.type === 'attachment');
+  const items = attachmentContent?.type === 'attachment' ? attachmentContent.data : undefined;
+  messageProxy.value = items ? isProxy(items) || isProxy(items[0]) : null;
+};
+
+const addAttachment = () => {
+  files.value = [
+    {
+      name: 'reactive-attachment.txt',
+      size: 1024,
+      status: 'success',
+      description: '1KB',
+      url: 'https://example.com/reactive-attachment.txt',
+    },
+  ];
+  sendStatus.value = '等待发送';
+  messageProxy.value = null;
+  void inspectInputBoundary();
+};
+
+const senderProps = computed(() => ({
+  defaultValue: '发送带附件的消息',
+  placeholder: '发送带附件的消息',
+  actions: ['attachment', 'send'],
+  attachmentsProps: {
+    items: files.value,
+    overflow: 'scrollX' as const,
+  },
+  uploadProps: {
+    accept: '.pdf,.docx,.txt,.md',
+  },
+  onFileRemove: (event: CustomEvent<TdAttachmentItem[]>) => {
+    files.value = [...event.detail];
+    void inspectInputBoundary();
+  },
+}));
+
+const messageProps = (message: ChatMessagesData): TdChatMessageConfigItem => ({
+  variant: message.role === 'user' ? 'base' : 'text',
+  placement: message.role === 'user' ? 'right' : 'left',
+});
+
+const mockEndpoint = `data:text/event-stream,${encodeURIComponent(
+  `data: ${JSON.stringify({ answer: '附件发送成功' })}\n\n`,
+)}`;
+
+let sentWithAttachment = false;
+const serviceConfig: ChatServiceConfig = {
+  endpoint: mockEndpoint,
+  stream: true,
+  onRequest: (params: ChatRequestParams) => {
+    sentWithAttachment = Boolean(params.attachments?.length);
+    sendStatus.value = sentWithAttachment ? '发送中' : '未携带附件';
+    return { method: 'GET' };
+  },
+  onMessage: (chunk: SSEChunkData): AIMessageContent => ({
+    type: 'markdown',
+    data: String((chunk.data as { answer?: string })?.answer ?? ''),
+  }),
+  onComplete: () => {
+    sendStatus.value = sentWithAttachment ? '发送成功' : '未携带附件';
+    void inspectMessageBoundary();
+    return null;
+  },
+  onError: () => {
+    sendStatus.value = '发送失败';
+  },
+};
+
+const formatProxyState = (value: ProxyState) => {
+  if (value == null) return '等待附件';
+  return value ? 'Proxy' : '非 Proxy';
+};
+</script>
+
+<style scoped>
+.case-card {
+  max-width: 680px;
+  padding: 16px;
+  border: 1px solid var(--td-component-border);
+  border-radius: 8px;
+}
+
+.case-card t-chatbot {
+  display: block;
+  height: 420px;
+  margin-top: 12px;
+}
+</style>

--- a/packages/pro-components/chat/chatbot/chatbot.md
+++ b/packages/pro-components/chat/chatbot/chatbot.md
@@ -1,5 +1,11 @@
 :: BASE_DOC ::
 
+## Vue Proxy 附件边界验证
+
+附件状态可以使用普通 `ref`，无需通过 `markRaw` 或 `shallowRef` 规避深度代理。Web Component 接收 Vue Proxy 后，会在附件进入 ChatEngine 消息状态前创建独立的非 Proxy 快照。
+
+{{ proxy-invariant }}
+
 ## API
 
 ### Chatbot Props

--- a/packages/tdesign-vue-next-chat/package.json
+++ b/packages/tdesign-vue-next-chat/package.json
@@ -44,7 +44,7 @@
     "marked-highlight": "catalog:docs",
     "tdesign-icons-vue-next": "catalog:tdesign",
     "tdesign-vue-next": "workspace:^",
-    "tdesign-web-components": "1.3.1-alpha.14",
+    "tdesign-web-components": "https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07",
     "omi-vueify": "^0.0.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,8 +783,8 @@ importers:
         specifier: workspace:^
         version: link:../tdesign-vue-next
       tdesign-web-components:
-        specifier: 1.3.1-alpha.14
-        version: 1.3.1-alpha.14
+        specifier: https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07
+        version: https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07
       vue:
         specifier: '>=3.1.0'
         version: 3.5.34(typescript@5.8.3)
@@ -10119,8 +10119,9 @@ packages:
     peerDependencies:
       vue: ~2.7.14
 
-  tdesign-web-components@1.3.1-alpha.14:
-    resolution: {integrity: sha512-wU/FfFotTwB2tobvqSKQ2Bmlt6xZPzPHJXb+Jch6J75oH8tTwdoIzzaA6tGcO17ZEQ9/hpW0c0vwwJqIyVdW8w==}
+  tdesign-web-components@https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07:
+    resolution: {integrity: sha512-+FglILjA8jeY5pMvO0akTFUTSQD+mWHDkrwZkhtWPT7R6Bm3lhS2L1wgoRu66UwdzTUIq3bODAAJaw15Zn5wNw==, tarball: https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07}
+    version: 1.3.1-alpha.14
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -22369,7 +22370,7 @@ snapshots:
       validator: 13.15.23
       vue: 2.7.14
 
-  tdesign-web-components@1.3.1-alpha.14:
+  tdesign-web-components@https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07:
     dependencies:
       '@babel/runtime': 7.27.6
       '@popperjs/core': 2.11.8


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- https://github.com/TDesignOteam/tdesign-web-components/issues/381
- 上游 `develop` 单包修复：https://github.com/TDesignOteam/tdesign-web-components/pull/411

### 💡 需求背景和解决方案

Vue 使用普通 `ref([])` 保存附件时，传给 Web Component 的附件数组和元素都是 Proxy。原问题不是 Web Component 不能接收 Proxy，而是旧实现把调用方拥有的完整附件对象直接写入 ChatEngine/Immer 消息状态；状态冻结和深层读取会触发 Proxy invariant，最终表现为 `Subscriber error`。业务侧因此不得不同时使用 `markRaw`、`shallowRef` 绕开问题。

真正的数据所有权修复位于 WebC #411：`t-chatbot` 发送时按消息展示契约创建自己拥有的新数组和新附件 DTO，只保存 `key`、`fileType`、`name`、`size`、`url`、`extension`、`status`、`type`、`description`、`percent`，不读取或持有 `raw`、`response` 等上传过程对象。Vue Proxy 可以正常停留在 Web Component 输入边界，但不会进入 ChatEngine 消息状态。

本 PR 从最新 `develop` 重建，仅用于验证上游单包修复：

- 保持当前发布线的 `tdesign-web-components/lib/*` 入口，不引入 `next` 分包；
- 不在 Vue 侧增加 Proxy 检测、递归克隆、`toRaw`、`markRaw` 或 `shallowRef` 补偿；
- `packages/tdesign-vue-next-chat` 临时固定依赖 WebC #411 提交 `893ae5b6` 的不可变预览包；
- 增加普通 `ref([])` 的真实发送 Demo，显示 Web Component 输入仍为 Proxy、ChatEngine 消息附件为非 Proxy 快照。

`markRaw(senderProps)` 旧用法仍然兼容，但修复后不再必要。正式合入前，应将 WebC 预览 URL 替换为其正式发布版本。

WebC 固定预览包：

```text
https://pkg.pr.new/TDesignOteam/tdesign-web-components/tdesign-web-components@893ae5b6e427181d5b13f712afd26618a5cb2e07
```

Vue Chat 固定预览包：

```text
https://pkg.pr.new/@tdesign-vue-next/chat@f5d04cc
```

StackBlitz（Vue 3.5.41，普通 `ref([])`，`startScript=dev`）：

- [StackBlitz 独立沙盒 Demo](https://stackblitz.com/edit/github-dd1cgndb?file=src%2FApp.vue&startScript=dev)
- [固定提交源码](https://github.com/RSS1102/omi-vueify-proxy-ab/tree/edef9a4c632fb14a8689c28d43e4f34fe73d7fcc)

验证结果：

- `pnpm install --frozen-lockfile`：通过；
- `pnpm run build:chat`：通过；
- `pnpm -C packages/tdesign-vue-next-chat/site run preview`：通过；
- Demo ESLint（禁用缓存）：通过；
- 固定提交预览包在全新目录、独立 npm 缓存中执行 `npm ci`：通过，无 `EINTEGRITY`；
- 浏览器真实点击发送：业务/WebC 输入附件为 Proxy，ChatEngine 消息附件为非 Proxy，发送成功，消息数 3，runtime error 0，console error 0；
- `markRaw(senderProps)` 对照用法：仍可正常发送。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

无。

#### @tdesign-vue-next/chat

- fix(Chatbot): 验证 Web Component 对响应式附件的数据所有权隔离

#### @tdesign-vue-next/nuxt

无。

#### @tdesign-vue-next/auto-import-resolver

无。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
