### PR TITLE
test(message): improve message test coverage

### DIFF
--- a/packages/components/message/__tests__/message-list.test.tsx
+++ b/packages/components/message/__tests__/message-list.test.tsx
@@ -1,0 +1,214 @@
+import { nextTick } from 'vue';
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_Z_INDEX } from '@tdesign/common-js/message/index';
+import { MessageList } from '@tdesign/components/message/message-list';
+import type { MessageOptions } from '@tdesign/components/message';
+
+interface MessageListItem extends MessageOptions {
+  key: number;
+}
+
+interface MessageListExposed {
+  add: (message: MessageOptions) => number;
+  removeAll: () => void;
+  list: Ref<MessageListItem[]>;
+  messageList: Ref<ComponentPublicInstance[]>;
+}
+
+const getExposed = (wrapper: VueWrapper) => wrapper.vm.$.exposed as unknown as MessageListExposed;
+
+const addMessage = async (wrapper: VueWrapper, options: MessageOptions = {}) => {
+  const key = getExposed(wrapper).add({ duration: 0, ...options });
+  await nextTick();
+  return key;
+};
+
+describe('MessageList', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it('does not render an empty list', () => {
+      const wrapper = mount(MessageList);
+
+      expect(wrapper.html()).toBe('');
+      wrapper.unmount();
+    });
+
+    it(':zIndex[number]', async () => {
+      const defaultWrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(defaultWrapper);
+      expect((defaultWrapper.element as HTMLElement).style.zIndex).toBe('0');
+      defaultWrapper.unmount();
+
+      const configuredWrapper = mount(MessageList, {
+        props: { placement: 'top', zIndex: DEFAULT_Z_INDEX },
+      });
+      await addMessage(configuredWrapper);
+      expect((configuredWrapper.element as HTMLElement).style.zIndex).toBe(String(DEFAULT_Z_INDEX));
+      configuredWrapper.unmount();
+
+      const customWrapper = mount(MessageList, { props: { placement: 'top', zIndex: 7001 } });
+      await addMessage(customWrapper);
+      expect((customWrapper.element as HTMLElement).style.zIndex).toBe('7001');
+      customWrapper.unmount();
+    });
+
+    it.each([
+      ['center', { left: '50%', top: '50%', transform: 'translateX(-50%) translateY(-50%)' }],
+      ['top', { left: '50%', top: '32px', transform: 'translateX(-50%)' }],
+      ['left', { left: '32px', top: '50%', transform: 'translateY(-50%)' }],
+      ['right', { right: '32px', top: '50%', transform: 'translateY(-50%)' }],
+      ['bottom', { bottom: '32px', left: '50%', transform: 'translateX(-50%)' }],
+      ['top-left', { left: '32px', top: '32px' }],
+      ['top-right', { right: '32px', top: '32px' }],
+      ['bottom-left', { bottom: '32px', left: '32px' }],
+      ['bottom-right', { bottom: '32px', right: '32px' }],
+    ] as const)(':placement[string] applies the %s placement', async (placement, expectedStyles) => {
+      const wrapper = mount(MessageList, { props: { placement } });
+      await addMessage(wrapper);
+      const element = wrapper.element as HTMLElement;
+
+      Object.entries(expectedStyles).forEach(([property, value]) => {
+        expect(element.style.getPropertyValue(property)).toBe(value);
+      });
+      wrapper.unmount();
+    });
+
+    it(':offset[array<number>]', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { offset: [12, -4] });
+      const message = wrapper.find('.t-message').element as HTMLElement;
+
+      expect(message.style.position).toBe('relative');
+      expect(message.style.left).toBe('12px');
+      expect(message.style.top).toBe('-4px');
+      wrapper.unmount();
+    });
+
+    it(':offset[array<string>]', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { offset: ['2em', '3rem'] });
+      const message = wrapper.find('.t-message').element as HTMLElement;
+
+      expect(message.style.left).toBe('2em');
+      expect(message.style.top).toBe('3rem');
+      wrapper.unmount();
+    });
+
+    it(':offset[array] treats zero as no inline offset', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { offset: [0, 0] });
+      const message = wrapper.find('.t-message').element as HTMLElement;
+
+      expect(message.style.left).toBe('');
+      expect(message.style.top).toBe('');
+      wrapper.unmount();
+    });
+
+    it(':className[string]', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { className: 'custom-message' });
+
+      expect(wrapper.find('.t-message').classes()).toContain('custom-message');
+      wrapper.unmount();
+    });
+
+    it(':style[object]', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { style: { color: 'rgb(255, 0, 0)' } });
+
+      expect((wrapper.find('.t-message').element as HTMLElement).style.color).toBe('rgb(255, 0, 0)');
+      wrapper.unmount();
+    });
+  });
+
+  describe('events', () => {
+    it('close-btn-click removes the selected message and preserves the callback', async () => {
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { closeBtn: true, content: 'first', onCloseBtnClick });
+      await addMessage(wrapper, { closeBtn: true, content: 'second' });
+
+      await wrapper.findAll('.t-message__close')[0].trigger('click');
+      expect(onCloseBtnClick).toHaveBeenCalledOnce();
+      expect(onCloseBtnClick).toHaveBeenCalledWith({ e: expect.any(MouseEvent) });
+      expect(wrapper.findAll('.t-message')).toHaveLength(1);
+      expect(wrapper.find('.t-message').text()).toContain('second');
+      wrapper.unmount();
+    });
+
+    it('duration-end removes the message and preserves the callback', async () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      getExposed(wrapper).add({ content: 'timed', duration: 30, onDurationEnd });
+      await nextTick();
+
+      vi.advanceTimersByTime(30);
+      await nextTick();
+      expect(onDurationEnd).toHaveBeenCalledOnce();
+      expect(wrapper.find('.t-message').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it('currently leaves one message when two messages expire in the same timer turn', async () => {
+      vi.useFakeTimers();
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      getExposed(wrapper).add({ content: 'first', duration: 30 });
+      getExposed(wrapper).add({ content: 'second', duration: 30 });
+      await nextTick();
+
+      vi.advanceTimersByTime(30);
+      await nextTick();
+
+      // Both callbacks capture their original array index; the second splice uses a stale index.
+      expect(wrapper.findAll('.t-message')).toHaveLength(1);
+      expect(wrapper.find('.t-message').text()).toContain('second');
+      wrapper.unmount();
+    });
+  });
+
+  describe('instanceFunctions', () => {
+    it('add() appends messages and returns unique keys', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      const firstKey = await addMessage(wrapper, { content: 'first' });
+      const secondKey = await addMessage(wrapper, { content: 'second' });
+      const exposed = getExposed(wrapper);
+
+      expect(secondKey).toBeGreaterThan(firstKey);
+      expect(exposed.list.value.map((item) => item.content)).toEqual(['first', 'second']);
+      expect(wrapper.findAll('.t-message')).toHaveLength(2);
+      expect(exposed.messageList.value.length).toBeGreaterThanOrEqual(2);
+      expect(typeof exposed.messageList.value[0].close).toBe('function');
+      wrapper.unmount();
+    });
+
+    it('messageList currently accumulates duplicate refs after an append rerender', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { content: 'first' });
+      await addMessage(wrapper, { content: 'second' });
+
+      // The ref callback only appends, so the first component is collected again on rerender.
+      expect(getExposed(wrapper).messageList.value).toHaveLength(3);
+      wrapper.unmount();
+    });
+
+    it('removeAll() removes every message', async () => {
+      const wrapper = mount(MessageList, { props: { placement: 'top' } });
+      await addMessage(wrapper, { content: 'first' });
+      await addMessage(wrapper, { content: 'second' });
+
+      getExposed(wrapper).removeAll();
+      await nextTick();
+      expect(getExposed(wrapper).list.value).toEqual([]);
+      expect(wrapper.find('.t-message__list').exists()).toBe(false);
+      wrapper.unmount();
+    });
+  });
+});

--- a/packages/components/message/__tests__/message.plugin.test.tsx
+++ b/packages/components/message/__tests__/message.plugin.test.tsx
@@ -1,0 +1,303 @@
+/* eslint-disable vue/one-component-per-file */
+import { createApp, defineComponent, h, inject, nextTick } from 'vue';
+import type { AppContext } from 'vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessagePlugin } from '@tdesign/components/message';
+import type { MessageInstance, MessageOptions } from '@tdesign/components/message';
+
+const EmptyApp = defineComponent({
+  render() {
+    return h('div');
+  },
+});
+
+describe('MessagePlugin', () => {
+  let initialBodyChildren: Set<Element>;
+  let attachId = 0;
+
+  const createAttach = () => {
+    attachId += 1;
+    const element = document.createElement('div');
+    element.id = `message-test-attach-${attachId}`;
+    document.body.appendChild(element);
+    return element;
+  };
+
+  const permanentOptions = (attach: HTMLElement, options: MessageOptions = {}): MessageOptions => ({
+    attach: () => attach,
+    duration: 0,
+    ...options,
+  });
+
+  beforeEach(() => {
+    initialBodyChildren = new Set(document.body.children);
+    Reflect.deleteProperty(MessagePlugin, '_context');
+  });
+
+  afterEach(async () => {
+    MessagePlugin.closeAll();
+    await nextTick();
+    Array.from(document.body.children).forEach((element) => {
+      if (!initialBodyChildren.has(element)) element.remove();
+    });
+    Reflect.deleteProperty(MessagePlugin, '_context');
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it(':message[string]', async () => {
+      const instance = await MessagePlugin('warning', 'String message', 0);
+      const message = document.querySelector('.t-message');
+
+      expect(instance).toBeDefined();
+      expect(message?.textContent).toContain('String message');
+      expect(message?.classList).toContain('t-is-warning');
+    });
+
+    it(':message[VNode]', async () => {
+      await MessagePlugin('info', h('span', { class: 'vnode-message' }, 'VNode message') as unknown as string, 0);
+
+      expect(document.querySelector('.vnode-message')?.textContent).toBe('VNode message');
+    });
+
+    it(':message[object]', async () => {
+      const attach = createAttach();
+      await MessagePlugin(
+        'success',
+        permanentOptions(attach, {
+          content: () => <strong class="object-message">Object message</strong>,
+        }),
+      );
+
+      expect(attach.querySelector('.object-message')?.textContent).toBe('Object message');
+      expect(attach.querySelector('.t-message')?.classList).toContain('t-is-success');
+    });
+
+    it(':message[array] currently ignores unsupported array input', async () => {
+      // Arrays are not part of the public type; this verifies the runtime guard around object options.
+      await MessagePlugin('info', [] as unknown as string, 0);
+
+      expect(document.querySelector('.t-message')).not.toBeNull();
+      expect(document.querySelector('.t-message')?.textContent).toBe('');
+    });
+
+    it.each([
+      ['info', MessagePlugin.info],
+      ['success', MessagePlugin.success],
+      ['warning', MessagePlugin.warning],
+      ['error', MessagePlugin.error],
+      ['question', MessagePlugin.question],
+      ['loading', MessagePlugin.loading],
+    ] as const)('%s(message) creates the corresponding theme', async (theme, showMessage) => {
+      const attach = createAttach();
+      await showMessage(permanentOptions(attach, { content: `${theme} message` }));
+
+      const message = attach.querySelector('.t-message');
+      expect(message?.textContent).toContain(`${theme} message`);
+      expect(message?.classList).toContain(`t-is-${theme}`);
+    });
+
+    it(':duration[number] accepts zero as the second argument', async () => {
+      vi.useFakeTimers();
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { content: 'Persistent', duration: 20 }), 0);
+
+      vi.runAllTimers();
+      await nextTick();
+      expect(attach.querySelector('.t-message')).not.toBeNull();
+    });
+
+    it(':attach[string]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info({ content: 'Selector attach', attach: `#${attach.id}`, duration: 0 });
+
+      expect(attach.querySelector('.t-message')?.textContent).toContain('Selector attach');
+    });
+
+    it(':attach[function]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { content: 'Function attach' }));
+
+      expect(attach.querySelector('.t-message')?.textContent).toContain('Function attach');
+    });
+
+    it(':className[string]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { className: 'plugin-message' }));
+
+      expect(attach.querySelector('.t-message')?.classList).toContain('plugin-message');
+    });
+
+    it(':offset[array]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { offset: [14, '2rem'] }));
+      const message = attach.querySelector('.t-message') as HTMLElement;
+
+      expect(message.style.left).toBe('14px');
+      expect(message.style.top).toBe('2rem');
+    });
+
+    it.each([
+      'center',
+      'top',
+      'left',
+      'right',
+      'bottom',
+      'top-left',
+      'top-right',
+      'bottom-left',
+      'bottom-right',
+    ] as const)(':placement[string] creates the %s list', async (placement) => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { content: placement, placement }));
+
+      expect(attach.querySelector('.t-message__list')).not.toBeNull();
+      expect(attach.querySelector('.t-message')?.textContent).toContain(placement);
+    });
+
+    it(':style[object]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { style: { color: 'rgb(0, 0, 255)' } }));
+
+      expect((attach.querySelector('.t-message') as HTMLElement).style.color).toBe('rgb(0, 0, 255)');
+    });
+
+    it(':zIndex[number]', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { zIndex: 7002 }));
+
+      expect((attach.querySelector('.t-message__list') as HTMLElement).style.zIndex).toBe('7002');
+    });
+
+    it(':context[AppContext]', async () => {
+      const attach = createAttach();
+      const app = createApp(EmptyApp);
+      app.provide('message-context', 'direct context');
+      const ContextConsumer = defineComponent({
+        setup() {
+          const value = inject('message-context');
+          return () => <span class="context-value">{String(value)}</span>;
+        },
+      });
+      const context = Reflect.get(app, '_context') as AppContext;
+
+      await MessagePlugin.info(permanentOptions(attach, { content: () => <ContextConsumer /> }), 0, context);
+      expect(attach.querySelector('.context-value')?.textContent).toBe('direct context');
+    });
+  });
+
+  describe('instanceFunctions', () => {
+    it('reuses one list for the same attach and placement', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { content: 'first' }));
+      await MessagePlugin.info(permanentOptions(attach, { content: 'second' }));
+      await MessagePlugin.info(permanentOptions(attach, { content: 'third' }));
+
+      expect(attach.querySelectorAll('.t-message__list')).toHaveLength(1);
+      expect(attach.querySelectorAll('.t-message')).toHaveLength(3);
+    });
+
+    it('creates separate lists for different placements', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { placement: 'top' }));
+      await MessagePlugin.info(permanentOptions(attach, { placement: 'bottom' }));
+
+      expect(attach.querySelectorAll('.t-message__list')).toHaveLength(2);
+    });
+
+    it('creates separate lists for different attach nodes', async () => {
+      const firstAttach = createAttach();
+      const secondAttach = createAttach();
+      await MessagePlugin.info(permanentOptions(firstAttach));
+      await MessagePlugin.info(permanentOptions(secondAttach));
+
+      expect(firstAttach.querySelectorAll('.t-message__list')).toHaveLength(1);
+      expect(secondAttach.querySelectorAll('.t-message__list')).toHaveLength(1);
+    });
+
+    it('recreates a cached list after its wrapper is detached', async () => {
+      const attach = createAttach();
+      await MessagePlugin.info(permanentOptions(attach, { content: 'first' }));
+      attach.firstElementChild?.remove();
+
+      await MessagePlugin.info(permanentOptions(attach, { content: 'second' }));
+      expect(attach.querySelectorAll('.t-message__list')).toHaveLength(1);
+      expect(attach.querySelector('.t-message')?.textContent).toContain('second');
+    });
+
+    it('returned close() removes its message', async () => {
+      const attach = createAttach();
+      const instance = await MessagePlugin.info(permanentOptions(attach, { closeBtn: true }));
+
+      instance.close();
+      await nextTick();
+      expect(attach.querySelector('.t-message')).toBeNull();
+    });
+
+    it('close() delegates to the resolved message instance', async () => {
+      const attach = createAttach();
+      const promise = MessagePlugin.info(permanentOptions(attach, { closeBtn: true }));
+      const instance = await promise;
+      const closeSpy = vi.spyOn(instance, 'close');
+
+      MessagePlugin.close(promise);
+      await Promise.resolve();
+      expect(closeSpy).toHaveBeenCalledOnce();
+    });
+
+    it('close() tolerates an unresolved message instance', async () => {
+      const emptyPromise = Promise.resolve(undefined as unknown as MessageInstance);
+
+      expect(() => MessagePlugin.close(emptyPromise)).not.toThrow();
+      await emptyPromise;
+    });
+
+    it('closeAll() removes messages from every attach and placement', async () => {
+      const firstAttach = createAttach();
+      const secondAttach = createAttach();
+      await MessagePlugin.info(permanentOptions(firstAttach, { placement: 'top' }));
+      await MessagePlugin.error(permanentOptions(firstAttach, { placement: 'bottom' }));
+      await MessagePlugin.success(permanentOptions(secondAttach, { placement: 'top' }));
+
+      MessagePlugin.closeAll();
+      await nextTick();
+      expect(firstAttach.querySelector('.t-message')).toBeNull();
+      expect(secondAttach.querySelector('.t-message')).toBeNull();
+    });
+
+    it('config() is currently missing although it is documented', () => {
+      // Keep the current public surface visible until the documented API is implemented or removed.
+      expect(Reflect.get(MessagePlugin, 'config')).toBeUndefined();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('install() exposes the callable plugin and all implemented methods', () => {
+      const app = createApp(EmptyApp);
+
+      MessagePlugin.install(app);
+      const installed = app.config.globalProperties.$message;
+      expect(installed).toBe(MessagePlugin);
+      ['info', 'success', 'warning', 'error', 'question', 'loading', 'close', 'closeAll'].forEach((method) => {
+        expect(typeof installed[method]).toBe('function');
+      });
+    });
+
+    it('uses the application context captured by install()', async () => {
+      const attach = createAttach();
+      const app = createApp(EmptyApp);
+      app.provide('installed-message-context', 'installed context');
+      MessagePlugin.install(app);
+      const ContextConsumer = defineComponent({
+        setup() {
+          const value = inject('installed-message-context');
+          return () => <span class="installed-context-value">{String(value)}</span>;
+        },
+      });
+
+      await MessagePlugin.info(permanentOptions(attach, { content: () => <ContextConsumer /> }));
+      expect(attach.querySelector('.installed-context-value')?.textContent).toBe('installed context');
+    });
+  });
+});

--- a/packages/components/message/__tests__/message.test.tsx
+++ b/packages/components/message/__tests__/message.test.tsx
@@ -1,104 +1,282 @@
-// @ts-nocheck
+import { h, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
-import { CloseIcon, InfoCircleFilledIcon } from 'tdesign-icons-vue-next';
-import { Message, MessagePlugin } from '@tdesign/components/message';
-import { nextTick } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  CheckCircleFilledIcon,
+  CloseIcon,
+  ErrorCircleFilledIcon,
+  HelpCircleFilledIcon,
+  InfoCircleFilledIcon,
+} from 'tdesign-icons-vue-next';
+import { Loading } from '@tdesign/components/loading';
+import { Message } from '@tdesign/components/message';
+import messageProps from '@tdesign/components/message/props';
 
-const text = '这是一条Message信息';
+const content = 'This is a message';
 
 describe('Message', () => {
-  describe(':props', () => {
-    it('', () => {
-      const wrapper = mount(() => <Message content={text} />);
-      const message = wrapper.find('.t-message');
-      expect(message.exists()).toBeTruthy();
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it('renders the root element', () => {
+      const wrapper = mount(Message, { props: { duration: 0 } });
+
+      expect(wrapper.classes()).toContain('t-message');
+      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(true);
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(false);
+      wrapper.unmount();
     });
 
-    it(':content', () => {
-      const wrapper = mount(() => <Message content={text} />);
-      const message = wrapper.find('.t-message');
-      expect(message.text()).toBe(text);
+    it(':closeBtn[boolean]', async () => {
+      const wrapper = mount(Message, { props: { closeBtn: false, duration: 0 } });
+
+      expect(wrapper.classes()).not.toContain('t-is-closable');
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(false);
+
+      await wrapper.setProps({ closeBtn: true });
+      expect(wrapper.classes()).toContain('t-is-closable');
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(true);
+      wrapper.unmount();
     });
 
-    it(':closeBtn', () => {
-      const wrapper = mount(() => <Message content={text} closeBtn />);
-      const message = wrapper.find('.t-message');
-      expect(message.findComponent(CloseIcon)).toBeTruthy();
+    it(':closeBtn[string]', () => {
+      const wrapper = mount(Message, { props: { closeBtn: 'Dismiss', duration: 0 } });
+
+      expect(wrapper.classes()).toContain('t-is-closable');
+      expect(wrapper.find('.t-message__close').text()).toBe('Dismiss');
+      wrapper.unmount();
     });
 
-    it(':icon', () => {
-      const wrapper = mount(() => <Message content={text} />);
-      const message = wrapper.find('.t-message');
-      expect(message.findComponent(InfoCircleFilledIcon)).toBeTruthy();
-    });
-
-    it(':theme', () => {
-      const themeList = ['info', 'success', 'warning', 'error', 'question', 'loading'];
-      themeList.forEach((theme) => {
-        const wrapper = mount(() => <Message content={text} theme={theme} />);
-        const message = wrapper.find('.t-message');
-        expect(message.classes()).toContain(`t-is-${theme}`);
+    it(':closeBtn[function]', () => {
+      const wrapper = mount(Message, {
+        props: {
+          closeBtn: () => <button class="custom-close">Dismiss</button>,
+          duration: 0,
+        },
       });
+
+      expect(wrapper.find('.custom-close').text()).toBe('Dismiss');
+      wrapper.unmount();
     });
 
-    it(':onCloseBtnClick', async () => {
-      const fn = vi.fn();
-      const wrapper = mount(() => <Message content={text} closeBtn onCloseBtnClick={fn} />);
-      const closeBtn = wrapper.findComponent(CloseIcon);
-      await closeBtn.trigger('click');
-      expect(fn).toBeCalled();
+    it(':closeBtn[slot]', () => {
+      const wrapper = mount(Message, {
+        props: { duration: 0 },
+        slots: { closeBtn: () => <button class="slot-close">Slot close</button> },
+      });
+
+      expect(wrapper.classes()).toContain('t-is-closable');
+      expect(wrapper.find('.slot-close').text()).toBe('Slot close');
+      wrapper.unmount();
     });
 
-    it(':onClose', async () => {
+    it(':content[string]', () => {
+      const wrapper = mount(Message, { props: { content, duration: 0 } });
+
+      expect(wrapper.text()).toContain(content);
+      wrapper.unmount();
+    });
+
+    it(':content[function]', () => {
+      const wrapper = mount(Message, {
+        props: {
+          content: () => <strong class="function-content">Function content</strong>,
+          duration: 0,
+        },
+      });
+
+      expect(wrapper.find('.function-content').text()).toBe('Function content');
+      wrapper.unmount();
+    });
+
+    it(':content[slot]', () => {
+      const wrapper = mount(Message, {
+        props: { duration: 0 },
+        slots: { default: () => <span class="slot-content">Slot content</span> },
+      });
+
+      expect(wrapper.find('.slot-content').text()).toBe('Slot content');
+      wrapper.unmount();
+    });
+
+    it(':duration[number]', async () => {
+      vi.useFakeTimers();
       const onClose = vi.fn();
-      const wrapper = mount(() => <Message content={text} closeBtn onClose={onClose} />);
-      const closeBtn = wrapper.findComponent(CloseIcon);
-      await closeBtn.trigger('click');
-      expect(onClose).toBeCalled();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(Message, {
+        props: { duration: 100, onClose, onDurationEnd, placement: 'top' },
+      });
+
+      vi.advanceTimersByTime(99);
+      expect(onDurationEnd).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      await nextTick();
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onClose).toHaveBeenCalledWith({ trigger: 'duration-end' });
+      expect(onDurationEnd).toHaveBeenCalledOnce();
+      wrapper.unmount();
     });
 
-    it(':onDurationEnd', () => {
+    it(':duration[zero]', async () => {
       vi.useFakeTimers();
       const onDurationEnd = vi.fn();
-      mount(() => <Message duration={3000} onDurationEnd={onDurationEnd} />);
-      expect(onDurationEnd).not.toBeCalled();
+      const wrapper = mount(Message, { props: { duration: 0, onDurationEnd } });
+
+      await wrapper.trigger('mouseleave');
       vi.runAllTimers();
-      expect(onDurationEnd).toHaveBeenCalledTimes(1);
+      expect(onDurationEnd).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it(':icon[boolean]', async () => {
+      const wrapper = mount(Message, { props: { duration: 0, icon: false } });
+
+      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(false);
+
+      await wrapper.setProps({ icon: true });
+      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':icon[function]', () => {
+      const icon = vi.fn(() => h('span', { class: 'function-icon' }, 'icon'));
+      const wrapper = mount(Message, { props: { duration: 0, icon } });
+
+      expect(icon).toHaveBeenCalledWith(h);
+      expect(wrapper.find('.function-icon').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':icon[slot]', () => {
+      const wrapper = mount(Message, {
+        props: { duration: 0 },
+        slots: { icon: () => <span class="slot-icon">icon</span> },
+      });
+
+      expect(wrapper.find('.slot-icon').exists()).toBe(true);
+      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it.each([
+      ['info', InfoCircleFilledIcon],
+      ['success', CheckCircleFilledIcon],
+      ['warning', ErrorCircleFilledIcon],
+      ['error', ErrorCircleFilledIcon],
+      ['question', HelpCircleFilledIcon],
+      ['loading', Loading],
+    ] as const)(':theme[string] renders the %s theme', (theme, Icon) => {
+      const wrapper = mount(Message, { props: { duration: 0, theme } });
+
+      expect(wrapper.classes()).toContain(`t-is-${theme}`);
+      expect(wrapper.findComponent(Icon).exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':theme[string] validates supported values', () => {
+      const validator = messageProps.theme.validator;
+
+      expect(validator(undefined)).toBe(true);
+      expect(validator('success')).toBe(true);
+      // @ts-expect-error verify runtime validation for an unsupported value
+      expect(validator('unsupported')).toBe(false);
+    });
+
+    it(':className[string]', () => {
+      const wrapper = mount(Message, { props: { className: 'custom-message', duration: 0 } });
+
+      expect(wrapper.classes()).toContain('custom-message');
+      wrapper.unmount();
+    });
+
+    it(':placement[string]', () => {
+      const wrapper = mount(Message, { props: { duration: 0, placement: 'bottom' } });
+
+      expect((wrapper.element as HTMLElement).style.transform).toBe('translate3d(0, 0, 0)');
+      wrapper.unmount();
     });
   });
 
-  describe('MessagePlugin', () => {
-    beforeEach(() => {
-      MessagePlugin.closeAll();
+  describe('events', () => {
+    it('close', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(Message, { props: { closeBtn: true, duration: 0, onClose } });
+
+      await wrapper.find('.t-message__close').trigger('click');
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onClose).toHaveBeenCalledWith({
+        trigger: 'close-click',
+        e: expect.any(MouseEvent),
+      });
+      wrapper.unmount();
     });
 
-    it('should create only one instance per placement', async () => {
-      MessagePlugin.info('msg1', 0);
-      MessagePlugin.info('msg2', 0);
-      MessagePlugin.info('msg3', 0);
+    it('close-btn-click', async () => {
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(Message, { props: { closeBtn: true, duration: 0, onCloseBtnClick } });
 
-      await nextTick();
-
-      const messages = document.querySelectorAll('.t-message');
-      expect(messages.length).toBe(3);
-
-      const containers = document.querySelectorAll('.t-message__list');
-      expect(containers.length).toBe(1);
+      await wrapper.find('.t-message__close').trigger('click');
+      expect(onCloseBtnClick).toHaveBeenCalledOnce();
+      expect(onCloseBtnClick).toHaveBeenCalledWith({ e: expect.any(MouseEvent) });
+      wrapper.unmount();
     });
 
-    it('should close all messages with closeAll()', async () => {
-      MessagePlugin.info('msg1', 0);
-      MessagePlugin.info('msg2', 0);
+    it('duration-end', async () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(Message, { props: { duration: 20, onDurationEnd } });
 
+      vi.advanceTimersByTime(20);
       await nextTick();
+      expect(onDurationEnd).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    });
+  });
 
-      expect(document.querySelectorAll('.t-message').length).toBe(2);
+  describe('instanceFunctions', () => {
+    it('close()', () => {
+      const onClose = vi.fn();
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(Message, { props: { duration: 0, onClose, onCloseBtnClick } });
+      const event = new MouseEvent('click');
 
-      MessagePlugin.closeAll();
-      await nextTick();
+      wrapper.vm.$.exposed?.close(event);
+      expect(onClose).toHaveBeenCalledWith({ trigger: 'close-click', e: event });
+      expect(onCloseBtnClick).toHaveBeenCalledWith({ e: event });
+      wrapper.unmount();
+    });
+  });
 
-      expect(document.querySelectorAll('.t-message').length).toBe(0);
+  describe('lifecycle', () => {
+    it('pauses the timer on mouseenter and restarts it on mouseleave', async () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(Message, { props: { duration: 100, onDurationEnd } });
+
+      vi.advanceTimersByTime(50);
+      await wrapper.trigger('mouseenter');
+      vi.advanceTimersByTime(100);
+      expect(onDurationEnd).not.toHaveBeenCalled();
+
+      await wrapper.trigger('mouseleave');
+      vi.advanceTimersByTime(100);
+      expect(onDurationEnd).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    });
+
+    it('currently leaves its duration timer active after unmount', () => {
+      vi.useFakeTimers();
+      const wrapper = mount(Message, { props: { duration: 100 } });
+
+      expect(vi.getTimerCount()).toBe(1);
+      wrapper.unmount();
+
+      // Current source has no unmount cleanup. Keep this characterization until it is fixed.
+      expect(vi.getTimerCount()).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- directly replace the legacy 10-case `Message` suite and remove `@ts-nocheck`
- split coverage by real implementation unit: `Message`, `MessageList`, and `MessagePlugin`
- cover every Message prop/event, all MessageOptions, placement/offset/style behavior, exposed methods, plugin install/context/reuse/close flows, and lifecycle boundaries
- keep the change test-only and avoid snapshot assertions

## Coverage

| Scope | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| Message directory (before) | 90.25% | 81.03% | 60% | 90.25% |
| Message directory (after) | 100% | 100% | 100% | 100% |

The suite grows from 1 file / 10 tests to 3 files / 88 tests.

## Source behavior recorded by tests

- #6894: simultaneous duration expiry can leave a message behind; component refs accumulate; duration timers remain active after unmount
- #3246: the documented `MessagePlugin.config()` API is still absent (existing historical issue, not duplicated)

These cases assert the current runtime behavior so this test-only PR stays green. A future source fix will make the characterization tests fail and signal that their expectations should be updated.

## Validation

- `pnpm -C packages/tdesign-vue-next/test test:unit message/__tests__`
- `pnpm -C packages/tdesign-vue-next/test test:snap message/__tests__`
- `pnpm -C packages/tdesign-vue-next/test test:unit-coverage message`
- `pnpm lint:tsc`
- target ESLint with `--max-warnings 0`
- full `pnpm lint`
- full unit and snapshot suites

Related to #5631.
