### PR TITLE
test(notification): improve notification test coverage

### DIFF
--- a/packages/components/notification/__tests__/notification-list.test.tsx
+++ b/packages/components/notification/__tests__/notification-list.test.tsx
@@ -1,0 +1,206 @@
+import { nextTick } from 'vue';
+import type { Ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Notification from '@tdesign/components/notification/notification';
+import NotificationList from '@tdesign/components/notification/notification-list';
+import type { NotificationOptions } from '@tdesign/components/notification/type';
+
+const animationMocks = vi.hoisted(() => ({
+  fadeIn: vi.fn(),
+  fadeOut: vi.fn((_dom: HTMLElement, _placement: string, onFinish: () => void) => onFinish()),
+}));
+
+vi.mock('@tdesign/components/notification/utils', () => animationMocks);
+
+interface NotificationListExposed {
+  add: (options: NotificationOptions) => number;
+  remove: (index: number) => void;
+  removeAll: () => void;
+  list: Ref<NotificationOptions[]>;
+  notificationList: Ref<Array<{ close: () => void }>>;
+}
+
+const getExposed = (wrapper: VueWrapper) => wrapper.vm.$.exposed as unknown as NotificationListExposed;
+
+const addNotification = async (wrapper: VueWrapper, options: NotificationOptions = {}) => {
+  const index = getExposed(wrapper).add({ duration: 0, content: '通知内容', ...options });
+  await nextTick();
+  return index;
+};
+
+describe('NotificationList', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it(':placement[string]', async () => {
+      const cases = {
+        'top-left': { left: '16px', top: '16px' },
+        'top-right': { right: '16px', top: '16px' },
+        'bottom-left': { left: '16px', bottom: '16px' },
+        'bottom-right': { right: '16px', bottom: '16px' },
+      } as const;
+
+      for (const [placement, expectedStyle] of Object.entries(cases)) {
+        const wrapper = mount(NotificationList, { props: { placement } });
+        await addNotification(wrapper);
+        const element = wrapper.find('.t-notification-list__show').element as HTMLElement;
+
+        Object.entries(expectedStyle).forEach(([property, value]) => {
+          expect(element.style[property as 'left']).toBe(value);
+        });
+        expect(element.style.zIndex).toBe('6000');
+        wrapper.unmount();
+      }
+
+      const validator = NotificationList.props.placement.validator;
+      expect(validator('top-right')).toBe(true);
+      expect(validator('center')).toBe(false);
+    });
+
+    it(':offset[array<number>]', async () => {
+      const wrapper = mount(NotificationList, {
+        props: { placement: 'top-left', offset: [-10, 20] },
+      });
+      await addNotification(wrapper);
+      const element = wrapper.find('.t-notification-list__show').element as HTMLElement;
+
+      expect(element.style.left).toBe('-10px');
+      expect(element.style.top).toBe('20px');
+    });
+
+    it(':offset[array<string>]', async () => {
+      const wrapper = mount(NotificationList, {
+        props: { placement: 'bottom-right', offset: ['2rem', '3em'] },
+      });
+      await addNotification(wrapper);
+      const element = wrapper.find('.t-notification-list__show').element as HTMLElement;
+
+      expect(element.style.right).toBe('2rem');
+      expect(element.style.bottom).toBe('3em');
+    });
+
+    it(':offset[array] keeps defaults for invalid length', async () => {
+      const wrapper = mount(NotificationList, {
+        props: { placement: 'top-right', offset: [10] },
+      });
+      await addNotification(wrapper);
+      const element = wrapper.find('.t-notification-list__show').element as HTMLElement;
+
+      expect(element.style.right).toBe('16px');
+      expect(element.style.top).toBe('16px');
+    });
+
+    it(':offset[array<number>] currently treats zero as an absent offset', async () => {
+      const wrapper = mount(NotificationList, {
+        props: { placement: 'top-left', offset: [0, 0] },
+      });
+      await addNotification(wrapper);
+      const element = wrapper.find('.t-notification-list__show').element as HTMLElement;
+
+      // Current behavior: getOffset(0) returns undefined, so both values fall back to 16px.
+      expect(element.style.left).toBe('16px');
+      expect(element.style.top).toBe('16px');
+    });
+  });
+
+  describe('instanceFunctions', () => {
+    it(':add[function]', async () => {
+      const wrapper = mount(NotificationList);
+
+      expect(await addNotification(wrapper, { title: '第一条' })).toBe(0);
+      expect(await addNotification(wrapper, { title: '第二条' })).toBe(1);
+      expect(wrapper.findAllComponents(Notification)).toHaveLength(2);
+      expect(getExposed(wrapper).list.value).toHaveLength(2);
+    });
+
+    it(':remove[function]', async () => {
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { title: '第一条' });
+      await addNotification(wrapper, { title: '第二条' });
+
+      getExposed(wrapper).remove(0);
+      await nextTick();
+      expect(wrapper.findAllComponents(Notification)).toHaveLength(1);
+      expect(wrapper.text()).toContain('第二条');
+    });
+
+    it(':removeAll[function]', async () => {
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper);
+      await addNotification(wrapper);
+
+      getExposed(wrapper).removeAll();
+      await nextTick();
+      expect(wrapper.find('.t-notification-list__show').exists()).toBe(false);
+      expect(getExposed(wrapper).list.value).toHaveLength(0);
+    });
+
+    it(':notificationList[ref]', async () => {
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper);
+
+      expect(getExposed(wrapper).notificationList.value).toHaveLength(1);
+      expect(getExposed(wrapper).notificationList.value[0].close).toEqual(expect.any(Function));
+    });
+  });
+
+  describe('events', () => {
+    it(':onCloseBtnClick[function]', async () => {
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { closeBtn: true, onCloseBtnClick });
+
+      await wrapper.find('.t-message__close').trigger('click');
+      expect(onCloseBtnClick).toHaveBeenCalledWith({ e: expect.any(MouseEvent) });
+      expect(getExposed(wrapper).list.value).toHaveLength(0);
+    });
+
+    it(':onDurationEnd[function]', async () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { duration: 100, onDurationEnd });
+
+      vi.advanceTimersByTime(100);
+      await nextTick();
+      expect(onDurationEnd).toHaveBeenCalledTimes(1);
+      expect(getExposed(wrapper).list.value).toHaveLength(0);
+    });
+
+    it(':onClose[function]', async () => {
+      const onClose = vi.fn();
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { onClose });
+
+      getExposed(wrapper).notificationList.value[0].close();
+      await nextTick();
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(getExposed(wrapper).list.value).toHaveLength(0);
+    });
+  });
+
+  describe('styles', () => {
+    it(':zIndex[number]', async () => {
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { zIndex: 7001 });
+
+      const notification = wrapper.find('.t-notification').element as HTMLElement;
+      expect(notification.style.marginBottom).toBe('16px');
+      expect(notification.style.zIndex).toBe('7001');
+    });
+
+    it(':zIndex[number] omits the item z-index when it is zero', async () => {
+      const wrapper = mount(NotificationList);
+      await addNotification(wrapper, { zIndex: 0 });
+
+      const notification = wrapper.find('.t-notification').element as HTMLElement;
+      expect(notification.style.marginBottom).toBe('16px');
+      expect(notification.style.zIndex).toBe('');
+    });
+  });
+});

--- a/packages/components/notification/__tests__/notification-plugin.test.tsx
+++ b/packages/components/notification/__tests__/notification-plugin.test.tsx
@@ -1,0 +1,298 @@
+import { createApp, nextTick } from 'vue';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NotifyPlugin } from '@tdesign/components/notification';
+
+const animationMocks = vi.hoisted(() => ({
+  fadeIn: vi.fn(),
+  fadeOut: vi.fn((_dom: HTMLElement, _placement: string, onFinish: () => void) => onFinish()),
+}));
+
+vi.mock('@tdesign/components/notification/utils', () => animationMocks);
+
+const attachNodes: HTMLElement[] = [];
+const EmptyApp = { render: (): null => null };
+const attachTo = (element: HTMLElement) => () => element;
+
+const createAttach = (id?: string) => {
+  const element = document.createElement('div');
+  if (id) element.id = id;
+  document.body.appendChild(element);
+  attachNodes.push(element);
+  return element;
+};
+
+const flushPlugin = async () => {
+  await Promise.resolve();
+  await nextTick();
+};
+
+describe('NotifyPlugin', () => {
+  afterEach(async () => {
+    NotifyPlugin.closeAll();
+    await nextTick();
+    attachNodes.splice(0).forEach((element) => element.remove());
+    // eslint-disable-next-line no-underscore-dangle
+    NotifyPlugin._context = undefined;
+    vi.clearAllMocks();
+  });
+
+  describe('methods', () => {
+    it(':call[function]', async () => {
+      const attach = createAttach();
+      const instance = await NotifyPlugin('warning', {
+        attach: attachTo(attach),
+        title: '警告',
+        content: '通知内容',
+        duration: 0,
+      });
+
+      expect(instance.close).toEqual(expect.any(Function));
+      expect(attach.querySelector('.t-notification')).not.toBeNull();
+      expect(attach.querySelector('.t-is-warning')).not.toBeNull();
+    });
+
+    it.each(['info', 'success', 'warning', 'error'] as const)(':%s[function]', async (theme) => {
+      const attach = createAttach();
+      const instance = await NotifyPlugin[theme]({
+        attach: attachTo(attach),
+        content: `${theme} content`,
+        duration: 0,
+      });
+
+      expect(instance.close).toEqual(expect.any(Function));
+      expect(attach.querySelector(`.t-is-${theme}`)).not.toBeNull();
+      expect(attach.textContent).toContain(`${theme} content`);
+    });
+
+    it(':close[function]', async () => {
+      const attach = createAttach();
+      const notification = NotifyPlugin.info({ attach: attachTo(attach), content: '待关闭', duration: 0 });
+      await notification;
+
+      NotifyPlugin.close(notification);
+      await flushPlugin();
+      expect(attach.querySelector('.t-notification')).toBeNull();
+    });
+
+    it(':closeAll[function]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({ attach: attachTo(attach), content: '第一条', duration: 0 });
+      await NotifyPlugin.success({ attach: attachTo(attach), content: '第二条', duration: 0 });
+      expect(attach.querySelectorAll('.t-notification')).toHaveLength(2);
+
+      NotifyPlugin.closeAll();
+      await nextTick();
+      expect(attach.querySelectorAll('.t-notification')).toHaveLength(0);
+    });
+
+    it(':config[function] is not exposed by the current implementation', () => {
+      // Current behavior: the generated API documents config(), but the plugin does not implement it.
+      expect((NotifyPlugin as unknown as { config?: unknown }).config).toBeUndefined();
+    });
+  });
+
+  describe('options', () => {
+    it(':attach[string]', async () => {
+      const attach = createAttach('notification-string-attach');
+      await NotifyPlugin.info({ attach: '#notification-string-attach', content: '字符串挂载', duration: 0 });
+
+      expect(attach.querySelector('.t-notification')?.textContent).toContain('字符串挂载');
+    });
+
+    it(':attach[function]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({ attach: () => attach, content: '函数挂载', duration: 0 });
+
+      expect(attach.querySelector('.t-notification')?.textContent).toContain('函数挂载');
+    });
+
+    it(':attach[HTMLElement]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        // @ts-expect-error the runtime accepts HTMLElement although AttachNode omits it
+        attach,
+        content: '节点挂载',
+        duration: 0,
+      });
+
+      expect(attach.querySelector('.t-notification')?.textContent).toContain('节点挂载');
+    });
+
+    it(':className[string]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        attach: attachTo(attach),
+        className: 'custom-notification',
+        content: '内容',
+        duration: 0,
+      });
+
+      expect(attach.querySelector('.t-notification')?.classList).toContain('custom-notification');
+    });
+
+    it(':offset[array<string/number>]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        attach: attachTo(attach),
+        placement: 'bottom-left',
+        offset: ['2rem', 24],
+        content: '内容',
+        duration: 0,
+      });
+      const list = attach.querySelector('.t-notification-list__show') as HTMLElement;
+
+      expect(list.style.left).toBe('2rem');
+      expect(list.style.bottom).toBe('24px');
+    });
+
+    it(':placement[string] creates one list for each placement', async () => {
+      const attach = createAttach();
+      const placements = ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const;
+
+      await Promise.all(
+        placements.map((placement) =>
+          NotifyPlugin.info({ attach: attachTo(attach), placement, content: placement, duration: 0 }),
+        ),
+      );
+
+      expect(attach.querySelectorAll('.t-notification-list__show')).toHaveLength(4);
+      placements.forEach((placement) => expect(attach.textContent).toContain(placement));
+    });
+
+    it(':style[string]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        attach: attachTo(attach),
+        style: 'color: red; width: 320px;',
+        content: '内容',
+        duration: 0,
+      });
+      const notification = attach.querySelector('.t-notification') as HTMLElement;
+
+      expect(notification.style.color).toBe('red');
+      expect(notification.style.width).toBe('320px');
+    });
+
+    it(':style[object]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        attach: attachTo(attach),
+        style: { color: 'blue', width: '280px' },
+        content: '内容',
+        duration: 0,
+      });
+      const notification = attach.querySelector('.t-notification') as HTMLElement;
+
+      expect(notification.style.color).toBe('blue');
+      expect(notification.style.width).toBe('280px');
+    });
+
+    it(':zIndex[number]', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({ attach: attachTo(attach), zIndex: 7002, content: '内容', duration: 0 });
+      const notification = attach.querySelector('.t-notification') as HTMLElement;
+
+      expect(notification.style.zIndex).toBe('7002');
+    });
+
+    it('uses default options and an empty content fallback', async () => {
+      const instance = await NotifyPlugin.info({ duration: 0 });
+      const notification = document.body.querySelector('.t-notification') as HTMLElement;
+
+      expect(instance.close).toEqual(expect.any(Function));
+      expect(notification).not.toBeNull();
+      expect(notification.textContent).toBe('');
+      expect(notification.style.zIndex).toBe('6000');
+    });
+  });
+
+  describe('behavior', () => {
+    it('reuses one list for notifications with the same attach and placement', async () => {
+      const attach = createAttach();
+      await NotifyPlugin.info({
+        attach: attachTo(attach),
+        placement: 'top-right',
+        content: '第一条',
+        duration: 0,
+      });
+      await NotifyPlugin.success({
+        attach: attachTo(attach),
+        placement: 'top-right',
+        content: '第二条',
+        duration: 0,
+      });
+
+      expect(attach.querySelectorAll('.t-notification-list__show')).toHaveLength(1);
+      expect(attach.querySelectorAll('.t-notification')).toHaveLength(2);
+    });
+
+    it('keeps separate lists for different attach nodes', async () => {
+      const firstAttach = createAttach();
+      const secondAttach = createAttach();
+      await NotifyPlugin.info({ attach: attachTo(firstAttach), content: '第一处', duration: 0 });
+      await NotifyPlugin.info({ attach: attachTo(secondAttach), content: '第二处', duration: 0 });
+
+      expect(firstAttach.querySelectorAll('.t-notification')).toHaveLength(1);
+      expect(secondAttach.querySelectorAll('.t-notification')).toHaveLength(1);
+    });
+
+    it('returns an instance that closes one notification and calls onClose', async () => {
+      const attach = createAttach();
+      const onClose = vi.fn();
+      const instance = await NotifyPlugin.info({
+        attach: attachTo(attach),
+        content: '关闭单条',
+        duration: 0,
+        onClose,
+      });
+
+      instance.close();
+      await nextTick();
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(attach.querySelector('.t-notification')).toBeNull();
+    });
+  });
+
+  describe('install', () => {
+    it('registers $notify and all implemented methods', () => {
+      const app = createApp(EmptyApp);
+      app.use(NotifyPlugin);
+      const globalProperties = app.config.globalProperties as Record<string, any>;
+
+      expect(globalProperties.$notify).toEqual(expect.any(Function));
+      ['info', 'success', 'warning', 'error', 'close', 'closeAll'].forEach((method) => {
+        expect(globalProperties.$notify[method]).toEqual(expect.any(Function));
+      });
+      // Current behavior: docs/examples mention this alias, but install() only registers $notify.
+      expect(globalProperties.$notification).toBeUndefined();
+    });
+
+    it('accepts an explicit app context', async () => {
+      const app = createApp(EmptyApp);
+      const attach = createAttach();
+      // eslint-disable-next-line no-underscore-dangle
+      const appContext = app._context;
+      const instance = await NotifyPlugin.info(
+        { attach: attachTo(attach), content: '显式上下文', duration: 0 },
+        appContext,
+      );
+
+      expect(instance).toBeDefined();
+      expect(attach.textContent).toContain('显式上下文');
+    });
+
+    it('uses the context saved by install()', async () => {
+      const app = createApp(EmptyApp);
+      app.use(NotifyPlugin);
+      const attach = createAttach();
+      const instance = await NotifyPlugin.info({
+        attach: attachTo(attach),
+        content: '安装上下文',
+        duration: 0,
+      });
+
+      expect(instance).toBeDefined();
+      expect(attach.textContent).toContain('安装上下文');
+    });
+  });
+});

--- a/packages/components/notification/__tests__/notification.test.tsx
+++ b/packages/components/notification/__tests__/notification.test.tsx
@@ -1,164 +1,298 @@
-// @ts-nocheck
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
-import { InfoCircleFilledIcon } from 'tdesign-icons-vue-next';
-import { nextTick } from 'vue';
-import { Notification, NotifyPlugin } from '@tdesign/components/notification';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AppIcon, CheckCircleFilledIcon, CloseIcon, InfoCircleFilledIcon } from 'tdesign-icons-vue-next';
+import { Notification } from '@tdesign/components/notification';
+import notificationProps from '@tdesign/components/notification/props';
+
+const getCloseButton = (wrapper: VueWrapper) => wrapper.find('.t-message__close');
 
 describe('Notification', () => {
-  describe(':base', () => {
-    it('render', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification></Notification>;
-        },
-      });
-      expect(wrapper.find('.t-notification').exists()).toBeTruthy();
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it(':base', () => {
+      const wrapper = mount(Notification);
+
+      expect(wrapper.find('.t-notification').exists()).toBe(true);
+      expect(wrapper.find('.t-notification__main').exists()).toBe(true);
+      expect(wrapper.find('.t-notification__content').exists()).toBe(true);
     });
 
-    it('render title', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification title="标题"></Notification>;
-        },
+    it(':closeBtn[boolean]', async () => {
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(Notification, {
+        props: { closeBtn: false, onCloseBtnClick },
       });
-      expect(wrapper.find('.t-notification__title').text()).toBe('标题');
+
+      expect(wrapper.findComponent(CloseIcon).exists()).toBe(false);
+      // Current behavior: closeBtn=false hides its content but leaves a clickable wrapper in the DOM.
+      expect(getCloseButton(wrapper).exists()).toBe(true);
+      await getCloseButton(wrapper).trigger('click');
+      expect(onCloseBtnClick).toHaveBeenCalledTimes(1);
+
+      const defaultWrapper = mount(Notification, { props: { closeBtn: true } });
+      expect(defaultWrapper.findComponent(CloseIcon).exists()).toBe(true);
     });
 
-    it('render content', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification content="文案"></Notification>;
-        },
-      });
-      expect(wrapper.find('.t-notification__content').text()).toBe('文案');
+    it(':closeBtn[string]', () => {
+      const wrapper = mount(Notification, { props: { closeBtn: '关闭通知' } });
+
+      expect(getCloseButton(wrapper).text()).toBe('关闭通知');
     });
 
-    it('render default', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification default="文案"></Notification>;
-        },
+    it(':closeBtn[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { closeBtn: () => <button class="custom-close">自定义关闭</button> },
       });
-      expect(wrapper.find('.t-notification__content').text()).toBe('文案');
+
+      expect(wrapper.find('.custom-close').text()).toBe('自定义关闭');
     });
 
-    it('render icon', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification icon={() => <InfoCircleFilledIcon />} default="文案"></Notification>;
-        },
+    it(':closeBtn[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { closeBtn: () => <button class="slot-close">插槽关闭</button> },
       });
-      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(true);
+
+      expect(wrapper.find('.slot-close').text()).toBe('插槽关闭');
     });
 
-    it('render footer', () => {
-      const wrapper = mount({
-        render() {
-          return <Notification footer={() => <InfoCircleFilledIcon />} default="文案"></Notification>;
-        },
-      });
-      expect(wrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(true);
+    it(':content[string]', () => {
+      const wrapper = mount(Notification, { props: { content: '通知内容' } });
+
+      expect(wrapper.find('.t-notification__content').text()).toBe('通知内容');
     });
 
-    it('duration', () => {
-      const fn = vi.fn();
-      mount({
-        render() {
-          return <Notification duration={3000} onDurationEnd={fn}></Notification>;
-        },
+    it(':content[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { content: () => <span class="content-function">函数内容</span> },
       });
-      setTimeout(() => {
-        expect(fn).toBeCalled();
-      }, 3000);
+
+      expect(wrapper.find('.content-function').text()).toBe('函数内容');
+    });
+
+    it(':content[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { content: () => <span class="content-slot">插槽内容</span> },
+      });
+
+      expect(wrapper.find('.content-slot').text()).toBe('插槽内容');
+    });
+
+    it(':default[string]', () => {
+      const wrapper = mount(Notification, {
+        props: { default: '默认内容', content: '备用内容' },
+      });
+
+      expect(wrapper.find('.t-notification__content').text()).toBe('默认内容');
+    });
+
+    it(':default[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { default: () => <span class="default-function">函数默认内容</span> },
+      });
+
+      expect(wrapper.find('.default-function').text()).toBe('函数默认内容');
+    });
+
+    it(':default[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { default: () => <span class="default-slot">默认插槽内容</span> },
+      });
+
+      expect(wrapper.find('.default-slot').text()).toBe('默认插槽内容');
+    });
+
+    it(':duration[number]', () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      mount(Notification, { props: { duration: 100, onDurationEnd } });
+
+      expect(onDurationEnd).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(100);
+      expect(onDurationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it(':duration[number] does not start a timer when duration is 0', () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      mount(Notification, { props: { duration: 0, onDurationEnd } });
+
+      vi.runAllTimers();
+      expect(onDurationEnd).not.toHaveBeenCalled();
+    });
+
+    it(':duration[number] pauses on mouseenter and restarts on mouseleave', async () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      const wrapper = mount(Notification, { props: { duration: 100, onDurationEnd } });
+
+      vi.advanceTimersByTime(50);
+      await wrapper.trigger('mouseenter');
+      vi.advanceTimersByTime(100);
+      expect(onDurationEnd).not.toHaveBeenCalled();
+
+      await wrapper.trigger('mouseleave');
+      vi.advanceTimersByTime(100);
+      expect(onDurationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it(':footer[string]', () => {
+      const wrapper = mount(Notification, { props: { footer: '底部内容' } });
+
+      expect(wrapper.find('.t-notification__main').text()).toContain('底部内容');
+    });
+
+    it(':footer[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { footer: () => <footer class="footer-function">函数底部</footer> },
+      });
+
+      expect(wrapper.find('.footer-function').text()).toBe('函数底部');
+    });
+
+    it(':footer[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { footer: () => <footer class="footer-slot">插槽底部</footer> },
+      });
+
+      expect(wrapper.find('.footer-slot').text()).toBe('插槽底部');
+    });
+
+    it(':icon[boolean]', () => {
+      const hiddenWrapper = mount(Notification, { props: { icon: false } });
+      expect(hiddenWrapper.find('.t-notification__icon').exists()).toBe(false);
+
+      const visibleWrapper = mount(Notification, { props: { icon: true } });
+      expect(visibleWrapper.findComponent(InfoCircleFilledIcon).exists()).toBe(true);
+    });
+
+    it(':icon[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { icon: () => <AppIcon class="icon-function" /> },
+      });
+
+      expect(wrapper.findComponent(AppIcon).exists()).toBe(true);
+      expect(wrapper.find('.icon-function').exists()).toBe(true);
+    });
+
+    it(':icon[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { icon: () => <AppIcon class="icon-slot" /> },
+      });
+
+      expect(wrapper.findComponent(AppIcon).exists()).toBe(true);
+      expect(wrapper.find('.icon-slot').exists()).toBe(true);
+    });
+
+    it(':theme[string]', () => {
+      const validator = notificationProps.theme.validator;
+      expect(validator(undefined)).toBe(true);
+      expect(validator('success')).toBe(true);
+      // @ts-expect-error validate unsupported values
+      expect(validator('primary')).toBe(false);
+
+      const cases = [
+        { theme: 'info', icon: InfoCircleFilledIcon },
+        { theme: 'success', icon: CheckCircleFilledIcon },
+        { theme: 'warning', icon: InfoCircleFilledIcon },
+        { theme: 'error', icon: InfoCircleFilledIcon },
+      ] as const;
+
+      cases.forEach(({ theme, icon }) => {
+        const wrapper = mount(Notification, { props: { theme } });
+        expect(wrapper.findComponent(icon).exists()).toBe(true);
+        expect(wrapper.find(`.t-is-${theme}`).exists()).toBe(true);
+      });
+    });
+
+    it(':title[string]', () => {
+      const wrapper = mount(Notification, { props: { title: '通知标题' } });
+
+      expect(wrapper.find('.t-notification__title').text()).toBe('通知标题');
+    });
+
+    it(':title[function]', () => {
+      const wrapper = mount(Notification, {
+        props: { title: () => <strong class="title-function">函数标题</strong> },
+      });
+
+      expect(wrapper.find('.title-function').text()).toBe('函数标题');
+    });
+
+    it(':title[slot]', () => {
+      const wrapper = mount(Notification, {
+        slots: { title: () => <strong class="title-slot">插槽标题</strong> },
+      });
+
+      expect(wrapper.find('.title-slot').text()).toBe('插槽标题');
+    });
+
+    it(':className[string]', () => {
+      const wrapper = mount(Notification, { props: { className: 'custom-notification' } });
+
+      expect(wrapper.classes()).toContain('custom-notification');
+    });
+
+    it(':placement[string]', () => {
+      const wrapper = mount(Notification, { props: { placement: 'bottom-left' } });
+
+      expect(wrapper.props('placement')).toBe('bottom-left');
     });
   });
 
-  describe(':theme', () => {
-    ['info', 'success', 'warning', 'error'].map((item) =>
-      it(item, () => {
-        const wrapper = mount({
-          render() {
-            return <Notification theme={item}></Notification>;
-          },
-        });
-        expect(wrapper.find(`.t-is-${item}`).exists()).toBeTruthy();
-      }),
-    );
-  });
+  describe('events', () => {
+    it(':onCloseBtnClick[function]', async () => {
+      const onCloseBtnClick = vi.fn();
+      const wrapper = mount(Notification, { props: { closeBtn: true, onCloseBtnClick } });
 
-  describe(':event', () => {
-    it(':onCloseBtnClick', async () => {
-      const fn = vi.fn();
-      const wrapper = mount({
-        render() {
-          return <Notification closeBtn={true} onCloseBtnClick={fn}></Notification>;
-        },
-      });
-      const btn = wrapper.find('.t-message__close');
-      await nextTick();
-      await btn.trigger('click');
-      expect(fn).toBeCalled();
+      await getCloseButton(wrapper).trigger('click');
+      expect(onCloseBtnClick).toHaveBeenCalledTimes(1);
+      expect(onCloseBtnClick).toHaveBeenCalledWith({ e: expect.any(MouseEvent) });
+    });
+
+    it(':onClose[function]', () => {
+      const onClose = vi.fn();
+      const wrapper = mount(Notification, { props: { onClose } });
+
+      wrapper.vm.$.exposed.close();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it(':onDurationEnd[function]', () => {
+      vi.useFakeTimers();
+      const onDurationEnd = vi.fn();
+      mount(Notification, { props: { duration: 50, onDurationEnd } });
+
+      vi.advanceTimersByTime(50);
+      expect(onDurationEnd).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe(':plugin', () => {
-    it('call', async () => {
-      const fn = vi.fn();
-      const instance = await NotifyPlugin.info({
-        title: '标题',
-        content: '用户表示普通操作信息提示',
-        offset: [-10, 20],
-        closeBtn: true,
-        onCloseBtnClick: fn,
-      });
-      expect(document.querySelector(`.t-notification`)).toBeTruthy();
-      const btn = document.querySelector('.t-message__close');
-      await nextTick();
-      await btn.click();
-      instance.close();
-      expect(fn).toBeCalled();
+  describe('instanceFunctions', () => {
+    it(':close[function]', () => {
+      const wrapper = mount(Notification, { props: { placement: 'top-right' } });
+
+      wrapper.vm.$.exposed.close();
+      expect((wrapper.element as HTMLElement).style.display).toBe('none');
     });
+  });
 
-    ['top-left', 'top-right', 'bottom-left', 'bottom-right'].map((item) =>
-      it(item, async () => {
-        await NotifyPlugin.info({
-          title: '标题',
-          place: '用户表示普通操作信息提示',
-          offset: [-10, 20],
-          placement: item,
-          duration: 100,
-        });
-        setTimeout(() => {
-          expect(document.querySelector(`.t-notification`)).toBeFalsy();
-        }, 300);
-      }),
-    );
+  describe('lifecycle', () => {
+    it('runs the entrance animation after mount', () => {
+      const animate = vi.fn(() => ({ onfinish: null }));
+      Object.defineProperty(HTMLElement.prototype, 'animate', {
+        configurable: true,
+        value: animate,
+      });
+      const wrapper = mount(Notification, { props: { placement: 'top-left' } });
 
-    ['info', 'success', 'warning', 'error'].map((item) =>
-      it(item, async () => {
-        await NotifyPlugin[item]({
-          title: '标题',
-          content: '用户表示普通操作信息提示',
-          offset: [-10, 20],
-          closeBtn: true,
-          duration: 0,
-        });
-      }),
-    );
-
-    it('close-all', async () => {
-      expect(document.querySelector(`.t-notification`)).toBeTruthy();
-      setTimeout(() => {
-        NotifyPlugin.closeAll({
-          title: '标题',
-          content: '用户表示普通操作信息提示',
-          offset: [-10, 20],
-          closeBtn: true,
-          duration: 1000,
-        });
-        expect(document.querySelector(`.t-notification`)).toBeFalsy();
-      }, 1000);
+      expect(wrapper.exists()).toBe(true);
+      expect(animate).toHaveBeenCalledTimes(1);
+      delete HTMLElement.prototype.animate;
     });
   });
 });

--- a/packages/components/notification/__tests__/notification.utils.test.tsx
+++ b/packages/components/notification/__tests__/notification.utils.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fadeIn, fadeOut } from '@tdesign/components/notification/utils';
+
+const animationOptions = { duration: 200, easing: 'linear' };
+
+const createElement = (animate?: (keyframes: Keyframe[], options: KeyframeAnimationOptions) => Animation) => {
+  const element = document.createElement('div');
+  Object.defineProperty(element, 'offsetWidth', { configurable: true, value: 120 });
+  Object.defineProperty(element, 'offsetHeight', { configurable: true, value: 48 });
+  Object.defineProperty(element, 'animate', { configurable: true, value: animate });
+  return element;
+};
+
+describe('NotificationAnimation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fadeIn', () => {
+    it('does nothing without an element', () => {
+      expect(() => fadeIn(undefined as unknown as HTMLElement, 'top-right')).not.toThrow();
+    });
+
+    it('does nothing for an unsupported placement', () => {
+      const animate = vi.fn();
+      const element = createElement(animate);
+
+      fadeIn(element, 'center');
+      expect(animate).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        'top-right',
+        [
+          { opacity: 0, transform: 'translateX(120px)' },
+          { opacity: 1, transform: 'translateX(0px)' },
+        ],
+      ],
+      [
+        'bottom-right',
+        [
+          { opacity: 0, transform: 'translateX(120px)', marginBottom: '-48px' },
+          { opacity: 1, transform: 'translateX(0px)' },
+        ],
+      ],
+      [
+        'top-left',
+        [
+          { opacity: 0, transform: 'translateX(-120px)' },
+          { opacity: 1, transform: 'translateX(0px)' },
+        ],
+      ],
+      [
+        'bottom-left',
+        [
+          { opacity: 0, transform: 'translateX(-120px)', marginBottom: '-48px' },
+          { opacity: 1, transform: 'translateX(0px)' },
+        ],
+      ],
+    ])('animates the %s placement', (placement, keyframes) => {
+      const animate = vi.fn();
+      const element = createElement(animate);
+
+      fadeIn(element, placement as string);
+      expect(animate).toHaveBeenCalledWith(keyframes, animationOptions);
+    });
+
+    it('tolerates browsers without Element.animate()', () => {
+      const element = createElement();
+
+      expect(() => fadeIn(element, 'top-right')).not.toThrow();
+    });
+  });
+
+  describe('fadeOut', () => {
+    it('does nothing without an element', () => {
+      const onFinish = vi.fn();
+
+      fadeOut(undefined as unknown as HTMLElement, 'top-right', onFinish);
+      expect(onFinish).not.toHaveBeenCalled();
+    });
+
+    it('finishes immediately for an unsupported placement', () => {
+      const onFinish = vi.fn();
+      const element = createElement();
+
+      fadeOut(element, 'center', onFinish);
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      [
+        'top-right',
+        [
+          { opacity: 1, transform: 'translateX(0px)' },
+          { opacity: 0, transform: 'translateX(120px)', marginBottom: '-48px' },
+        ],
+      ],
+      [
+        'bottom-right',
+        [
+          { opacity: 1, transform: 'translateX(0px)' },
+          { opacity: 0, transform: 'translateX(120px)' },
+        ],
+      ],
+      [
+        'top-left',
+        [
+          { opacity: 1, transform: 'translateX(0px)' },
+          { opacity: 0, transform: 'translateX(-120px)', marginBottom: '-48px' },
+        ],
+      ],
+      [
+        'bottom-left',
+        [
+          { opacity: 1, transform: 'translateX(0px)' },
+          { opacity: 0, transform: 'translateX(-120px)' },
+        ],
+      ],
+    ])('animates the %s placement and finishes after the animation', (placement, keyframes) => {
+      const animation = { onfinish: null } as unknown as Animation;
+      const animate = vi.fn(() => animation);
+      const onFinish = vi.fn();
+      const element = createElement(animate);
+
+      fadeOut(element, placement as string, onFinish);
+      expect(animate).toHaveBeenCalledWith(keyframes, animationOptions);
+      expect(onFinish).not.toHaveBeenCalled();
+      animation.onfinish?.(new Event('finish') as AnimationPlaybackEvent);
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the element and finishes when Element.animate() is unavailable', () => {
+      const onFinish = vi.fn();
+      const element = createElement();
+
+      fadeOut(element, 'top-right', onFinish);
+      expect(element.style.display).toBe('none');
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Ref #5631
- Ref #6895
- 历史测试 PR：#2043

### 💡 需求背景和解决方案

本 PR 仅重写 Notification 测试，不修改组件源码。

原测试只有 1 个文件、22 个用例，包含 `ts-nocheck`；duration、placement 和 closeAll 等用例使用未等待的原生 `setTimeout`，实际断言不会执行。NotificationList、动画工具、插件安装、完整 options、实例方法，以及 String / Function / Slot 等 API 形态均缺少系统覆盖。

本次直接替换旧测试，重写为 4 个文件、83 个用例：

| 文件 | 用例数 | 覆盖内容 |
| --- | ---: | --- |
| `notification.test.tsx` | 31 | Notification 全部 props、TNode、events、instance functions、lifecycle、计时与悬停 |
| `notification-list.test.tsx` | 14 | placement / offset、列表增删、事件转发、子实例和样式 |
| `notification-plugin.test.tsx` | 24 | 插件主题方法、attach、options、复用/隔离、close / closeAll、install / appContext |
| `notification.utils.test.tsx` | 14 | 四个方位的 fadeIn / fadeOut、Web Animations API 有无时的分支及边界输入 |

测试结构参照 Form 组件规范：顶层按真实组件或工具命名，内部按 `props`、`events`、`instanceFunctions`、`lifecycle` 等组织；API 用例采用 `:prop[type]` 命名，String / Function / Slot 分开覆盖。没有场景式测试文件、快照断言或 `ts-nocheck`。

覆盖率结果：

- Notification 目录：Statements 88.99% → 99.38%，Branches 83.60% → 97.75%，Functions 76.66% → 100%，Lines 88.99% → 99.38%。
- `notification.tsx`：Statements 90.29% → 98.05%，Branches 84.21% → 96.29%，Functions 87.50% → 100%，Lines 90.29% → 98.05%。
- `notification-list.tsx`：Statements 89.58% → 100%，Branches 82.60% → 100%，Functions 75% → 100%，Lines 89.58% → 100%。
- `plugin.ts`：Statements 80.72% → 100%，Branches 88.23% → 96.15%，Functions 66.66% → 100%，Lines 80.72% → 100%。
- `notification/utils`：Statements 75% → 100%，Branches 80.76% → 100%，Functions 80% → 100%，Lines 75% → 100%。

重写过程中确认了 `closeBtn=false` 仍保留可点击容器、数值零 offset 被当作未传值、文档公开的 `NotifyPlugin.config()` 未实现、`this.$notification` 别名未注册等当前源码行为，详见 #6895。测试按当前真实行为断言并添加注释，源码修复后会自然提醒同步更新。

### ✅ 验证

- Notification 普通模式：4 files / 83 tests passed
- Notification snapshot 模式：4 files / 83 tests passed
- Notification coverage 模式：4 files / 83 tests passed
- Vue 全量普通模式：158 files / 3632 passed，2 skipped，3 todo
- Vue 全量 snapshot 模式：158 files / 3614 passed，20 skipped，3 todo
- `pnpm exec tsc --noEmit`
- ESLint `--max-warnings 0`
- `pnpm lint`

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须补充
