### PR TITLE
fix(radio): 修复原生事件透传与键盘监听清理

### DIFF
--- a/packages/components/radio/__tests__/radio.hooks.test.tsx
+++ b/packages/components/radio/__tests__/radio.hooks.test.tsx
@@ -84,14 +84,14 @@ describe('Radio hooks', () => {
       expect(setValue).not.toHaveBeenCalled();
     });
 
-    // Current behavior is tracked by #6844. The listener remains active after the component is unmounted.
     it('lifecycle', () => {
       const { setValue, wrapper } = mountKeyboard();
       const root = wrapper.element;
 
       wrapper.unmount();
       const event = dispatchKeyboard(root, { code: 'Space' });
-      expect(setValue).toHaveBeenCalledWith(1, { e: event });
+      expect(event.defaultPrevented).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -229,29 +229,31 @@ describe('Radio', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
-    // Current behavior is tracked by #6844. These listeners should be bound to the input after the source is fixed.
-    it('focus/blur/keydown/keyup', async () => {
+    it('focus/blur/keydown/keyup/keypress', async () => {
       const onFocus = vi.fn();
       const onBlur = vi.fn();
       const onKeydown = vi.fn();
       const onKeyup = vi.fn();
+      const onKeypress = vi.fn();
       const wrapper = mount(Radio, {
-        attrs: { onBlur, onFocus, onKeydown, onKeyup },
+        attrs: { onBlur, onFocus, onKeydown, onKeyup, onKeypress },
       });
       const input = wrapper.get(INPUT);
 
-      expect(input.attributes('keydown')).toBeDefined();
+      expect(input.attributes('keydown')).toBeUndefined();
       expect(wrapper.attributes('onfocus')).toBeUndefined();
 
       await input.trigger('focus');
       await input.trigger('blur');
       await input.trigger('keydown', { key: 'Enter' });
       await input.trigger('keyup', { key: 'Enter' });
+      await input.trigger('keypress', { key: 'Enter' });
 
-      expect(onFocus).not.toHaveBeenCalled();
-      expect(onBlur).not.toHaveBeenCalled();
-      expect(onKeydown).not.toHaveBeenCalled();
-      expect(onKeyup).not.toHaveBeenCalled();
+      expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(onBlur).toHaveBeenCalledTimes(1);
+      expect(onKeydown).toHaveBeenCalledTimes(1);
+      expect(onKeyup).toHaveBeenCalledTimes(1);
+      expect(onKeypress).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/components/radio/hooks/useKeyboard.ts
+++ b/packages/components/radio/hooks/useKeyboard.ts
@@ -1,4 +1,4 @@
-import { onBeforeMount, onMounted, Ref } from 'vue';
+import { onBeforeUnmount, onMounted, Ref } from 'vue';
 import { isString } from 'lodash-es';
 import { off, on } from '@tdesign/shared-utils';
 import { CHECKED_CODE_REG } from '@tdesign/common-js/common';
@@ -35,7 +35,7 @@ export function useKeyboard(
     on(radioGroupRef.value, 'keydown', checkRadioInGroup);
   });
 
-  onBeforeMount(() => {
+  onBeforeUnmount(() => {
     off(radioGroupRef.value, 'keydown', checkRadioInGroup);
   });
 }

--- a/packages/components/radio/radio.tsx
+++ b/packages/components/radio/radio.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, inject, toRefs, computed, ref, ComputedRef } from 'vue';
+import type { InputHTMLAttributes } from 'vue';
 import {
   useVModel,
   useContent,
@@ -57,17 +58,15 @@ export default defineComponent({
 
     const inputEvents = computed(() =>
       getValidAttrs({
-        focus: attrs.onFocus,
-        blur: attrs.onBlur,
-        keydown: attrs.onKeydown,
-        keyup: attrs.onKeyup,
-        keypresss: attrs.onKeypresss,
+        onFocus: attrs.onFocus as InputHTMLAttributes['onFocus'],
+        onBlur: attrs.onBlur as InputHTMLAttributes['onBlur'],
+        onKeydown: attrs.onKeydown as InputHTMLAttributes['onKeydown'],
+        onKeyup: attrs.onKeyup as InputHTMLAttributes['onKeyup'],
+        onKeypress: attrs.onKeypress as InputHTMLAttributes['onKeypress'],
       }),
     );
     const wrapperAttrs = computed(() => {
-      const events = [...Object.keys(inputEvents.value), 'input', 'change'].map(
-        (str) => `on${str[0].toUpperCase()}${str.slice(1)}`,
-      );
+      const events = [...Object.keys(inputEvents.value), 'onInput', 'onChange'];
       return omit(attrs, events);
     });
     /** Event END */


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Fixes #6844
- RadioButton 独立使用问题已拆分至待讨论 issue #6885，本 PR 不处理该项。
- 关联测试 PR：#6843。

### 💡 需求背景和解决方案

#6844 确认了 Radio 组件中的三项行为问题。本 PR 处理其中已经明确的前两项：

1. `radio.tsx` 使用 `focus`、`keydown` 等普通属性 key 展开到原生 input，导致 `onFocus`、`onKeydown` 等监听函数被序列化为 HTML 属性而未绑定为事件；同时 `keypresss` / `onKeypresss` 存在拼写错误。
2. `useKeyboard` 在 `onBeforeMount` 中解绑 RadioGroup 的 `keydown` 监听，挂载前 ref 尚不存在，组件卸载时也不会清理监听器。

本 PR：

- 将透传给 input 的监听器改为 Vue JSX 所需的 `onFocus`、`onBlur`、`onKeydown`、`onKeyup`、`onKeypress`。
- 同步调整外层 label 的 attrs 排除逻辑，避免事件重复落到外层。
- 使用 `onBeforeUnmount` 清理 RadioGroup 的 `keydown` 监听器。
- 将 #6843 中记录旧行为的断言更新为修复后的预期，并补充 `onKeypress` 回归覆盖。
- 验证卸载后的 RadioGroup DOM 节点不会继续响应键盘事件。

RadioButton 是否支持独立使用涉及组件 API 定位，已拆分至 #6885 继续讨论。

### ✅ 验证

- Radio 定向测试：4 files / 51 tests passed。
- 改动文件 ESLint：通过。
- 提交钩子 Prettier / ESLint：通过。
- `pnpm lint:tsc`：本次 Radio 类型错误已清零；当前工作区仍有 `select.tsx` 两处与本 PR 无关的类型错误。
- `pnpm test:vue`：Radio 用例通过；全量运行受工作区原有 `packages/common` 子模块版本偏移导致的无关快照失败影响。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Radio): 修复原生事件监听未正确透传及 RadioGroup 键盘监听卸载后未清理问题

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/nuxt

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
