### PR TITLE
fix(radio): 修复 RadioGroup false 值处理异常

### DIFF
--- a/packages/components/radio/__tests__/radio-group.test.tsx
+++ b/packages/components/radio/__tests__/radio-group.test.tsx
@@ -274,8 +274,7 @@ describe('RadioGroup', () => {
       const implicitBooleanWrapper = mount(RadioGroup, {
         props: { options: [{ label: 'False', value: false }] },
       });
-      // Current behavior is tracked by #6882. An absent defaultValue is normalized to false.
-      expect(implicitBooleanWrapper.get(RADIO).classes()).toContain('t-is-checked');
+      expect(implicitBooleanWrapper.get(RADIO).classes()).not.toContain('t-is-checked');
     });
 
     it(':modelValue[string/number/boolean]', async () => {
@@ -301,7 +300,7 @@ describe('RadioGroup', () => {
       expect(numberWrapper.get(RADIO).classes()).toContain('t-is-checked');
 
       const booleanWrapper = mount(RadioGroup, {
-        props: { modelValue: true, options: [{ label: 'True', value: true }] },
+        props: { modelValue: false, options: [{ label: 'False', value: false }] },
       });
       expect(booleanWrapper.get(RADIO).classes()).toContain('t-is-checked');
     });
@@ -315,11 +314,11 @@ describe('RadioGroup', () => {
       expect(validateVariant('default-filled')).toBe(true);
       expect(validateVariant('filled')).toBe(false);
 
-      const wrapper = mountGroupWithOptions();
+      const wrapper = mountGroupWithOptions({ value: 1 });
       expect(wrapper.get(RADIO_GROUP).classes()).toContain('t-radio-group__outline');
       expect(wrapper.find(BG_BLOCK).exists()).toBe(false);
 
-      await wrapper.setProps({ value: 1, variant: 'primary-filled' });
+      await wrapper.setProps({ variant: 'primary-filled' });
       expect(wrapper.get(RADIO_GROUP).classes()).toContain('t-radio-group--filled');
       expect(wrapper.get(RADIO_GROUP).classes()).toContain('t-radio-group--primary-filled');
       expect(wrapper.find(BG_BLOCK).exists()).toBe(true);
@@ -377,8 +376,19 @@ describe('RadioGroup', () => {
         props: { options: ['first'], variant: 'primary-filled' },
       });
       await nextTick();
-      // Current behavior is tracked by #6882. An absent defaultValue currently normalizes to false.
-      expect(emptyWrapper.get(BG_BLOCK).attributes('style')).toContain('height: 9px');
+      expect(emptyWrapper.find(BG_BLOCK).exists()).toBe(false);
+
+      const explicitFalseWrapper = mount(RadioGroup, {
+        props: {
+          defaultValue: false,
+          options: [{ label: 'False', value: false }],
+          theme: 'button',
+          variant: 'primary-filled',
+        },
+      });
+      await nextTick();
+      expect(explicitFalseWrapper.get(RADIO_BUTTON).classes()).toContain('t-is-checked');
+      expect(explicitFalseWrapper.find(BG_BLOCK).exists()).toBe(true);
 
       const outlineWrapper = mount(
         <RadioGroup variant="outline" value="first">
@@ -461,6 +471,60 @@ describe('RadioGroup', () => {
   });
 
   describe('events', () => {
+    it('mouse change preserves boolean false', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(
+        <RadioGroup onChange={onChange}>
+          <Radio value={false}>False</Radio>
+        </RadioGroup>,
+      );
+
+      expect(wrapper.get(RADIO).classes()).not.toContain('t-is-checked');
+      await wrapper.get(RADIO).trigger('click');
+      expect(onChange).toHaveBeenCalledWith(false, {
+        e: expect.any(MouseEvent),
+        name: '',
+      });
+      expect(wrapper.get(RADIO).classes()).toContain('t-is-checked');
+    });
+
+    it('keyboard change preserves boolean, string, and number values', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(
+        <RadioGroup onChange={onChange}>
+          <Radio value={true}>True</Radio>
+          <Radio value={false}>False</Radio>
+          <Radio value="false">String false</Radio>
+          <Radio value={0}>Zero</Radio>
+        </RadioGroup>,
+      );
+      const radios = wrapper.findAll(RADIO);
+
+      radios.forEach((radio) => {
+        expect(radio.classes()).not.toContain('t-is-checked');
+      });
+
+      await radios[1].trigger('keydown', { code: 'Space' });
+      expect(onChange).toHaveBeenLastCalledWith(false, {
+        e: expect.any(KeyboardEvent),
+      });
+      expect(radios[1].classes()).toContain('t-is-checked');
+
+      await radios[2].trigger('keydown', { code: 'Space' });
+      expect(onChange).toHaveBeenLastCalledWith('false', {
+        e: expect.any(KeyboardEvent),
+      });
+      expect(radios[1].classes()).not.toContain('t-is-checked');
+      expect(radios[2].classes()).toContain('t-is-checked');
+
+      await radios[3].trigger('keydown', { code: 'Space' });
+      expect(onChange).toHaveBeenLastCalledWith(0, {
+        e: expect.any(KeyboardEvent),
+      });
+      expect(radios[2].classes()).not.toContain('t-is-checked');
+      expect(radios[3].classes()).toContain('t-is-checked');
+    });
+
     it('change', async () => {
       const onChange = vi.fn();
       const wrapper = mountGroupWithOptions({

--- a/packages/components/radio/__tests__/radio.hooks.test.tsx
+++ b/packages/components/radio/__tests__/radio.hooks.test.tsx
@@ -56,10 +56,17 @@ describe('Radio hooks', () => {
       const trueEvent = dispatchKeyboard(wrapper.element, { code: 'Space' });
       expect(setValue).toHaveBeenLastCalledWith(true, { e: trueEvent });
 
-      // Current behavior is tracked by #6882. The false mapping falls back to the original string.
       input.dataset.value = 'false';
       const falseEvent = dispatchKeyboard(wrapper.element, { code: 'Space' });
-      expect(setValue).toHaveBeenLastCalledWith('false', { e: falseEvent });
+      expect(setValue).toHaveBeenLastCalledWith(false, { e: falseEvent });
+
+      input.dataset.value = "'false'";
+      const stringFalseEvent = dispatchKeyboard(wrapper.element, { code: 'Space' });
+      expect(setValue).toHaveBeenLastCalledWith('false', { e: stringFalseEvent });
+
+      input.dataset.value = '0';
+      const zeroEvent = dispatchKeyboard(wrapper.element, { code: 'Space' });
+      expect(setValue).toHaveBeenLastCalledWith(0, { e: zeroEvent });
     });
 
     it('allowUncheck[boolean]', () => {

--- a/packages/components/radio/hooks/useKeyboard.ts
+++ b/packages/components/radio/hooks/useKeyboard.ts
@@ -23,7 +23,8 @@ export function useKeyboard(
         // Number
         let value: number | string | boolean = !isNaN(Number(data.value)) ? Number(data.value) : data.value;
         // Boolean
-        value = (isString(value) && { true: true, false: false }[value]) || value;
+        if (value === 'true') value = true;
+        if (value === 'false') value = false;
         // String
         value = isString(value) && value[0] === "'" ? value.replace(/'/g, '') : value;
         setInnerValue(value, { e });

--- a/packages/components/radio/radio-group-props.ts
+++ b/packages/components/radio/radio-group-props.ts
@@ -68,6 +68,7 @@ export default {
   /** 选中的值，非受控属性 */
   defaultValue: {
     type: [String, Number, Boolean] as PropType<TdRadioGroupProps['defaultValue']>,
+    default: undefined as TdRadioGroupProps['defaultValue'],
   },
   /** 单选组件按钮形式 */
   variant: {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6882

关联讨论：#6843

### 💡 需求背景和解决方案

`RadioGroup` 使用布尔值选项时存在两个相互关联的问题：

1. 键盘选择 `false` 时，dataset 反序列化使用 `||`，导致布尔值 `false` 回退为字符串 `"false"`。
2. 未传 `defaultValue` 时，Vue 会把 Boolean 类型 prop 归一化为 `false`，导致值为 `false` 的选项在非受控场景中被隐式选中，`filled` variant 下还会出现未预期的选中背景。

本 PR 采用最小范围修复：

- 对 dataset 中的 `"true"` / `"false"` 做严格等值转换，避免 falsy 回退；字符串 `"false"` 和数字 `0` 仍保持各自原有类型。
- 将 `defaultValue` 的运行时缺省值显式设为 `undefined`，区分“未传值”和“显式传入 false”；不改变现有 props 类型及受控 `modelValue` 行为。

为避免回归，新增/调整测试覆盖：

- 未传 `modelValue` / `defaultValue` 时不自动选中 false。
- 显式传入 `modelValue: false` 或 `defaultValue: false` 时仍正常选中。
- 鼠标、键盘两条交互路径。
- boolean `true` / `false`、string `"false"`、number `0` 的类型边界。
- outline / filled 两种 variant 的选中背景行为。

本地验证：

- Radio 相关 4 个测试文件，53 个测试全部通过。
- 本 PR 涉及文件 ESLint 通过，commit hooks 通过。
- 全量 `pnpm lint:tsc` 当前仍被 `packages/components/select/select.tsx:595` 的既有隐式 `any` 报错阻断；Radio 相关文件没有新增类型错误。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Radio): 修复 RadioGroup 对 false 值的键盘转换及缺省值处理异常

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/nuxt

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
