### PR TITLE
test(popup): improve popup test coverage

### DIFF
--- a/packages/components/popup/__tests__/popup.container.test.tsx
+++ b/packages/components/popup/__tests__/popup.container.test.tsx
@@ -1,0 +1,286 @@
+import { createCommentVNode, createTextVNode, defineComponent, Fragment, h, nextTick, ref } from 'vue';
+import { mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PopupContainer from '@tdesign/components/popup/container';
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  readonly observe = vi.fn();
+
+  readonly unobserve = vi.fn();
+
+  readonly disconnect = vi.fn();
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverMock.instances.push(this);
+  }
+
+  emit(contentRect: Partial<DOMRectReadOnly> = {}) {
+    this.callback(
+      [
+        {
+          contentRect: {
+            bottom: 0,
+            height: 10,
+            left: 0,
+            right: 0,
+            top: 0,
+            width: 10,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+            ...contentRect,
+          },
+        } as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+}
+
+const wrappers: VueWrapper[] = [];
+
+function mountContainer(
+  props: Record<string, unknown> = {},
+  slots: Record<string, any> = {
+    default: () => <button class="trigger">trigger</button>,
+    content: () => <div class="content">content</div>,
+  },
+) {
+  const wrapper = mount(PopupContainer, {
+    attachTo: document.body,
+    props: {
+      attach: 'body',
+      forwardRef: vi.fn(),
+      ...props,
+    },
+    slots,
+  });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+describe('PopupContainer', () => {
+  beforeEach(() => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    wrappers
+      .splice(0)
+      .reverse()
+      .forEach((wrapper) => wrapper.unmount());
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('props', () => {
+    it(':visible[boolean]', async () => {
+      const wrapper = mountContainer({ visible: false });
+      expect(document.querySelector('.content')).toBeNull();
+
+      await wrapper.setProps({ visible: true });
+      await nextTick();
+      expect(document.querySelector('.content')?.textContent).toBe('content');
+      expect(wrapper.emitted('contentMounted')).toHaveLength(1);
+    });
+
+    it(':attach[string]', async () => {
+      const target = document.createElement('div');
+      target.id = 'container-target';
+      document.body.appendChild(target);
+      mountContainer({ attach: '#container-target', visible: true });
+      await nextTick();
+
+      expect(target.querySelector('.content')?.textContent).toBe('content');
+    });
+
+    it(':attach[function]', async () => {
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      const attach = vi.fn(() => target);
+      mountContainer({ attach, visible: true });
+      await nextTick();
+
+      expect(attach).toHaveBeenCalled();
+      expect(target.querySelector('.content')?.textContent).toBe('content');
+    });
+
+    it(':forwardRef[function]', async () => {
+      const forwardRef = vi.fn();
+      const wrapper = mountContainer({ forwardRef });
+      await nextTick();
+
+      expect(forwardRef).toHaveBeenCalledWith(wrapper.find('.trigger').element);
+    });
+
+    it('forwards class attributes to the trigger', () => {
+      const wrapper = mount(PopupContainer, {
+        attrs: { class: 'custom-trigger-class', id: 'ignored-id' },
+        props: { attach: 'body', forwardRef: vi.fn() },
+        slots: { default: () => <button>trigger</button> },
+      });
+      wrappers.push(wrapper);
+
+      expect(wrapper.find('button').classes()).toContain('custom-trigger-class');
+      expect(wrapper.find('button').attributes('id')).toBeUndefined();
+    });
+  });
+
+  describe('slots', () => {
+    it('renders one element without an extra wrapper', () => {
+      const wrapper = mountContainer();
+      expect(wrapper.find('.trigger').element.tagName).toBe('BUTTON');
+      expect(wrapper.find('span').exists()).toBe(false);
+    });
+
+    it('wraps a text trigger in a span', () => {
+      const wrapper = mountContainer({}, { default: () => 'text trigger' });
+      expect(wrapper.find('span').text()).toBe('text trigger');
+    });
+
+    it('wraps multiple trigger nodes in a span', () => {
+      const wrapper = mountContainer(
+        {},
+        {
+          default: () => [<b class="first">first</b>, <i class="second">second</i>],
+        },
+      );
+      expect(wrapper.find('span').exists()).toBe(true);
+      expect(wrapper.findAll('span > *')).toHaveLength(2);
+    });
+
+    it('flattens an array nested in trigger nodes', () => {
+      const wrapper = mountContainer(
+        {},
+        {
+          default: () => [[<button class="nested-array-trigger">trigger</button>]],
+        },
+      );
+      expect(wrapper.find('.nested-array-trigger').exists()).toBe(true);
+    });
+
+    it('flattens fragments and removes comments and whitespace', () => {
+      const wrapper = mountContainer(
+        {},
+        {
+          default: () => [
+            createTextVNode('   '),
+            createCommentVNode('ignored'),
+            h(Fragment, null, [<button class="real-trigger">real trigger</button>]),
+          ],
+        },
+      );
+
+      expect(wrapper.find('.real-trigger').exists()).toBe(true);
+      expect(wrapper.find('span').exists()).toBe(false);
+    });
+
+    it('an empty Fragment currently throws while filtering trigger nodes', () => {
+      // Current behavior: filterEmpty recursively reads `children` from an empty Fragment, where Vue supplies null.
+      expect(() =>
+        mount(PopupContainer, {
+          props: { attach: 'body', forwardRef: vi.fn() },
+          slots: {
+            default: () => (
+              <Fragment>
+                <Fragment></Fragment>
+                <button>trigger</button>
+              </Fragment>
+            ),
+          },
+        }),
+      ).toThrow(TypeError);
+    });
+  });
+
+  describe('events', () => {
+    it('emits resize when the trigger rectangle changes', async () => {
+      const wrapper = mountContainer();
+      await nextTick();
+      const triggerObserver = ResizeObserverMock.instances.find((observer) =>
+        observer.observe.mock.calls.some(([element]) => (element as Element).classList?.contains('trigger')),
+      );
+
+      triggerObserver.emit({ height: 10, width: 10 });
+      await nextTick();
+      expect(wrapper.emitted('resize')).toHaveLength(1);
+
+      triggerObserver.emit({ height: 10, width: 10 });
+      await nextTick();
+      expect(wrapper.emitted('resize')).toHaveLength(1);
+
+      triggerObserver.emit({ height: 20, width: 10 });
+      await nextTick();
+      expect(wrapper.emitted('resize')).toHaveLength(2);
+    });
+
+    it('emits resize when the content resizes', async () => {
+      const wrapper = mountContainer({ visible: true });
+      await nextTick();
+      const contentObserver = ResizeObserverMock.instances.find((observer) =>
+        observer.observe.mock.calls.some(([element]) => (element as Element).classList?.contains('content')),
+      );
+
+      contentObserver.emit({ height: 30, width: 30 });
+      expect(wrapper.emitted('resize')).toHaveLength(1);
+    });
+  });
+
+  describe('instanceFunctions', () => {
+    it('unmountContent()', async () => {
+      const wrapper = mountContainer({ visible: true });
+      await nextTick();
+      expect(document.querySelector('.content')).not.toBeNull();
+
+      (wrapper.vm.$.exposed as { unmountContent: () => void }).unmountContent();
+      await nextTick();
+      expect(document.querySelector('.content')).toBeNull();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('updates the forwarded element when the trigger root changes', async () => {
+      const useAlternative = ref(false);
+      const forwardRef = vi.fn();
+      const Host = defineComponent(() => () => (
+        <PopupContainer attach="body" forwardRef={forwardRef}>
+          {useAlternative.value ? (
+            <div class="alternative-trigger">alternative</div>
+          ) : (
+            <button class="initial-trigger">initial</button>
+          )}
+        </PopupContainer>
+      ));
+      const wrapper = mount(Host, { attachTo: document.body });
+      wrappers.push(wrapper);
+      await nextTick();
+      expect(forwardRef).toHaveBeenLastCalledWith(wrapper.find('.initial-trigger').element);
+
+      useAlternative.value = true;
+      await nextTick();
+      expect(forwardRef).toHaveBeenLastCalledWith(wrapper.find('.alternative-trigger').element);
+    });
+
+    it('disconnects resize observers on unmount', async () => {
+      const wrapper = mountContainer({ visible: true });
+      await nextTick();
+      const observers = [...ResizeObserverMock.instances];
+
+      wrapper.unmount();
+      wrappers.splice(wrappers.indexOf(wrapper), 1);
+
+      observers.forEach((observer) => {
+        expect(observer.unobserve).toHaveBeenCalled();
+        expect(observer.disconnect).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/components/popup/__tests__/popup.test.tsx
+++ b/packages/components/popup/__tests__/popup.test.tsx
@@ -1,348 +1,1076 @@
-// @ts-nocheck
-import { mount } from '@vue/test-utils';
-import { describe, it, beforeEach, afterEach, expect } from 'vitest';
-import { usePrefixClass } from '@tdesign/shared-hooks';
+import { nextTick } from 'vue';
+import { mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Popup from '@tdesign/components/popup';
+import popupProps from '@tdesign/components/popup/props';
 
-const POPUPClASS = `.${usePrefixClass('popup').value}`;
+const { createPopperMock, popperInstances } = vi.hoisted(() => ({
+  createPopperMock: vi.fn(),
+  popperInstances: [] as Array<{
+    state: { elements: { reference: Element; popper: HTMLElement } };
+    update: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('@popperjs/core', () => ({
+  createPopper: createPopperMock,
+}));
+
+type PopupWrapper = VueWrapper<InstanceType<typeof Popup>>;
+
+const wrappers: PopupWrapper[] = [];
+const contentText = 'popup content';
+
+function getPopup() {
+  return document.querySelector<HTMLElement>('.t-popup');
+}
+
+function getPopupContent() {
+  return document.querySelector<HTMLElement>('.t-popup__content');
+}
+
+function getExposed(wrapper: PopupWrapper) {
+  return wrapper.vm.$.exposed as {
+    close: () => void;
+    getOverlay: () => HTMLElement | undefined;
+    getOverlayState: () => { hover: boolean };
+    getPopper: () => any;
+    update: () => void;
+  };
+}
+
+function mountPopup(
+  props: Record<string, unknown> = {},
+  slots: Record<string, any> = { default: () => <button class="trigger">trigger</button> },
+) {
+  const wrapper = mount(Popup, {
+    attachTo: document.body,
+    props,
+    slots,
+  }) as PopupWrapper;
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+async function flushRender() {
+  await nextTick();
+  await nextTick();
+}
+
+async function waitForTimeout() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushRender();
+}
+
+async function setVisible(wrapper: PopupWrapper, visible = true) {
+  await wrapper.setProps({ visible });
+  await flushRender();
+}
+
+function setRect(element: Element, rect: Partial<DOMRect>) {
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+    ...rect,
+  });
+}
+
 describe('Popup', () => {
   beforeEach(() => {
-    // create teleport target
-    const el = document.createElement('div');
-    el.id = 'container';
-    document.body.appendChild(el);
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      bottom: 10,
+      height: 10,
+      left: 0,
+      right: 10,
+      top: 0,
+      width: 10,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    popperInstances.length = 0;
+    createPopperMock.mockImplementation((reference: Element, popper: HTMLElement, options: Record<string, any>) => {
+      popper.setAttribute('data-popper-placement', options.placement);
+      const instance = {
+        state: { elements: { reference, popper } },
+        update: vi.fn(),
+        destroy: vi.fn(),
+      };
+      popperInstances.push(instance);
+      return instance;
+    });
   });
+
   afterEach(() => {
-    // clean up
-    document.body.outerHTML = '';
+    wrappers
+      .splice(0)
+      .reverse()
+      .forEach((wrapper) => wrapper.unmount());
+    document.body.innerHTML = '';
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    createPopperMock.mockReset();
   });
-  const content = '这里是弹出内容';
-  const visible = true;
-  describe(':props', () => {
-    /** 制定挂载节点  */
-    it(':attach into div#container', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-          attach: '#container',
-        },
-        slots: {
-          default: <button id="btn">触发器</button>,
-        },
-      });
-      await wrapper.setProps({
-        visible: true,
-      });
-      // 该组件不能用wrapper.html()来判断,本身组件不会有内容, 只是会插入到其他容器里
-      expect(document.querySelector('#container').innerHTML.includes(content)).toEqual(true);
+
+  describe('props', () => {
+    it(':attach[string]', async () => {
+      const target = document.createElement('div');
+      target.id = 'popup-container';
+      document.body.appendChild(target);
+      const wrapper = mountPopup({ attach: '#popup-container', content: contentText, visible: false });
+
+      await setVisible(wrapper);
+
+      expect(target.querySelector('.t-popup__content')?.textContent).toBe(contentText);
     });
 
-    /** 浮层里面的内容 */
-    it(':content from props', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-        },
-        slots: {
-          default: <button id="btn">触发器</button>,
-        },
-      });
-      await wrapper.setProps({
-        visible,
-      });
-      expect(document.querySelector(`${POPUPClASS}__content`).textContent).toEqual(content);
+    it(':attach[function]', async () => {
+      const target = document.createElement('div');
+      document.body.appendChild(target);
+      const attach = vi.fn(() => target);
+      const wrapper = mountPopup({ attach, content: contentText, visible: false });
+
+      await setVisible(wrapper);
+
+      expect(attach).toHaveBeenCalled();
+      expect(target.querySelector('.t-popup__content')?.textContent).toBe(contentText);
     });
-    /** 触发元素，同 triggerElement */
-    it(':default ', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">触发器</button>,
-        },
+
+    it(':content[string]', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+
+      expect(getPopupContent()?.textContent).toBe(contentText);
+      expect(getPopupContent()?.classList.contains('t-popup__content--text')).toBe(true);
+    });
+
+    it(':content[function]', async () => {
+      const wrapper = mountPopup({
+        content: () => <strong class="function-content">function content</strong>,
+        visible: false,
       });
-      await wrapper.setProps({
+      await setVisible(wrapper);
+
+      expect(getPopupContent()?.querySelector('.function-content')?.textContent).toBe('function content');
+      expect(getPopupContent()?.classList.contains('t-popup__content--text')).toBe(false);
+    });
+
+    it(':content[slot]', async () => {
+      const wrapper = mountPopup(
+        { visible: false },
+        {
+          default: () => <button class="trigger">trigger</button>,
+          content: () => <em class="slot-content">slot content</em>,
+        },
+      );
+      await setVisible(wrapper);
+
+      expect(getPopupContent()?.querySelector('.slot-content')?.textContent).toBe('slot content');
+    });
+
+    it(':default[string]', () => {
+      const wrapper = mountPopup({ default: 'text trigger' }, {});
+      expect(wrapper.text()).toBe('text trigger');
+      expect(wrapper.find('span').exists()).toBe(true);
+    });
+
+    it(':default[function]', () => {
+      const wrapper = mountPopup({ default: () => <button class="function-trigger">function trigger</button> }, {});
+      expect(wrapper.find('.function-trigger').text()).toBe('function trigger');
+    });
+
+    it(':default[slot]', () => {
+      const wrapper = mountPopup({}, { default: () => <button class="slot-trigger">slot trigger</button> });
+      expect(wrapper.find('.slot-trigger').text()).toBe('slot trigger');
+    });
+
+    it(':delay[number]', async () => {
+      vi.useFakeTimers();
+      const wrapper = mountPopup({ content: contentText, delay: 30 });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('mouseenter');
+      await vi.advanceTimersByTimeAsync(29);
+      expect(getPopup()).toBeNull();
+      await vi.advanceTimersByTimeAsync(1);
+      await flushRender();
+      expect(getPopup()?.style.display).not.toBe('none');
+
+      await wrapper.find('.trigger').trigger('mouseleave');
+      await vi.advanceTimersByTimeAsync(29);
+      expect(getPopup()?.style.display).not.toBe('none');
+      await vi.advanceTimersByTimeAsync(1);
+      await flushRender();
+      expect(getPopup()?.style.display).toBe('none');
+    });
+
+    it(':delay[array]', async () => {
+      vi.useFakeTimers();
+      const wrapper = mountPopup({ content: contentText, delay: [20, 40] });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('mouseenter');
+      await vi.advanceTimersByTimeAsync(20);
+      await flushRender();
+      expect(getPopup()?.style.display).not.toBe('none');
+
+      await wrapper.find('.trigger').trigger('mouseleave');
+      await vi.advanceTimersByTimeAsync(39);
+      expect(getPopup()?.style.display).not.toBe('none');
+      await vi.advanceTimersByTimeAsync(1);
+      await flushRender();
+      expect(getPopup()?.style.display).toBe('none');
+    });
+
+    it(':destroyOnClose[boolean]', async () => {
+      const retained = mountPopup({ content: contentText, visible: false });
+      await setVisible(retained);
+      await setVisible(retained, false);
+      expect(getPopup()).not.toBeNull();
+      expect(getPopup()?.style.display).toBe('none');
+      retained.unmount();
+      wrappers.splice(wrappers.indexOf(retained), 1);
+      document.body.innerHTML = '';
+
+      const destroyed = mountPopup({ content: contentText, destroyOnClose: true, visible: false });
+      await setVisible(destroyed);
+      expect(getPopup()).not.toBeNull();
+      await setVisible(destroyed, false);
+      expect(getPopup()).toBeNull();
+    });
+
+    it(':disabled[boolean]', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({
+        content: contentText,
+        disabled: true,
         trigger: 'click',
+        visible: false,
+        onVisibleChange,
       });
-      const btn = wrapper.find('#btn');
-      expect(document.querySelector(POPUPClASS)).toBeNull();
-      await btn.trigger('click');
-      expect(document.querySelector(POPUPClASS)).toBeDefined();
-    });
-    /** 延时显示或隐藏覆层，[延迟显示的时间，延迟隐藏的时间]，单位：毫秒。如果只有一个时间，则表示显示和隐藏的延迟时间相同。示例 `'300'` 或者 `[200, 200]`。默认为：[250, 150] */
-    it.skip(':delay', async () => {});
+      await flushRender();
 
-    /** 是否在关闭浮层时销毁浮层 */
-    it.skip(':destroyOnClose', () => {
-      // hover没实现 先跳过
+      await wrapper.find('.trigger').trigger('click');
+      await waitForTimeout();
+      expect(onVisibleChange).not.toHaveBeenCalled();
+      expect(getPopup()).toBeNull();
+
+      await wrapper.setProps({ visible: true });
+      await flushRender();
+      expect(getPopupContent()?.classList.contains('t-is-disabled')).toBe(true);
     });
-    /** 是否禁用组件 */
-    it(':disabled be true', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      await wrapper.setProps({
-        trigger: 'click',
-      });
-      const btn = wrapper.find('#btn');
-      btn.element.setAttribute('disabled', 'disabled');
-      await btn.trigger('click');
-      expect(document.body.textContent).toEqual('');
+
+    it.each([undefined, '', null])(':hideEmptyPopup[boolean] with content %s', async (content) => {
+      const wrapper = mountPopup({ content, hideEmptyPopup: true, visible: false });
+      await setVisible(wrapper);
+
+      expect(getPopup()?.style.visibility).toBe('hidden');
     });
-    /** 浮层内容部分类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]` */
-    it(':overlayInnerClassName', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-        },
-        slots: {
-          default: <button>触发器</button>,
-        },
-      });
-      const overlayInnerClassName = 'a-custom-class';
-      await wrapper.setProps({
-        overlayInnerClassName,
-        visible,
-      });
-      expect(document.querySelector(`${POPUPClASS}__content`).className.includes(overlayInnerClassName)).toEqual(true);
+
+    it.each([
+      ['string', 'outer-a outer-b'],
+      ['object', { 'outer-object': true }],
+      ['array', ['outer-array', { 'outer-enabled': true }]],
+    ])(':overlayClassName[%s]', async (_, overlayClassName) => {
+      const wrapper = mountPopup({ content: contentText, overlayClassName, visible: false });
+      await setVisible(wrapper);
+
+      expect(getPopup()?.className).toContain('outer');
     });
-    /** 浮层内容部分样式，第一个参数 `triggerElement` 表示触发元素 DOM 节点，第二个参数 `popupElement` 表示浮层元素 DOM 节点 */
-    it(':overlayInnerStyle', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-        },
-        slots: {
-          default: <button>触发器</button>,
-        },
-      });
-      const overlayInnerStyle = {
-        height: '666px',
-      };
-      await wrapper.setProps({
-        overlayInnerStyle,
-        visible,
-      });
-      expect(document.querySelector(`${POPUPClASS}__content`).style.cssText.includes('666px')).toEqual(true);
+
+    it.each([
+      ['string', 'inner-a inner-b'],
+      ['object', { 'inner-object': true }],
+      ['array', ['inner-array', { 'inner-enabled': true }]],
+    ])(':overlayInnerClassName[%s]', async (_, overlayInnerClassName) => {
+      const wrapper = mountPopup({ content: contentText, overlayInnerClassName, visible: false });
+      await setVisible(wrapper);
+
+      expect(getPopupContent()?.className).toContain('inner');
     });
-    /** 浮层样式，第一个参数 `triggerElement` 表示触发元素 DOM 节点，第二个参数 `popupElement` 表示浮层元素 DOM 节点 */
-    it(':overlayStyle', async () => {
-      // 有bug跳过, 会被覆盖
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-        },
-        slots: {
-          default: <button>触发器</button>,
-        },
-      });
-      const overlayStyle = {
-        height: '666px',
-      };
-      await wrapper.setProps({
-        overlayStyle,
-        content,
-        visible,
-      });
-      expect(document.body.innerHTML.includes('666px')).toEqual(true);
-      // typeof overlayStyle === 'function'
-      await wrapper.setProps({
-        overlayStyle(_triggerEl, _overlayEl) {
-          overlayStyle.height = '233px';
-          return overlayStyle;
-        },
-      });
-      expect(document.body.innerHTML.includes('233px')).toEqual(true);
+
+    it(':overlayInnerStyle[object]', async () => {
+      const wrapper = mountPopup({ content: contentText, overlayInnerStyle: { color: 'red' }, visible: false });
+      await setVisible(wrapper);
+
+      expect(getPopupContent()?.style.color).toBe('red');
     });
-    /** 浮层出现位置 */
-    const position = 'top';
-    it(`:placement be ${position}`, async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
+
+    it(':overlayInnerStyle[function]', async () => {
+      const overlayInnerStyle = vi.fn(() => ({ width: '120px' }));
+      const wrapper = mountPopup({ content: contentText, overlayInnerStyle, visible: false });
+      await setVisible(wrapper);
+
+      expect(overlayInnerStyle).toHaveBeenCalledWith(wrapper.find('.trigger').element, getPopupContent());
+      expect(getPopupContent()?.style.width).toBe('120px');
+    });
+
+    it(':overlayInnerStyle[boolean]', async () => {
+      const wrapper = mountPopup({ content: contentText, overlayInnerStyle: false, visible: false });
+      await setVisible(wrapper);
+      expect(getPopupContent()?.getAttribute('style')).toBeNull();
+    });
+
+    it(':overlayStyle[object]', async () => {
+      const wrapper = mountPopup({ content: contentText, overlayStyle: { color: 'blue' }, visible: false });
+      await setVisible(wrapper);
+      expect(getPopup()?.style.color).toBe('blue');
+    });
+
+    it(':overlayStyle[function]', async () => {
+      const overlayStyle = vi.fn(() => ({ width: '160px' }));
+      const wrapper = mountPopup({ content: contentText, overlayStyle, visible: false });
+      await setVisible(wrapper);
+
+      expect(overlayStyle).toHaveBeenCalledWith(wrapper.find('.trigger').element, getPopupContent());
+      expect(getPopup()?.style.width).toBe('160px');
+    });
+
+    it(':overlayStyle[boolean]', async () => {
+      const wrapper = mountPopup({ content: contentText, overlayStyle: false, visible: false });
+      await setVisible(wrapper);
+      expect(getPopup()?.style.color).toBe('');
+    });
+
+    it.each([
+      ['top', 'top'],
+      ['left', 'left'],
+      ['right', 'right'],
+      ['bottom', 'bottom'],
+      ['top-left', 'top-start'],
+      ['top-right', 'top-end'],
+      ['bottom-left', 'bottom-start'],
+      ['bottom-right', 'bottom-end'],
+      ['left-top', 'left-start'],
+      ['left-bottom', 'left-end'],
+      ['right-top', 'right-start'],
+      ['right-bottom', 'right-end'],
+    ])(':placement[%s]', async (placement, expected) => {
+      const wrapper = mountPopup({ content: contentText, placement, visible: false });
+      await setVisible(wrapper);
+
+      if (createPopperMock.mock.calls.length) {
+        expect(createPopperMock).toHaveBeenLastCalledWith(
+          wrapper.find('.trigger').element,
+          getPopup(),
+          expect.objectContaining({ placement: expected }),
+        );
+        expect(getPopup()?.dataset.popperPlacement).toBe(expected);
+      } else {
+        expect(getExposed(wrapper).getPopper().state.options.placement).toBe(expected);
+      }
+    });
+
+    it(':popperOptions[object]', async () => {
+      const modifiers = [{ name: 'flip', enabled: false }];
+      const wrapper = mountPopup({
+        content: contentText,
+        popperOptions: { placement: 'bottom', strategy: 'fixed', modifiers },
+        visible: false,
+      });
+      await setVisible(wrapper);
+
+      if (createPopperMock.mock.calls.length) {
+        expect(createPopperMock).toHaveBeenLastCalledWith(
+          wrapper.find('.trigger').element,
+          getPopup(),
+          expect.objectContaining({ placement: 'bottom', strategy: 'fixed', modifiers }),
+        );
+      } else {
+        expect(getExposed(wrapper).getPopper().state.options).toEqual(
+          expect.objectContaining({ placement: 'bottom', strategy: 'fixed', modifiers }),
+        );
+      }
+    });
+
+    it(':showArrow[boolean] calculates horizontal arrow position', async () => {
+      const wrapper = mountPopup({ content: contentText, placement: 'top', showArrow: true, visible: false });
+      await setVisible(wrapper);
+      const trigger = wrapper.find('.trigger').element;
+      const popup = getPopup();
+      setRect(trigger, { left: 20, width: 20 });
+      setRect(popup, { left: 0, width: 100 });
+      Object.defineProperty(popup, 'offsetWidth', { configurable: true, value: 100 });
+
+      getExposed(wrapper).update();
+      await nextTick();
+
+      const arrow = popup.querySelector<HTMLElement>('.t-popup__arrow');
+      expect(arrow?.style.left).toBe('26px');
+      expect(arrow?.style.marginLeft).toBe('0px');
+    });
+
+    it(':showArrow[boolean] calculates vertical arrow position', async () => {
+      const wrapper = mountPopup({ content: contentText, placement: 'left', showArrow: true, visible: false });
+      await setVisible(wrapper);
+      const trigger = wrapper.find('.trigger').element;
+      const popup = getPopup();
+      setRect(trigger, { height: 20, top: 20 });
+      setRect(popup, { height: 100, top: 0 });
+      Object.defineProperty(popup, 'offsetHeight', { configurable: true, value: 100 });
+
+      getExposed(wrapper).update();
+      await nextTick();
+
+      const arrow = popup.querySelector<HTMLElement>('.t-popup__arrow');
+      expect(arrow?.style.top).toBe('26px');
+      expect(arrow?.style.marginTop).toBe('0px');
+    });
+
+    it(':showArrow[boolean] keeps the default position when the trigger is out of range', async () => {
+      const wrapper = mountPopup({ content: contentText, placement: 'top', showArrow: true, visible: false });
+      await setVisible(wrapper);
+      const trigger = wrapper.find('.trigger').element;
+      const popup = getPopup();
+      setRect(trigger, { left: 200, width: 20 });
+      setRect(popup, { left: 0, width: 100 });
+      Object.defineProperty(popup, 'offsetWidth', { configurable: true, value: 100 });
+
+      getExposed(wrapper).update();
+      await nextTick();
+      expect(popup.querySelector<HTMLElement>('.t-popup__arrow')?.style.left).toBe('');
+    });
+
+    it(':showArrow[boolean] keeps the default vertical position when the trigger is out of range', async () => {
+      const wrapper = mountPopup({ content: contentText, placement: 'left', showArrow: true, visible: false });
+      await setVisible(wrapper);
+      const trigger = wrapper.find('.trigger').element;
+      const popup = getPopup();
+      setRect(trigger, { height: 20, top: 200 });
+      setRect(popup, { height: 100, top: 0 });
+      Object.defineProperties(popup, {
+        clientHeight: { configurable: true, value: 100 },
+        offsetHeight: { configurable: true, value: undefined },
       });
 
-      await wrapper.setProps({
-        content,
-        visible,
-        placement: 'top',
-      });
+      getExposed(wrapper).update();
+      await nextTick();
+      expect(popup.querySelector<HTMLElement>('.t-popup__arrow')?.style.top).toBe('');
+    });
 
-      // 涉及插件popperjs,先用data属性判断
-      expect(document.querySelector(`${POPUPClASS}`).attributes['data-popper-placement'].value).toBe(
-        position.replace(/-(left|top)$/, '-start').replace(/-(right|bottom)$/, '-end'),
+    it.skipIf(process.env.TEST_TARGET === 'snap')(
+      ':showArrow[boolean] tolerates a missing string trigger element',
+      async () => {
+        createPopperMock.mockReturnValue(undefined);
+        const wrapper = mountPopup(
+          {
+            content: contentText,
+            showArrow: true,
+            triggerElement: '#missing-trigger',
+            visible: false,
+          },
+          {},
+        );
+
+        await setVisible(wrapper);
+
+        expect(getPopup()?.querySelector('.t-popup__arrow')).not.toBeNull();
+        expect(getPopup()?.querySelector<HTMLElement>('.t-popup__arrow')?.getAttribute('style')).toBeNull();
+      },
+    );
+
+    it(':trigger[hover]', async () => {
+      vi.useFakeTimers();
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, delay: 0, onVisibleChange });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('mouseenter');
+      await vi.runOnlyPendingTimersAsync();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'trigger-element-hover' });
+
+      await wrapper.find('.trigger').trigger('mouseleave');
+      await vi.runOnlyPendingTimersAsync();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-hover' }),
       );
     });
-    /** 是否显示浮层箭头 */
-    it(':showArrow be true', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button>触发器</button>,
-        },
-      });
 
-      await wrapper.setProps({
-        content,
-        visible,
-        showArrow: true,
-      });
-      expect(document.querySelector(`${POPUPClASS}__content`).className.includes('content--arrow')).toEqual(true); // <div class="t-popup__content t-popup__content--arrow">这
-    });
-    /** 触发浮层出现的方式 */
-    it(':trigger is click', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      await wrapper.setProps({
-        trigger: 'click',
-      });
-      const btn = wrapper.find('#btn');
-      expect(document.querySelector(POPUPClASS)).toBeNull();
-      await btn.trigger('click');
-      expect(document.querySelector(POPUPClASS)).toBeDefined();
-    });
-    /** 触发元素 */
-    it(':triggerElement is `click`', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
+    it(':trigger[click]', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'click', onVisibleChange });
+      await flushRender();
 
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      await wrapper.setProps({
-        content,
-        trigger: 'click',
-      });
-      const btn = wrapper.find('#btn');
-      expect(document.querySelector(POPUPClASS)).toBeNull();
-      await btn.trigger('click');
-      expect(document.querySelector(POPUPClASS)).toBeDefined();
-    });
-    it(':triggerElement is `context-menu`', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      await wrapper.setProps({
-        content,
-        trigger: 'context-menu',
-      });
-      const btn = wrapper.find('#btn');
-      expect(document.querySelector(POPUPClASS)).toBeNull();
-      await btn.trigger('contextmenu');
-      expect(document.querySelector(POPUPClASS)).toBeDefined();
-    });
-    it(':triggerElement is `focusin`', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      await wrapper.setProps({
-        content,
-        trigger: 'focus',
-      });
-      const btn = wrapper.find('#btn');
-      expect(document.querySelector(POPUPClASS)).toBeNull();
-      await btn.trigger('focus');
-      expect(document.querySelector(POPUPClASS)).toBeDefined();
-    });
-    /** 是否显示浮层 */
-    it(':visible', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          content,
-        },
-        slots: {
-          default: <button>触发器</button>,
-        },
-      });
-      expect(document.body.textContent).toEqual('');
-      await wrapper.setProps({
-        visible,
-      });
-      expect(document.body.textContent).toEqual(content);
+      await wrapper.find('.trigger').trigger('click');
+      await waitForTimeout();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'trigger-element-click' });
+
+      await wrapper.find('.trigger').trigger('click');
+      await waitForTimeout();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-click' }),
+      );
     });
 
-    /** 组件层级，Web 侧样式默认为 5500，移动端和小程序样式默认为 1500 */
-    it(':zIndex', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-      });
-      const zIndex = 1213;
-      await wrapper.setProps({
-        zIndex,
-        visible,
-      });
-      expect(document.querySelector(`${POPUPClASS}`).style.cssText.includes(String(zIndex))).toEqual(true);
+    it(':trigger[focus]', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'focus', onVisibleChange });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('focusin');
+      await waitForTimeout();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'trigger-element-focus' });
+
+      await wrapper.find('.trigger').trigger('focusout');
+      await waitForTimeout();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-blur' }),
+      );
+    });
+
+    it(':trigger[context-menu] toggles on the contextmenu event', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'context-menu', onVisibleChange });
+      await flushRender();
+      const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+
+      wrapper.find('.trigger').element.dispatchEvent(event);
+      await waitForTimeout();
+
+      expect(preventDefault).toHaveBeenCalled();
+      // Current behavior: getTriggerType checks `context-menu`, while the native event type is `contextmenu`.
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'trigger-element-close' });
+    });
+
+    it(":trigger[context-menu] maps the source code's hyphenated event name to keydown-esc", async () => {
+      vi.useFakeTimers();
+      const addEventListener = vi.spyOn(HTMLElement.prototype, 'addEventListener');
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'context-menu', onVisibleChange });
+      await flushRender();
+      const contextMenuCalls = addEventListener.mock.calls.filter(([type]) => type === 'contextmenu');
+      const contextMenuCall = contextMenuCalls[contextMenuCalls.length - 1];
+      const listener = contextMenuCall?.[1] as EventListener;
+      const event = new MouseEvent('context-menu', { cancelable: true });
+
+      listener.call(wrapper.find('.trigger').element, event);
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'keydown-esc' });
+    });
+
+    it(':trigger[mousedown] currently does not register a mousedown listener', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'mousedown', onVisibleChange });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('mousedown');
+      await waitForTimeout();
+
+      // Current behavior: `mousedown` is accepted by props but is absent from the event-name map.
+      expect(onVisibleChange).not.toHaveBeenCalled();
+      expect(getPopup()).toBeNull();
+    });
+
+    it(':triggerElement[string]', async () => {
+      const trigger = document.createElement('button');
+      trigger.id = 'external-trigger';
+      document.body.appendChild(trigger);
+      const onVisibleChange = vi.fn();
+      mountPopup({ content: contentText, trigger: 'click', triggerElement: '#external-trigger', onVisibleChange }, {});
+      await flushRender();
+
+      trigger.click();
+      await waitForTimeout();
+      expect(onVisibleChange).toHaveBeenLastCalledWith(true, { trigger: 'trigger-element-click' });
+    });
+
+    it(':triggerElement[function]', () => {
+      const wrapper = mountPopup(
+        { triggerElement: () => <button class="function-element">function element</button> },
+        {},
+      );
+      expect(wrapper.find('.function-element').text()).toBe('function element');
+    });
+
+    it(':triggerElement[slot]', () => {
+      const wrapper = mountPopup({}, { default: () => <button class="slot-element">slot element</button> });
+      expect(wrapper.find('.slot-element').text()).toBe('slot element');
+    });
+
+    it(':visible[boolean]', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      expect(getPopup()).toBeNull();
+
+      await setVisible(wrapper);
+      expect(getPopup()?.style.display).not.toBe('none');
+
+      await setVisible(wrapper, false);
+      expect(getPopup()?.style.display).toBe('none');
+    });
+
+    it(':defaultVisible[boolean]', async () => {
+      mountPopup({ content: contentText, defaultVisible: true });
+      await flushRender();
+      expect(getPopup()?.style.display).not.toBe('none');
+    });
+
+    it(':modelValue[boolean]', async () => {
+      const wrapper = mountPopup({ content: contentText, modelValue: false });
+      expect(getPopup()).toBeNull();
+
+      await wrapper.setProps({ modelValue: true });
+      await flushRender();
+      expect(getPopup()?.style.display).not.toBe('none');
+    });
+
+    it(':zIndex[number]', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false, zIndex: 6000 });
+      await setVisible(wrapper);
+      expect(getPopup()?.style.zIndex).toBe('6000');
     });
   });
-  describe('@event', () => {
-    /** 下拉选项滚动事件 */
-    it('onScroll', () => {});
-    /** 当浮层隐藏或显示时触发，`trigger=document` 表示点击非浮层元素触发；`trigger=context-menu` 表示右击触发 */
-    it('onVisibleChange', () => {});
-    it('keydown-esc hide popup', async () => {
-      const wrapper = await mount(Popup, {
-        props: {
-          visible: false,
-          attach: '#container',
-        },
-        slots: {
-          default: <button id="btn">btn</button>,
-        },
-        global: {
-          stubs: { teleport: false },
-        },
+
+  describe('events', () => {
+    it('onOverlayClick', async () => {
+      const onOverlayClick = vi.fn();
+      const wrapper = mountPopup({ content: contentText, onOverlayClick, visible: false });
+      await setVisible(wrapper);
+
+      const event = new MouseEvent('click', { bubbles: true });
+      getPopup().dispatchEvent(event);
+      expect(onOverlayClick).toHaveBeenCalledWith({ e: event });
+    });
+
+    it('onScroll', async () => {
+      const onScroll = vi.fn();
+      const wrapper = mountPopup({ content: contentText, onScroll, visible: false });
+      await setVisible(wrapper);
+      const event = new WheelEvent('scroll', { bubbles: true });
+
+      getPopupContent().dispatchEvent(event);
+      expect(onScroll).toHaveBeenCalledWith({ e: event });
+    });
+
+    it('onScrollToBottom', async () => {
+      vi.useFakeTimers();
+      const onScrollToBottom = vi.fn();
+      const wrapper = mountPopup({ content: contentText, onScrollToBottom, visible: false });
+      await setVisible(wrapper);
+      const content = getPopupContent();
+      Object.defineProperties(content, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, value: 300 },
+        scrollTop: { configurable: true, value: 100, writable: true },
       });
-      await wrapper.setProps({
-        content,
-        visible,
-        trigger: 'focus',
+
+      content.dispatchEvent(new WheelEvent('scroll', { bubbles: true }));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onScrollToBottom).not.toHaveBeenCalled();
+
+      content.scrollTop = 199.5;
+      const event = new WheelEvent('scroll', { bubbles: true });
+      content.dispatchEvent(event);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onScrollToBottom).toHaveBeenCalledWith({ e: event });
+    });
+
+    it('onVisibleChange + update:modelValue', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({
+        content: contentText,
+        modelValue: false,
+        trigger: 'click',
+        onVisibleChange,
       });
-      const btn = wrapper.find('#btn');
-      await btn.trigger('keydown.esc');
-      await new Promise(setTimeout);
-      expect(wrapper.emitted()['update:visible'][0]).toEqual([false]);
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('click');
+      await waitForTimeout();
+
+      expect(onVisibleChange).toHaveBeenCalledWith(true, { trigger: 'trigger-element-click' });
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true]);
+    });
+
+    it('update:visible', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false, trigger: 'click' });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('click');
+      await waitForTimeout();
+
+      expect(wrapper.emitted('update:visible')?.[0]).toEqual([true]);
+    });
+
+    it('closes on a document mousedown', async () => {
+      const onVisibleChange = vi.fn();
+      mountPopup({ content: contentText, defaultVisible: true, trigger: 'click', onVisibleChange });
+      await flushRender();
+      const event = new MouseEvent('mousedown', { bubbles: true });
+
+      document.body.dispatchEvent(event);
+      await waitForTimeout();
+
+      expect(onVisibleChange).toHaveBeenLastCalledWith(false, { e: event, trigger: 'document' });
+    });
+
+    it('does not close on a mousedown inside the trigger or popup', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, defaultVisible: true, trigger: 'click', onVisibleChange });
+      await flushRender();
+
+      wrapper.find('.trigger').element.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      getPopupContent().dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      await waitForTimeout();
+
+      expect(onVisibleChange).not.toHaveBeenCalled();
+    });
+
+    it('keeps parent popups open for interactions inside a nested popup', async () => {
+      vi.useFakeTimers();
+      const onParentVisibleChange = vi.fn();
+      const onChildVisibleChange = vi.fn();
+      mountPopup({
+        content: () => (
+          <Popup content="nested content" defaultVisible delay={0} onVisibleChange={onChildVisibleChange}>
+            <button class="nested-trigger">nested trigger</button>
+          </Popup>
+        ),
+        defaultVisible: true,
+        delay: 0,
+        onVisibleChange: onParentVisibleChange,
+      });
+      await flushRender();
+      const popups = [...document.querySelectorAll<HTMLElement>('.t-popup')];
+      const childPopup = popups.find((popup) => popup.hasAttribute('data-td-popup-parent'));
+      const parentPopup = popups.find((popup) => !popup.hasAttribute('data-td-popup-parent'));
+      expect(childPopup).toBeDefined();
+      expect(parentPopup).toBeDefined();
+
+      setRect(childPopup, { height: 10, width: 10, x: 0, y: 0 });
+      const mouseleave = new MouseEvent('mouseleave');
+      Object.defineProperties(mouseleave, {
+        x: { value: 5 },
+        y: { value: 5 },
+      });
+      parentPopup.dispatchEvent(mouseleave);
+      await vi.runOnlyPendingTimersAsync();
+      expect(onParentVisibleChange).not.toHaveBeenCalled();
+
+      childPopup.querySelector('.t-popup__content').dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(onChildVisibleChange).not.toHaveBeenCalled();
+      expect(onParentVisibleChange).not.toHaveBeenCalled();
+    });
+
+    it('propagates a mouseleave from a nested hover popup to its parent', async () => {
+      vi.useFakeTimers();
+      const onParentVisibleChange = vi.fn();
+      const onChildVisibleChange = vi.fn();
+      mountPopup({
+        content: () => (
+          <Popup content="nested content" defaultVisible delay={0} onVisibleChange={onChildVisibleChange}>
+            <button>nested trigger</button>
+          </Popup>
+        ),
+        defaultVisible: true,
+        delay: 0,
+        onVisibleChange: onParentVisibleChange,
+      });
+      await flushRender();
+      const childPopup = [...document.querySelectorAll<HTMLElement>('.t-popup')].find((popup) =>
+        popup.hasAttribute('data-td-popup-parent'),
+      );
+      setRect(childPopup, { height: 10, width: 10, x: 0, y: 0 });
+
+      childPopup.dispatchEvent(new MouseEvent('mouseleave', { clientX: 50, clientY: 50 }));
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(onChildVisibleChange).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-hover' }),
+      );
+      expect(onParentVisibleChange).toHaveBeenLastCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-hover' }),
+      );
+    });
+
+    it.each([
+      ['key', { key: 'Escape' }],
+      ['code', { key: 'Enter', code: 'Escape' }],
+      ['keyCode', { key: 'Enter', code: 'Enter', keyCode: 27 }],
+    ])('closes a focus popup with Escape detected by %s', async (_, keyboardInit) => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'focus', onVisibleChange });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('focusin');
+      await waitForTimeout();
+      onVisibleChange.mockClear();
+
+      wrapper.find('.trigger').element.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, ...keyboardInit }));
+      await waitForTimeout();
+
+      expect(onVisibleChange).toHaveBeenLastCalledWith(false, expect.objectContaining({ trigger: 'keydown-esc' }));
+    });
+
+    it('a non-Escape key currently consumes the focus escape listener', async () => {
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, trigger: 'focus', onVisibleChange });
+      await flushRender();
+
+      await wrapper.find('.trigger').trigger('focusin');
+      await waitForTimeout();
+      onVisibleChange.mockClear();
+
+      await wrapper.find('.trigger').trigger('keydown', { key: 'Enter' });
+      await wrapper.find('.trigger').trigger('keydown', { key: 'Escape' });
+      await waitForTimeout();
+
+      // Current behavior: the listener is registered with `once`, so Enter removes it before Escape.
+      expect(onVisibleChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('instanceFunctions', () => {
+    it('getOverlay()', async () => {
+      const wrapper = mountPopup({ content: contentText, destroyOnClose: true, visible: false });
+      expect(getExposed(wrapper).getOverlay()).toBeUndefined();
+
+      await setVisible(wrapper);
+      expect(getExposed(wrapper).getOverlay()).toBe(getPopupContent());
+    });
+
+    it('getOverlayState()', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+      expect(getExposed(wrapper).getOverlayState()).toEqual({ hover: false });
+
+      getPopup().dispatchEvent(new MouseEvent('mouseenter'));
+      expect(getExposed(wrapper).getOverlayState()).toEqual({ hover: true });
+      getPopup().dispatchEvent(new MouseEvent('mouseleave'));
+      expect(getExposed(wrapper).getOverlayState()).toEqual({ hover: false });
+    });
+
+    it('getPopper()', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      expect(getExposed(wrapper).getPopper()).toBeUndefined();
+
+      await setVisible(wrapper);
+      expect(getExposed(wrapper).getPopper()).toBeDefined();
+      if (popperInstances.length) {
+        expect(getExposed(wrapper).getPopper()).toBe(popperInstances[0]);
+      }
+    });
+
+    it('update()', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+      const trigger = wrapper.find('.trigger').element;
+      setRect(trigger, { height: 20, width: 20 });
+      const popper = getExposed(wrapper).getPopper();
+      const update = vi.spyOn(popper, 'update');
+
+      getExposed(wrapper).update();
+
+      expect(update).toHaveBeenCalled();
+      expect(popper.state.elements.reference).toBe(trigger);
+    });
+
+    it('update() updates a trigger inside a shadow root', async () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const wrapper = mount(Popup, {
+        attachTo: shadowRoot as unknown as Element,
+        props: { content: contentText, visible: false },
+        slots: { default: () => <button class="shadow-trigger">trigger</button> },
+      }) as PopupWrapper;
+      wrappers.push(wrapper);
+      await setVisible(wrapper);
+      const popper = getExposed(wrapper).getPopper();
+      const update = vi.spyOn(popper, 'update');
+
+      getExposed(wrapper).update();
+
+      expect(update).toHaveBeenCalled();
+      expect(popper.state.elements.reference.getRootNode()).toBe(shadowRoot);
+    });
+
+    it('update() closes when the trigger element is detached', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+      wrapper.find('.trigger').element.remove();
+
+      getExposed(wrapper).update();
+
+      expect(wrapper.emitted('update:visible')?.at(-1)).toEqual([false]);
+    });
+
+    it('close()', async () => {
+      vi.useFakeTimers();
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, defaultVisible: true, onVisibleChange });
+      await flushRender();
+
+      getExposed(wrapper).close();
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(onVisibleChange).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ trigger: 'trigger-element-close' }),
+      );
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('destroys popper and removes the document listener on unmount', async () => {
+      const removeEventListener = vi.spyOn(document, 'removeEventListener');
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+      const popper = getExposed(wrapper).getPopper();
+      const destroy = vi.spyOn(popper, 'destroy');
+
+      wrapper.unmount();
+      wrappers.splice(wrappers.indexOf(wrapper), 1);
+
+      expect(destroy).toHaveBeenCalled();
+      expect(removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function), true);
+    });
+
+    it('clears delayed visibility changes on unmount', async () => {
+      vi.useFakeTimers();
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup({ content: contentText, delay: 100, onVisibleChange });
+      await wrapper.find('.trigger').trigger('mouseenter');
+
+      wrapper.unmount();
+      wrappers.splice(wrappers.indexOf(wrapper), 1);
+      await vi.runAllTimersAsync();
+
+      expect(onVisibleChange).not.toHaveBeenCalled();
+    });
+
+    it('updates an existing popper when placement changes', async () => {
+      const wrapper = mountPopup({ content: contentText, placement: 'top', visible: false });
+      await setVisible(wrapper);
+      const firstPopper = getExposed(wrapper).getPopper();
+      const destroy = vi.spyOn(firstPopper, 'destroy');
+
+      await wrapper.setProps({ placement: 'bottom' });
+      await flushRender();
+
+      expect(destroy).toHaveBeenCalled();
+      if (createPopperMock.mock.calls.length) {
+        expect(createPopperMock).toHaveBeenCalledTimes(2);
+      } else {
+        expect(getExposed(wrapper).getPopper()).not.toBe(firstPopper);
+      }
+    });
+
+    it('handles the popper onFirstUpdate callback', async () => {
+      const wrapper = mountPopup({ content: contentText, visible: false });
+      await setVisible(wrapper);
+      const popper = getExposed(wrapper).getPopper();
+      const update = vi.spyOn(popper, 'update');
+      const options = createPopperMock.mock.calls.length
+        ? (createPopperMock.mock.calls[0][2] as { onFirstUpdate: () => void })
+        : popper.state.options;
+
+      options.onFirstUpdate();
+      await nextTick();
+
+      expect(update).toHaveBeenCalled();
+    });
+
+    it('updates a visible popup when its container emits resize', async () => {
+      const wrapper = mountPopup({ content: contentText, expandAnimation: true, visible: false });
+      await setVisible(wrapper);
+      const popper = getExposed(wrapper).getPopper();
+      const update = vi.spyOn(popper, 'update');
+      update.mockClear();
+
+      wrapper.findComponent({ name: 'TPopupContainer' }).vm.$emit('resize');
+      await nextTick();
+
+      expect(update).toHaveBeenCalled();
+      expect(getPopup()).not.toBeNull();
+    });
+
+    it('calls an injected updateScrollTop when the overlay opens', async () => {
+      const updateScrollTop = vi.fn();
+      const wrapper = mount(Popup, {
+        attachTo: document.body,
+        global: { provide: { updateScrollTop } },
+        props: { content: contentText, visible: false },
+        slots: { default: () => <button class="trigger">trigger</button> },
+      }) as PopupWrapper;
+      wrappers.push(wrapper);
+
+      await setVisible(wrapper);
+      expect(updateScrollTop).toHaveBeenCalledWith(getPopupContent());
+    });
+
+    it('rebinds listeners when trigger and triggerElement change', async () => {
+      const triggerA = document.createElement('button');
+      triggerA.id = 'trigger-a';
+      const triggerB = document.createElement('button');
+      triggerB.id = 'trigger-b';
+      document.body.append(triggerA, triggerB);
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup(
+        { content: contentText, trigger: 'click', triggerElement: '#trigger-a', onVisibleChange },
+        {},
+      );
+      await flushRender();
+
+      await wrapper.setProps({ trigger: 'focus', triggerElement: '#trigger-b' });
+      await flushRender();
+      triggerA.click();
+      triggerB.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      await waitForTimeout();
+
+      expect(onVisibleChange).toHaveBeenCalledTimes(1);
+      expect(onVisibleChange).toHaveBeenCalledWith(true, { trigger: 'trigger-element-focus' });
+    });
+
+    it('external trigger listeners currently remain active after unmount', async () => {
+      vi.useFakeTimers();
+      const trigger = document.createElement('button');
+      trigger.id = 'persistent-trigger';
+      document.body.appendChild(trigger);
+      const onVisibleChange = vi.fn();
+      const wrapper = mountPopup(
+        { content: contentText, trigger: 'click', triggerElement: '#persistent-trigger', onVisibleChange },
+        {},
+      );
+      await flushRender();
+
+      wrapper.unmount();
+      wrappers.splice(wrappers.indexOf(wrapper), 1);
+      trigger.click();
+      await vi.runAllTimersAsync();
+
+      // Current behavior: component teardown does not call trigger.clean() for an external triggerElement.
+      expect(onVisibleChange).toHaveBeenCalledWith(true, { trigger: 'trigger-element-click' });
+    });
+  });
+
+  describe('props validators', () => {
+    it(':trigger[string]', () => {
+      const validator = popupProps.trigger.validator;
+      expect(validator(undefined)).toBe(true);
+      expect(validator('click')).toBe(true);
+      expect(validator('mousedown')).toBe(true);
+      expect(validator('invalid' as never)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Ref #5631
- Ref #6899
- 历史测试 PR：#1966、#2008

### 💡 需求背景和解决方案

本 PR 仅重写 Popup 测试，不修改组件源码。

原测试只有 1 个文件、20 个用例，其中 2 个直接跳过；包含 `ts-nocheck`，`delay` 与 `destroyOnClose` 没有真实断言，`onScroll` 和 `onVisibleChange` 是空用例。`mousedown`、完整 context-menu / focus 键盘行为、v-model、嵌套 Popup、实例方法、生命周期、Container、String / Function / Slot 等 API 形态也没有系统覆盖。

本次直接替换旧测试，重写为 2 个文件、103 个用例：

| 文件 | 用例数 | 覆盖内容 |
| --- | ---: | --- |
| `popup.test.tsx` | 87 | Popup 全部 props、五种 trigger、v-model、events、嵌套浮层、instance functions、lifecycle、Popper 与箭头定位分支 |
| `popup.container.test.tsx` | 16 | attach、trigger 节点过滤、Teleport、ResizeObserver、事件、实例方法与生命周期 |

测试结构参照 Form 组件规范：顶层使用真实组件名，内部按 `props`、`events`、`instanceFunctions`、`lifecycle` 组织；API 用例采用 `:prop[type]` 命名，String / Function / Slot 分开覆盖。没有场景式文件、快照断言或 `ts-nocheck`。

覆盖率结果：

- Popup 目录：Statements 76.67% → 99.57%，Branches 74.28% → 95.17%，Functions 71.69% → 100%，Lines 76.67% → 99.57%。
- `popup.tsx`：Statements 70.35% → 99.58%，Branches 72.38% → 96.49%，Functions 67.56% → 100%，Lines 70.35% → 99.58%。
- `container.tsx`：Statements 85.62% → 99.34%，Branches 81.81% → 90.74%，Functions 80% → 100%，Lines 85.62% → 99.34%。
- `props.ts`：Branches 50% → 100%，其余维持 100%。

重写过程中确认了 `trigger="mousedown"` 不注册监听、context-menu 来源错误、focus Escape 监听被任意按键消费、外部 triggerElement 监听卸载后残留、空 Fragment 导致 Container 抛错等当前源码行为，详见 #6899。测试按当前真实行为断言并添加注释，源码修复后会自然提醒同步更新。

### ✅ 验证

- Popup 普通模式：2 files / 103 tests passed
- Popup snapshot 模式：2 files / 102 passed，1 个仅在全局预加载真实 Popper 时跳过
- Popup coverage 模式：2 files / 103 tests passed
- Vue 全量普通模式：156 files / 3656 passed，3 todo
- Vue 全量 snapshot 模式：Popup 全部通过；全量仅 Tree 一个既有 3ms 延时用例偶发失败，单独复跑通过
- `pnpm exec tsc --noEmit`
- ESLint `--max-warnings 0`
- `pnpm lint`

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须补充
