### PR TITLE
fix(swiper):  fix current value is override by defaultCurrent and custom navigation does not render

### DIFF
--- a/packages/components/swiper/__tests__/swiper.test.tsx
+++ b/packages/components/swiper/__tests__/swiper.test.tsx
@@ -193,11 +193,10 @@ describe('Swiper', () => {
       wrapper.unmount();
     });
 
-    it(':current[number] with :defaultCurrent[number] keeps current behavior for zero', () => {
+    it(':current[number] takes precedence over :defaultCurrent[number] for zero', () => {
       const wrapper = mountSwiper({ current: 0, defaultCurrent: 2 });
 
-      // `props.current || props.defaultCurrent` currently treats the controlled zero as absent.
-      expect(getActiveNavigationIndex(wrapper)).toBe(2);
+      expect(getActiveNavigationIndex(wrapper)).toBe(0);
 
       wrapper.unmount();
     });
@@ -318,9 +317,8 @@ describe('Swiper', () => {
     it(':navigation[function]', () => {
       const wrapper = mountSwiper({ navigation: () => h('div', { class: 'function-navigation' }, 'Function') });
 
-      // The public TNode type accepts a function, but the current implementation falls back to the default navigation.
-      expect(wrapper.find('.function-navigation').exists()).toBe(false);
-      expect(wrapper.find('.t-swiper__navigation-bars').exists()).toBe(true);
+      expect(wrapper.find('.function-navigation').text()).toBe('Function');
+      expect(wrapper.find('.t-swiper__navigation-bars').exists()).toBe(false);
 
       wrapper.unmount();
     });
@@ -593,13 +591,26 @@ describe('Swiper', () => {
       wrapper.unmount();
     });
 
-    it(':autoplay[true] keeps its timer after unmount in the current implementation', () => {
-      const wrapper = mountSwiper({ autoplay: true, interval: 1000 });
+    it(':autoplay[true] clears its timer after unmount', () => {
+      const onChange = vi.fn();
+      const wrapper = mountSwiper({ autoplay: true, interval: 1000, duration: 100, onChange });
 
       expect(vi.getTimerCount()).toBeGreaterThan(0);
       wrapper.unmount();
-      // The source currently has no unmount hook that clears the autoplay timer.
+      expect(vi.getTimerCount()).toBe(0);
+      vi.advanceTimersByTime(1000);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('clears its switching timer after unmount', async () => {
+      const wrapper = mountSwiper({ duration: 100 });
+
+      await nextTick();
+      await wrapper.find('.t-swiper__arrow-right').trigger('click');
       expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+      wrapper.unmount();
+      expect(vi.getTimerCount()).toBe(0);
     });
   });
 });

--- a/packages/components/swiper/props.ts
+++ b/packages/components/swiper/props.ts
@@ -30,7 +30,7 @@ export default {
   /** 当前轮播在哪一项（下标） */
   current: {
     type: Number,
-    default: 0,
+    default: undefined,
   },
   /** 当前轮播在哪一项（下标），非受控属性 */
   defaultCurrent: {

--- a/packages/components/swiper/swiper.tsx
+++ b/packages/components/swiper/swiper.tsx
@@ -1,4 +1,4 @@
-import { cloneVNode, computed, defineComponent, isVNode, onMounted, ref, watch } from 'vue';
+import { cloneVNode, computed, defineComponent, isVNode, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { ChevronLeftIcon as TdChevronLeftIcon, ChevronRightIcon as TdChevronRightIcon } from 'tdesign-icons-vue-next';
 
 import {
@@ -33,12 +33,12 @@ export default defineComponent({
       ChevronRightIcon: TdChevronRightIcon,
     });
     let swiperTimer: ReturnType<typeof setTimeout> | null = null;
-    let swiperSwitchingTimer = 0;
+    let swiperSwitchingTimer: ReturnType<typeof setTimeout> | null = null;
     let isBeginToEnd = false;
     let isEndToBegin = false;
 
-    const currentIndex = ref(props.current || props.defaultCurrent);
-    const navActiveIndex = ref(props.current || props.defaultCurrent);
+    const currentIndex = ref(props.current ?? props.defaultCurrent);
+    const navActiveIndex = ref(props.current ?? props.defaultCurrent);
     const isHovering = ref(false);
     const isSwitching = ref(false);
     const showArrow = ref(false);
@@ -170,9 +170,15 @@ export default defineComponent({
       currentIndex.value = targetIndex;
     };
     const clearTimer = () => {
-      if (swiperTimer) {
+      if (swiperTimer !== null) {
         clearTimeout(swiperTimer);
         swiperTimer = null;
+      }
+    };
+    const clearSwitchingTimer = () => {
+      if (swiperSwitchingTimer !== null) {
+        clearTimeout(swiperSwitchingTimer);
+        swiperSwitchingTimer = null;
       }
     };
     const setTimer = () => {
@@ -258,7 +264,9 @@ export default defineComponent({
     const renderNavigation = () => {
       if (isVNode(props.navigation)) return props.navigation;
       const navigationSlot = renderTNodeJSX('navigation');
-      if (navigationSlot && isVNode(navigationSlot?.[0])) return navigationSlot;
+      if (typeof props.navigation === 'function' || (navigationSlot && isVNode(navigationSlot?.[0]))) {
+        return navigationSlot;
+      }
 
       if (navigationConfig.value.type === 'fraction') {
         return (
@@ -311,27 +319,34 @@ export default defineComponent({
       () => isSwitching.value,
       () => {
         if (isSwitching.value) {
-          if (swiperSwitchingTimer) clearTimeout(swiperSwitchingTimer);
+          clearSwitchingTimer();
           swiperSwitchingTimer = setTimeout(() => {
             isSwitching.value = false;
-            swiperSwitchingTimer = 0;
+            swiperSwitchingTimer = null;
             if (isEnd.value) {
               clearTimer();
             }
-          }, props.duration + 50) as unknown as number;
+          }, props.duration + 50);
         }
       },
     );
     watch(
       () => props.current,
-      () => {
-        swiperTo(props.current, { source: 'autoplay' });
+      (current) => {
+        if (current !== undefined) {
+          swiperTo(current, { source: 'autoplay' });
+        }
       },
     );
 
     onMounted(() => {
       setTimer();
       showArrow.value = navigationConfig.value.showSlideBtn === 'always';
+    });
+
+    onBeforeUnmount(() => {
+      clearTimer();
+      clearSwitchingTimer();
     });
 
     useResizeObserver(swiperWrap, () => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6883

关联测试覆盖率 PR：#6884

### 💡 需求背景和解决方案

本 PR 修复 Swiper 的三个独立问题：

1. 同时传入 `current={0}` 和非零 `defaultCurrent` 时，受控值 `0` 被 `||` 当作 falsy，错误回退到 `defaultCurrent`。
2. `navigation` 公开类型支持 Function，但函数返回的 TNode 没有被 `renderNavigation` 接收，最终回退为默认导航器。
3. 组件卸载时没有清理 autoplay 与 switching 计时器，卸载后仍可能触发回调或保留无效任务。

修复方式：

- 将受控 `current` 的运行时缺省值设为 `undefined`，使用 `props.current ?? props.defaultCurrent` 初始化；组件未传值时仍通过 `defaultCurrent=0` 保持原有默认行为。
- 仅为 Function 类型的 `navigation` 返回 `useTNodeJSX` 渲染结果，保留对象配置、VNode 和 slot 的既有分支。
- 统一 switching timer 的句柄类型，并在 `onBeforeUnmount` 中清理 autoplay 与 switching timer。
- 更新 #6884 中记录旧行为的断言，并增加 switching timer 卸载清理测试。

影响边界验证：

- 显式 `current=0` 优先于 `defaultCurrent`，仅传 `defaultCurrent` 仍正常生效。
- navigation object、VNode、slot、Function 均有回归测试。
- autoplay 正常切换、非循环停止、悬浮暂停/恢复及卸载清理均有覆盖。

本地验证：

- Swiper / SwiperItem 共 2 个测试文件、57 个测试全部通过。
- 本 PR 涉及文件 ESLint 通过，commit hooks 通过。
- 全量 `pnpm lint:tsc` 当前仍被 `packages/components/select/select.tsx:595` 的既有隐式 `any` 报错阻断；Swiper 相关文件没有新增类型错误。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Swiper): 修复 `current` 为 `0` 时被 `defaultCurrent` 覆盖的问题
- fix(Swiper): 修复 `navigation` 传入函数时未渲染自定义导航的问题

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/nuxt

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
