### PR TITLE
test(sticky-tool): improve sticky-tool test coverage

### DIFF
--- a/packages/components/sticky-tool/__tests__/sticky-item.test.tsx
+++ b/packages/components/sticky-tool/__tests__/sticky-item.test.tsx
@@ -1,0 +1,257 @@
+import { nextTick } from 'vue';
+import type { Slots, VNode } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Popup from '@tdesign/components/popup';
+import { StickyItem } from '@tdesign/components/sticky-tool';
+import stickyItemProps from '@tdesign/components/sticky-tool/sticky-item-props';
+
+type StickyItemMountProps = Partial<InstanceType<typeof StickyItem>['$props']>;
+
+const getPopupTrigger = (wrapper: VueWrapper) => {
+  const popupSlots = wrapper.findComponent(Popup).vm.$slots as Slots;
+  return popupSlots.default?.()[0] as VNode;
+};
+
+const getVNodeText = (node: VNode) => {
+  if (typeof node.children === 'string') return node.children;
+  if (!Array.isArray(node.children)) return '';
+  return node.children.map((child) => (typeof child === 'string' ? child : (child as VNode).children)).join('');
+};
+
+describe('StickyItem', () => {
+  const wrappers: VueWrapper[] = [];
+
+  const mountStickyItem = (props: StickyItemMountProps = {}, slots: Record<string, () => unknown> = {}) => {
+    const wrapper = mount(StickyItem, {
+      props: {
+        onClick: vi.fn(),
+        onHover: vi.fn(),
+        ...props,
+      },
+      slots,
+    });
+    wrappers.push(wrapper);
+    return wrapper;
+  };
+
+  afterEach(() => {
+    wrappers.forEach((wrapper) => wrapper.unmount());
+    wrappers.length = 0;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  describe('props', () => {
+    it(':icon[function]', () => {
+      const wrapper = mountStickyItem({ icon: () => <span class="function-icon">icon</span> });
+
+      expect(wrapper.find('.function-icon').text()).toBe('icon');
+    });
+
+    it(':icon[slot]', () => {
+      const wrapper = mountStickyItem({}, { icon: () => <span class="slot-icon">icon slot</span> });
+
+      expect(wrapper.find('.slot-icon').text()).toBe('icon slot');
+    });
+
+    it(':label[string]', () => {
+      const wrapper = mountStickyItem({ label: 'Feedback' });
+
+      expect(wrapper.find('.t-sticky-item__label').text()).toBe('Feedback');
+    });
+
+    it(':label[function]', () => {
+      const wrapper = mountStickyItem({ label: () => <span class="function-label">Feedback</span> });
+
+      expect(wrapper.find('.function-label').text()).toBe('Feedback');
+    });
+
+    it(':label[slot]', () => {
+      const wrapper = mountStickyItem({}, { label: () => <span class="slot-label">Feedback slot</span> });
+
+      expect(wrapper.find('.slot-label').text()).toBe('Feedback slot');
+    });
+
+    it(':label[function] takes precedence over label slot', () => {
+      const wrapper = mountStickyItem(
+        { label: () => <span class="function-label">Function</span> },
+        { label: () => <span class="slot-label">Slot</span> },
+      );
+
+      expect(wrapper.find('.function-label').exists()).toBe(true);
+      expect(wrapper.find('.slot-label').exists()).toBe(false);
+    });
+
+    it(':popup[string]', async () => {
+      const wrapper = mountStickyItem({ popup: 'Popup text', popupProps: { visible: true } });
+      await nextTick();
+
+      const content = wrapper.findComponent(Popup).props('content') as () => unknown;
+      expect(content()).toBe('Popup text');
+    });
+
+    it(':popup[function]', () => {
+      const wrapper = mountStickyItem({
+        popup: () => <span class="function-popup">Function popup</span>,
+      });
+      const content = wrapper.findComponent(Popup).props('content') as () => unknown;
+      const node = content() as VNode;
+
+      expect(node.props?.class).toBe('function-popup');
+      expect(getVNodeText(node)).toBe('Function popup');
+    });
+
+    it(':popup[slot]', () => {
+      const wrapper = mountStickyItem({}, { popup: () => <span class="slot-popup">Slot popup</span> });
+      const content = wrapper.findComponent(Popup).props('content') as () => unknown;
+      const nodes = content() as VNode[];
+
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0].props?.class).toBe('slot-popup');
+      expect(getVNodeText(nodes[0])).toBe('Slot popup');
+    });
+
+    it(':popupProps[object]', () => {
+      const wrapper = mountStickyItem({
+        popup: 'Popup',
+        basePopupProps: { disabled: true, showArrow: false, overlayInnerClassName: 'base-popup' },
+        popupProps: { showArrow: true, overlayInnerClassName: 'item-popup' },
+      });
+      const popup = wrapper.findComponent(Popup);
+
+      expect(popup.props('disabled')).toBe(true);
+      expect(popup.props('showArrow')).toBe(true);
+      expect(popup.props('overlayInnerClassName')).toBe('item-popup');
+      expect(popup.props('hideEmptyPopup')).toBe(true);
+    });
+
+    it(':trigger[string]', () => {
+      const validator = stickyItemProps.trigger.validator;
+      const defaultWrapper = mountStickyItem();
+      const clickWrapper = mountStickyItem({ trigger: 'click' });
+
+      expect(validator(undefined as never)).toBe(true);
+      expect(validator(null as never)).toBe(true);
+      expect(validator('hover')).toBe(true);
+      expect(validator('focus' as never)).toBe(false);
+      expect(defaultWrapper.findComponent(Popup).props('trigger')).toBe('hover');
+      expect(clickWrapper.findComponent(Popup).props('trigger')).toBe('click');
+    });
+
+    it(':type[string]', async () => {
+      const wrapper = mountStickyItem({ label: 'Feedback' });
+
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--normal');
+      expect(wrapper.find('.t-sticky-item__label').exists()).toBe(true);
+
+      await wrapper.setProps({ type: 'compact' });
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--compact');
+      expect(wrapper.find('.t-sticky-item__label').exists()).toBe(false);
+    });
+
+    it(':shape[string]', async () => {
+      const wrapper = mountStickyItem();
+
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--square');
+      await wrapper.setProps({ shape: 'round' });
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--round');
+    });
+
+    it(':placement[string]', async () => {
+      const wrapper = mountStickyItem({ placement: 'right-bottom' });
+
+      expect(wrapper.findComponent(Popup).props('placement')).toBe('left');
+      await wrapper.setProps({ placement: 'left-top' });
+      expect(wrapper.findComponent(Popup).props('placement')).toBe('right');
+    });
+
+    it(':baseWidth[number]', () => {
+      const normalWrapper = mountStickyItem({ baseWidth: 120 });
+      const compactWrapper = mountStickyItem({ baseWidth: 120, type: 'compact' });
+
+      expect(getPopupTrigger(normalWrapper).props?.style).toEqual({ margin: 'calc((120 - 56px)/2)' });
+      expect(getPopupTrigger(compactWrapper).props?.style).toEqual({ margin: 'calc((120 - 40px)/2)' });
+    });
+
+    it(':baseWidth[string]', () => {
+      const wrapper = mountStickyItem({ baseWidth: '10rem' });
+
+      expect(getPopupTrigger(wrapper).props?.style).toEqual({ margin: 'calc((10rem - 56px)/2)' });
+    });
+  });
+
+  describe('events', () => {
+    it('click', async () => {
+      const onClick = vi.fn();
+      const icon = () => <span>icon</span>;
+      const wrapper = mountStickyItem({ label: 'Feedback', icon, trigger: 'click', onClick });
+
+      await wrapper.find('.t-sticky-item').trigger('click');
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      const context = onClick.mock.calls[0][0];
+      expect(context.e).toBeInstanceOf(MouseEvent);
+      expect(context.item).toMatchObject({ icon, label: 'Feedback', trigger: 'click' });
+    });
+
+    it('hover', async () => {
+      const onHover = vi.fn();
+      const wrapper = mountStickyItem({ label: 'Feedback', onHover });
+
+      await wrapper.find('.t-sticky-item').trigger('mouseenter');
+
+      expect(onHover).toHaveBeenCalledTimes(1);
+      const context = onHover.mock.calls[0][0];
+      expect(context.e).toBeInstanceOf(MouseEvent);
+      expect(context.item).toMatchObject({ label: 'Feedback', trigger: 'hover' });
+    });
+
+    it('reports errors for omitted standalone event handlers [current behavior]', async () => {
+      const errorHandler = vi.fn();
+      const wrapper = mount(StickyItem, {
+        global: { config: { errorHandler } },
+      });
+      wrappers.push(wrapper);
+
+      await wrapper.find('.t-sticky-item').trigger('click');
+      await wrapper.find('.t-sticky-item').trigger('mouseenter');
+
+      expect(errorHandler).toHaveBeenCalledTimes(2);
+      expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(TypeError);
+      expect(errorHandler.mock.calls[1][0]).toBeInstanceOf(TypeError);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('does not react to popupProps replacement [current behavior]', async () => {
+      const wrapper = mountStickyItem({
+        basePopupProps: { disabled: false },
+        popupProps: { showArrow: false },
+      });
+      const popup = wrapper.findComponent(Popup);
+
+      await wrapper.setProps({
+        basePopupProps: { disabled: true },
+        popupProps: { showArrow: true },
+      });
+
+      // popupProps is merged once during setup and the merged object is not recomputed after prop replacement.
+      expect(popup.props('showArrow')).toBe(false);
+      expect(popup.props('disabled')).toBe(false);
+    });
+
+    it('removes the item on unmount', () => {
+      const wrapper = mount(StickyItem, {
+        props: { onClick: vi.fn(), onHover: vi.fn() },
+        attachTo: document.body,
+      });
+      wrappers.push(wrapper);
+      expect(document.querySelector('.t-sticky-item')).not.toBeNull();
+
+      wrapper.unmount();
+      expect(document.querySelector('.t-sticky-item')).toBeNull();
+    });
+  });
+});

--- a/packages/components/sticky-tool/__tests__/sticky-tool.test.tsx
+++ b/packages/components/sticky-tool/__tests__/sticky-tool.test.tsx
@@ -1,7 +1,258 @@
-// import { mount } from '@vue/test-utils';
-import { describe, it } from 'vitest';
-// import { StickyTool } from '@tdesign/components/sticky-tool';
+import { Fragment, nextTick } from 'vue';
+import type { VNode } from 'vue';
+import { mount } from '@vue/test-utils';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Popup from '@tdesign/components/popup';
+import { StickyItem, StickyTool } from '@tdesign/components/sticky-tool';
+import stickyToolProps from '@tdesign/components/sticky-tool/props';
+
+const DEFAULT_ITEM = { label: 'Feedback', popup: 'Tell us what you think' };
+
+const getVNodeText = (node: VNode) => {
+  if (typeof node.children === 'string') return node.children;
+  if (!Array.isArray(node.children)) return '';
+  return node.children.map((child) => (typeof child === 'string' ? child : (child as VNode).children)).join('');
+};
 
 describe('StickyTool', () => {
-  it('props', () => {});
+  const wrappers: VueWrapper[] = [];
+
+  const mountStickyTool = (options: Parameters<typeof mount>[1] = {}) => {
+    const wrapper = mount(StickyTool, options);
+    wrappers.push(wrapper);
+    return wrapper;
+  };
+
+  afterEach(() => {
+    wrappers.forEach((wrapper) => wrapper.unmount());
+    wrappers.length = 0;
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  describe('props', () => {
+    it(':list[array]', () => {
+      const emptyWrapper = mountStickyTool();
+      expect(emptyWrapper.findAll('.t-sticky-item')).toHaveLength(0);
+
+      const wrapper = mountStickyTool({
+        props: {
+          list: [DEFAULT_ITEM, { label: 'Help', trigger: 'click' }],
+        },
+      });
+
+      expect(wrapper.findAll('.t-sticky-item')).toHaveLength(2);
+      expect(wrapper.findAll('.t-sticky-item__label').map((item) => item.text())).toEqual(['Feedback', 'Help']);
+      expect(wrapper.findAllComponents(StickyItem)[1].props('trigger')).toBe('click');
+    });
+
+    it(':list[array] takes precedence over the default slot', () => {
+      const wrapper = mountStickyTool({
+        props: { list: [DEFAULT_ITEM] },
+        slots: {
+          default: () => <StickyItem label="Slot item" />,
+        },
+      });
+
+      expect(wrapper.findAll('.t-sticky-item')).toHaveLength(1);
+      expect(wrapper.find('.t-sticky-item__label').text()).toBe('Feedback');
+    });
+
+    it(':list[array] derives props and named slots from StickyItem children', () => {
+      const wrapper = mountStickyTool({
+        slots: {
+          default: () => (
+            <Fragment>
+              <div class="ignored-child">ignored</div>
+              <StickyItem
+                label="Slot item"
+                v-slots={{
+                  icon: () => <span class="slot-icon">icon</span>,
+                  popup: () => <span class="slot-popup">popup</span>,
+                }}
+              />
+            </Fragment>
+          ),
+        },
+      });
+
+      expect(wrapper.findAll('.t-sticky-item')).toHaveLength(1);
+      expect(wrapper.find('.slot-icon').text()).toBe('icon');
+      expect(wrapper.find('.t-sticky-item__label').text()).toBe('Slot item');
+      const content = wrapper.findComponent(Popup).props('content') as () => unknown;
+      const popupContent = content() as VNode | VNode[];
+      const popupNode = Array.isArray(popupContent) ? popupContent[0] : popupContent;
+      expect(popupNode.props?.class).toBe('slot-popup');
+      expect(getVNodeText(popupNode)).toBe('popup');
+    });
+
+    it(':offset[array<number>]', () => {
+      const defaultWrapper = mountStickyTool();
+      expect(defaultWrapper.find('.t-sticky-tool').attributes('style')).toContain('right: 80px');
+      expect(defaultWrapper.find('.t-sticky-tool').attributes('style')).toContain('bottom: 24px');
+
+      const wrapper = mountStickyTool({ props: { offset: [-10, 20] } });
+      expect(wrapper.find('.t-sticky-tool').attributes('style')).toContain('right: 70px');
+      expect(wrapper.find('.t-sticky-tool').attributes('style')).toContain('bottom: 44px');
+    });
+
+    it(':offset[array<string>]', () => {
+      const wrapper = mountStickyTool({ props: { offset: ['10em', '8rem'] } });
+      const style = wrapper.find('.t-sticky-tool').attributes('style');
+
+      expect(style).toContain('right: calc( 80px + 10em)');
+      expect(style).toContain('bottom: calc( 24px + 8rem)');
+    });
+
+    it(':offset[array<string>] preserves numeric-string concatenation [current behavior]', () => {
+      const wrapper = mountStickyTool({ props: { offset: ['10', '8'] } });
+      const style = wrapper.find('.t-sticky-tool').attributes('style');
+
+      // Numeric strings currently concatenate with the defaults instead of being added numerically.
+      expect(style).toContain('right: 8010px');
+      expect(style).toContain('bottom: 248px');
+    });
+
+    it.each([
+      ['right-top', ['right: 80px', 'top: 24px']],
+      ['right-center', ['right: 80px', 'top: 50%', 'transform: translate(0, -50%)']],
+      ['right-bottom', ['right: 80px', 'bottom: 24px']],
+      ['left-top', ['left: 80px', 'top: 24px']],
+      ['left-center', ['left: 80px', 'top: 50%', 'transform: translate(0, -50%)']],
+      ['left-bottom', ['left: 80px', 'bottom: 24px']],
+    ] as const)(':placement[string] %s', (placement, expectedStyles) => {
+      const wrapper = mountStickyTool({ props: { placement, list: [DEFAULT_ITEM] } });
+      const style = wrapper.find('.t-sticky-tool').attributes('style');
+
+      expectedStyles.forEach((expectedStyle) => expect(style).toContain(expectedStyle));
+      expect(wrapper.findComponent(StickyItem).props('placement')).toBe(placement);
+    });
+
+    it(':placement[string] validates supported values', () => {
+      const validator = stickyToolProps.placement.validator;
+
+      expect(validator(undefined as never)).toBe(true);
+      expect(validator(null as never)).toBe(true);
+      expect(validator('left-center')).toBe(true);
+      expect(validator('center' as never)).toBe(false);
+    });
+
+    it(':popupProps[object]', () => {
+      const wrapper = mountStickyTool({
+        props: {
+          list: [
+            DEFAULT_ITEM,
+            {
+              label: 'Item override',
+              popupProps: { showArrow: false, overlayInnerClassName: 'item-popup' },
+            },
+          ],
+          popupProps: { disabled: true, showArrow: true, overlayInnerClassName: 'tool-popup' },
+        },
+      });
+      const popups = wrapper.findAllComponents(Popup);
+
+      expect(popups[0].props('disabled')).toBe(true);
+      expect(popups[0].props('showArrow')).toBe(true);
+      expect(popups[0].props('overlayInnerClassName')).toBe('tool-popup');
+      expect(popups[1].props('disabled')).toBe(true);
+      expect(popups[1].props('showArrow')).toBe(false);
+      expect(popups[1].props('overlayInnerClassName')).toBe('item-popup');
+    });
+
+    it(':shape[string]', async () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM] } });
+      const validator = stickyToolProps.shape.validator;
+
+      expect(validator(undefined as never)).toBe(true);
+      expect(validator(null as never)).toBe(true);
+      expect(validator('square')).toBe(true);
+      expect(validator('pill' as never)).toBe(false);
+      expect(wrapper.find('.t-sticky-tool').classes()).toContain('t-sticky-tool--square');
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--square');
+
+      await wrapper.setProps({ shape: 'round' });
+      expect(wrapper.find('.t-sticky-tool').classes()).toContain('t-sticky-tool--round');
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--round');
+    });
+
+    it(':type[string]', async () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM] } });
+      const validator = stickyToolProps.type.validator;
+
+      expect(validator(undefined as never)).toBe(true);
+      expect(validator(null as never)).toBe(true);
+      expect(validator('normal')).toBe(true);
+      expect(validator('mini' as never)).toBe(false);
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--normal');
+      expect(wrapper.find('.t-sticky-item__label').exists()).toBe(true);
+
+      await wrapper.setProps({ type: 'compact' });
+      expect(wrapper.find('.t-sticky-item').classes()).toContain('t-sticky-item--compact');
+      expect(wrapper.find('.t-sticky-item__label').exists()).toBe(false);
+    });
+
+    it(':width[number]', () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM], width: 120 } });
+
+      expect((wrapper.find('.t-sticky-tool').element as HTMLElement).style.width).toBe('120px');
+      expect(wrapper.findComponent(StickyItem).props('baseWidth')).toBe('120px');
+    });
+
+    it(':width[string]', () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM], width: '10rem', type: 'compact' } });
+
+      expect((wrapper.find('.t-sticky-tool').element as HTMLElement).style.width).toBe('10rem');
+      expect(wrapper.findComponent(StickyItem).props('baseWidth')).toBe('10rem');
+    });
+
+    it(':width[number] ignores zero [current behavior]', () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM], width: 0 } });
+
+      // The implementation uses a truthiness check, so zero is currently not forwarded to the DOM or child item.
+      expect((wrapper.find('.t-sticky-tool').element as HTMLElement).style.width).toBe('');
+      expect(wrapper.find('.t-sticky-item').attributes('style')).toBeUndefined();
+    });
+  });
+
+  describe('events', () => {
+    it('click', async () => {
+      const onClick = vi.fn();
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM], onClick } });
+
+      await wrapper.find('.t-sticky-item').trigger('click');
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+      const context = onClick.mock.calls[0][0];
+      expect(context.e).toBeInstanceOf(MouseEvent);
+      expect(context.item).toMatchObject({ label: 'Feedback', popup: 'Tell us what you think', trigger: 'hover' });
+    });
+
+    it('hover', async () => {
+      const onHover = vi.fn();
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM], onHover } });
+
+      await wrapper.find('.t-sticky-item').trigger('mouseenter');
+
+      expect(onHover).toHaveBeenCalledTimes(1);
+      const context = onHover.mock.calls[0][0];
+      expect(context.e).toBeInstanceOf(MouseEvent);
+      expect(context.item).toMatchObject({ label: 'Feedback', popup: 'Tell us what you think', trigger: 'hover' });
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('reacts to list replacement and removes rendered content on unmount', async () => {
+      const wrapper = mountStickyTool({ props: { list: [DEFAULT_ITEM] }, attachTo: document.body });
+      expect(document.querySelectorAll('.t-sticky-item')).toHaveLength(1);
+
+      await wrapper.setProps({ list: [{ label: 'One' }, { label: 'Two' }] });
+      await nextTick();
+      expect(wrapper.findAll('.t-sticky-item__label').map((item) => item.text())).toEqual(['One', 'Two']);
+
+      wrapper.unmount();
+      expect(document.querySelector('.t-sticky-tool')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Ref #5631
- Ref #6901

### 💡 需求背景和解决方案

本 PR 仅重写 StickyTool 测试，不修改组件源码。

原测试只有 1 个空用例，组件实际上没有任何有效覆盖。StickyTool 的 list / 默认插槽两种使用方式、位置和偏移计算、Popup 透传、事件，以及公开子组件 StickyItem 的 TNode、触发方式和父级继承属性均缺少覆盖。

本次直接替换旧测试，重写为 2 个真实组件文件、43 个用例：

| 文件 | 用例数 | 覆盖内容 |
| --- | ---: | --- |
| `sticky-tool.test.tsx` | 22 | 全部 StickyTool props、列表/StickyItem 插槽转换、六种 placement、offset、Popup 透传优先级、events、lifecycle |
| `sticky-item.test.tsx` | 21 | 全部 StickyItem props，icon / label / popup 的 Function / String / Slot 形态，继承的 type / shape / placement / baseWidth / Popup props、events、lifecycle |

测试结构参照 Form 组件规范：顶层按真实组件命名，内部按 `props`、`events`、`lifecycle` 组织；API 用例采用 `:prop[type]` 命名，String / Function / Slot 分开覆盖。没有快照断言、`ts-nocheck` 或场景式测试文件。

覆盖率结果：

- StickyTool 目录：Statements 0% → 100%，Branches 0% → 95.31%，Functions 0% → 100%，Lines 0% → 100%。
- `sticky-item.tsx`：Statements / Branches / Functions / Lines 均为 100%。
- `sticky-tool.tsx`：Statements 100%，Branches 90.62%，Functions 100%，Lines 100%。

`sticky-tool.tsx:42-44` 中 `const list = node?.props || {}` 后再判断 `!list`，其 true 分支按当前实现不可达。重写过程中还确认了数字字符串 offset 拼接、`width=0` 被忽略、StickyItem 独立交互缺少回调时报错、Popup 透传替换不响应等当前源码行为，详见 #6901。测试按真实行为断言并添加注释，源码修复后会提醒同步更新。

### ✅ 验证

- StickyTool 普通模式：2 files / 43 tests passed
- StickyTool snapshot 模式：2 files / 43 tests passed
- StickyTool coverage 模式：2 files / 43 tests passed
- Vue 全量普通模式：160 files / 3672 tests passed（2 skipped / 3 todo）
- Vue 全量 snapshot 模式：160 files / 3654 tests passed（20 skipped / 3 todo）
- `pnpm exec tsc --noEmit`
- 目标 ESLint `--max-warnings 0`
- `pnpm lint`

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
