### PR TITLE
test(cascader): improve cascader test coverage

### DIFF
--- a/packages/components/cascader/__tests__/cascader-item.test.tsx
+++ b/packages/components/cascader/__tests__/cascader-item.test.tsx
@@ -1,0 +1,245 @@
+import { h } from 'vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { ChevronRightIcon } from 'tdesign-icons-vue-next';
+import TreeStore from '@tdesign/common-js/tree/tree-store';
+import { Checkbox } from '@tdesign/components/checkbox';
+import { Loading } from '@tdesign/components/loading';
+import CascaderItem from '@tdesign/components/cascader/components/Item';
+import type { CascaderContextType } from '@tdesign/components/cascader/types';
+
+const createStore = () => {
+  const store = new TreeStore({
+    checkable: true,
+    expandMutex: true,
+    expandParent: true,
+    keys: {},
+  });
+  store.append([
+    {
+      label: 'Parent',
+      value: 'parent',
+      children: [
+        { label: 'Child child', value: 'child' },
+        { label: 'Disabled', value: 'disabled', disabled: true },
+      ],
+    },
+  ]);
+  store.refreshNodes();
+  return store;
+};
+
+const createContext = (store: TreeStore, overrides: Partial<CascaderContextType> = {}) =>
+  ({
+    checkProps: undefined,
+    checkStrictly: false,
+    clearable: false,
+    disabled: false,
+    filterable: false,
+    inputVal: '',
+    isParentFilterable: false,
+    lazy: true,
+    max: 0,
+    minCollapsedNum: 0,
+    multiple: false,
+    reserveKeyword: true,
+    setExpand: vi.fn(),
+    setInputVal: vi.fn(),
+    setTreeNodes: vi.fn(),
+    setValue: vi.fn(),
+    setVisible: vi.fn(),
+    showAllLevels: true,
+    size: 'medium',
+    treeNodes: store.getNodes(),
+    treeStore: store,
+    value: '',
+    valueMode: 'onlyLeaf',
+    valueType: 'single',
+    visible: true,
+    ...overrides,
+  } as CascaderContextType);
+
+describe('CascaderItem', () => {
+  describe('props', () => {
+    it(':node[default] creates an empty object', () => {
+      const component = CascaderItem as unknown as { props: { node: { default: () => object } } };
+
+      expect(component.props.node.default()).toEqual({});
+    });
+
+    it(':node[object] renders a single leaf label and title', () => {
+      const store = createStore();
+      const node = store.getNode('child');
+      const wrapper = mount(CascaderItem, { props: { node, cascaderContext: createContext(store) } });
+
+      expect(wrapper.text()).toBe('Child child');
+      expect(wrapper.find('[role="label"]').attributes('title')).toBe('Child child');
+      expect(wrapper.classes()).toContain('t-cascader__item--leaf');
+      wrapper.unmount();
+    });
+
+    it(':node[object] highlights every matching filter segment and uses the full path title', () => {
+      const store = createStore();
+      const node = store.getNode('child');
+      const wrapper = mount(CascaderItem, {
+        props: { node, cascaderContext: createContext(store, { inputVal: 'Child' }) },
+      });
+
+      expect(wrapper.findAll('.t-cascader__item-label--filter')).toHaveLength(1);
+      expect(wrapper.find('.t-cascader__item-label--filter').text()).toBe('Child');
+      expect(wrapper.find('[role="label"]').attributes('title')).toBe('Parent/Child child');
+      wrapper.unmount();
+    });
+
+    it(':node[object] omits the title for a non-string label', () => {
+      const store = createStore();
+      const node = store.getNode('child');
+      node.label = h('span', 'VNode label') as unknown as string;
+      const wrapper = mount(CascaderItem, { props: { node, cascaderContext: createContext(store) } });
+
+      expect(wrapper.find('[role="label"]').attributes('title')).toBeUndefined();
+      wrapper.unmount();
+    });
+
+    it(':optionChild[VNode]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store),
+          node: store.getNode('child'),
+          optionChild: h('strong', { class: 'custom-option' }, 'Custom option') as never,
+        },
+      });
+
+      expect(wrapper.find('.custom-option').text()).toBe('Custom option');
+      expect(wrapper.find('[role="label"]').exists()).toBe(false);
+      wrapper.unmount();
+    });
+
+    it(':cascaderContext[object] renders a configured checkbox in multiple mode', async () => {
+      const store = createStore();
+      const node = store.getNode('child');
+      node.checked = true;
+      node.indeterminate = true;
+      const onChange = vi.fn();
+      const wrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, {
+            checkProps: { readonly: true },
+            inputVal: 'Child',
+            max: 2,
+            multiple: true,
+            value: ['child'],
+          }),
+          node,
+          onChange,
+        },
+      });
+      const checkbox = wrapper.findComponent(Checkbox);
+
+      expect(checkbox.props('checked')).toBe(true);
+      expect(checkbox.props('indeterminate')).toBe(true);
+      expect(checkbox.props('name')).toBe('child');
+      expect(checkbox.props('readonly')).toBe(true);
+      expect(checkbox.props('title')).toBe('Parent/Child child');
+      expect(wrapper.find('.t-cascader__item-label--filter').exists()).toBe(true);
+      checkbox.props('onChange')(false, { e: new Event('change') });
+      expect(onChange).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    });
+
+    it(':node[object] supports an empty checkbox label', () => {
+      const store = createStore();
+      const node = store.getNode('child');
+      node.label = undefined as unknown as string;
+      const wrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, { multiple: true, value: [] }),
+          node,
+        },
+      });
+
+      expect(wrapper.findComponent(Checkbox).text()).toBe('');
+      wrapper.unmount();
+    });
+
+    it(':cascaderContext[object] disables checkboxes for disabled nodes and max selection', () => {
+      const store = createStore();
+      const disabledWrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, { multiple: true, value: [] }),
+          node: store.getNode('disabled'),
+        },
+      });
+      expect(disabledWrapper.findComponent(Checkbox).props('disabled')).toBe(true);
+      disabledWrapper.unmount();
+
+      const limitedWrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, { max: 1, multiple: true, value: ['disabled'] }),
+          node: store.getNode('child'),
+        },
+      });
+      expect(limitedWrapper.findComponent(Checkbox).props('disabled')).toBe(true);
+      limitedWrapper.unmount();
+    });
+
+    it(':cascaderContext[object] stops label-trigger selection on expandable parents', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, { isParentFilterable: false, multiple: true, value: [] }),
+          node: store.getNode('parent'),
+        },
+      });
+
+      expect(wrapper.findComponent(Checkbox).props('stopLabelTrigger')).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':node[object] renders expand and loading icons for a parent', async () => {
+      const store = createStore();
+      const node = store.getNode('parent');
+      const wrapper = mount(CascaderItem, { props: { node, cascaderContext: createContext(store) } });
+
+      expect(wrapper.findComponent(ChevronRightIcon).exists()).toBe(true);
+      wrapper.unmount();
+
+      node.loading = true;
+      const loadingWrapper = mount(CascaderItem, { props: { node, cascaderContext: createContext(store) } });
+      expect(loadingWrapper.findComponent(Loading).exists()).toBe(true);
+      loadingWrapper.unmount();
+    });
+
+    it(':cascaderContext[object] hides the parent icon while parent filtering is enabled', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderItem, {
+        props: {
+          cascaderContext: createContext(store, { isParentFilterable: true }),
+          node: store.getNode('parent'),
+        },
+      });
+
+      expect(wrapper.findComponent(ChevronRightIcon).exists()).toBe(false);
+      expect(wrapper.classes()).toContain('t-cascader__item--leaf');
+      wrapper.unmount();
+    });
+  });
+
+  describe('events', () => {
+    it('click and mouseenter', async () => {
+      const store = createStore();
+      const onClick = vi.fn();
+      const onMouseenter = vi.fn();
+      const wrapper = mount(CascaderItem, {
+        props: { cascaderContext: createContext(store), node: store.getNode('child'), onClick, onMouseenter },
+      });
+
+      await wrapper.trigger('click');
+      await wrapper.trigger('mouseenter');
+      expect(onClick).toHaveBeenCalledOnce();
+      expect(onMouseenter).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    });
+  });
+});

--- a/packages/components/cascader/__tests__/cascader-panel.test.tsx
+++ b/packages/components/cascader/__tests__/cascader-panel.test.tsx
@@ -1,0 +1,135 @@
+import { nextTick } from 'vue';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CascaderPanel } from '@tdesign/components/cascader';
+import type { CascaderOption } from '@tdesign/components/cascader/types';
+
+const options: CascaderOption[] = [
+  {
+    label: 'Parent',
+    value: 'parent',
+    children: [
+      { label: 'First child', value: 'first' },
+      { label: 'Second child', value: 'second' },
+    ],
+  },
+  { label: 'Leaf', value: 'leaf' },
+];
+
+describe('CascaderPanel', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it(':options[array]', () => {
+      const wrapper = mount(CascaderPanel, { props: { options } });
+
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(1);
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it(':value[string]', async () => {
+      const wrapper = mount(CascaderPanel, { props: { options, value: 'first' } });
+      await nextTick();
+
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(2);
+      expect(wrapper.text()).toContain('First child');
+      wrapper.unmount();
+    });
+
+    it(':multiple[boolean]', () => {
+      const wrapper = mount(CascaderPanel, { props: { multiple: true, options, value: ['first'] } });
+
+      expect(wrapper.findAll('.t-checkbox').length).toBeGreaterThan(0);
+      wrapper.unmount();
+    });
+
+    it(':empty[string]', () => {
+      const wrapper = mount(CascaderPanel, { props: { empty: 'No data', options: [] } });
+
+      expect(wrapper.text()).toBe('No data');
+      wrapper.unmount();
+    });
+
+    it(':empty[function]', () => {
+      const wrapper = mount(CascaderPanel, {
+        props: { empty: () => <span class="function-empty">No data</span>, options: [] },
+      });
+
+      expect(wrapper.find('.function-empty').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':empty[slot]', () => {
+      const wrapper = mount(CascaderPanel, {
+        props: { options: [] },
+        slots: { empty: () => <span class="slot-empty">No data</span> },
+      });
+
+      expect(wrapper.find('.slot-empty').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':option[slot]', () => {
+      const wrapper = mount(CascaderPanel, {
+        props: { options },
+        slots: { option: ({ item }) => <span class="slot-option">{String(item.label)}</span> },
+      });
+
+      expect(wrapper.findAll('.slot-option')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it('currently does not forward option, loading, loadingText, or panel and column content', () => {
+      const wrapper = mount(CascaderPanel, {
+        props: {
+          columnFooter: () => <span class="column-footer">Footer</span>,
+          columnHeader: () => <span class="column-header">Header</span>,
+          loading: true,
+          loadingText: 'Loading options',
+          option: () => <span class="function-option">Option</span>,
+          options,
+          panelBottomContent: 'Panel bottom',
+          panelTopContent: 'Panel top',
+        },
+        slots: {
+          columnFooter: () => <span class="slot-footer">Footer slot</span>,
+          columnHeader: () => <span class="slot-header">Header slot</span>,
+          loadingText: () => <span class="slot-loading">Loading slot</span>,
+          panelBottomContent: () => <span class="slot-panel-bottom">Panel bottom slot</span>,
+          panelTopContent: () => <span class="slot-panel-top">Panel top slot</span>,
+        },
+      });
+
+      // CascaderPanel currently forwards only empty/option/loadingText slots, but loadingText is inert because loading
+      // itself is not forwarded.
+      expect(wrapper.find('.function-option').exists()).toBe(false);
+      expect(wrapper.find('.column-header').exists()).toBe(false);
+      expect(wrapper.find('.column-footer').exists()).toBe(false);
+      expect(wrapper.find('.slot-header').exists()).toBe(false);
+      expect(wrapper.find('.slot-footer').exists()).toBe(false);
+      expect(wrapper.find('.slot-loading').exists()).toBe(false);
+      expect(wrapper.find('.slot-panel-top').exists()).toBe(false);
+      expect(wrapper.find('.slot-panel-bottom').exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('Loading options');
+      expect(wrapper.text()).not.toContain('Panel top');
+      expect(wrapper.text()).not.toContain('Panel bottom');
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(2);
+      wrapper.unmount();
+    });
+  });
+
+  describe('events', () => {
+    it('change', async () => {
+      const onChange = vi.fn();
+      const wrapper = mount(CascaderPanel, { props: { onChange, options } });
+
+      await wrapper.findAll('.t-cascader__item')[1].trigger('click');
+      expect(onChange).toHaveBeenCalledWith('leaf', expect.objectContaining({ source: 'check' }));
+      wrapper.unmount();
+    });
+  });
+});

--- a/packages/components/cascader/__tests__/cascader-sub-panel.test.tsx
+++ b/packages/components/cascader/__tests__/cascader-sub-panel.test.tsx
@@ -1,0 +1,400 @@
+/* eslint-disable vue/one-component-per-file */
+import { defineComponent, h, nextTick, ref, watch } from 'vue';
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TreeStore from '@tdesign/common-js/tree/tree-store';
+import CascaderSubPanel from '@tdesign/components/cascader/components/Panel';
+import type { CascaderContextType, CascaderOption, FilterValue, TreeNode } from '@tdesign/components/cascader/types';
+
+const options: CascaderOption[] = [
+  {
+    label: 'Alpha',
+    value: 'alpha',
+    children: [
+      { label: 'Alpha One', value: 'alpha-1' },
+      { label: 'Alpha Two', value: 'alpha-2' },
+    ],
+  },
+  {
+    label: 'Beta',
+    value: 'beta',
+    children: [{ label: 'Beta One', value: 'beta-1' }],
+  },
+];
+
+const createStore = (data: CascaderOption[] = options) => {
+  const store = new TreeStore({
+    checkable: true,
+    expandMutex: true,
+    expandParent: true,
+    keys: {},
+  });
+  store.append(data);
+  store.refreshNodes();
+  return store;
+};
+
+const getVisibleNodes = (store: TreeStore) => store.getNodes().filter((node: TreeNode) => node.visible);
+
+const createContext = (store: TreeStore, overrides: Partial<CascaderContextType> = {}) =>
+  ({
+    checkProps: undefined,
+    checkStrictly: false,
+    clearable: false,
+    disabled: false,
+    filterable: false,
+    inputVal: '',
+    isParentFilterable: false,
+    lazy: true,
+    max: 0,
+    minCollapsedNum: 0,
+    multiple: false,
+    reserveKeyword: true,
+    setExpand: vi.fn(),
+    setInputVal: vi.fn(),
+    setTreeNodes: vi.fn(),
+    setValue: vi.fn(),
+    setVisible: vi.fn(),
+    showAllLevels: true,
+    size: 'medium',
+    treeNodes: getVisibleNodes(store),
+    treeStore: store,
+    value: '',
+    valueMode: 'onlyLeaf',
+    valueType: 'single',
+    visible: true,
+    ...overrides,
+  } as CascaderContextType);
+
+const FilterControl = defineComponent({
+  name: 'FilterControl',
+  props: {
+    onFilter: { type: Function, required: true },
+  },
+  setup(props) {
+    const value = ref('');
+    watch(value, (filter) => props.onFilter(filter));
+    return () => (
+      <input
+        class="column-filter"
+        value={value.value}
+        onInput={(event) => {
+          value.value = (event.target as HTMLInputElement).value;
+        }}
+      />
+    );
+  },
+});
+
+describe('CascaderSubPanel', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  describe('props', () => {
+    it(':cascaderContext[object] renders the current tree panels', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, { props: { cascaderContext: createContext(store) } });
+
+      expect(wrapper.classes()).toContain('t-cascader--normal');
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(1);
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it(':loading[boolean]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store), loading: true },
+      });
+
+      expect(wrapper.classes()).not.toContain('t-cascader--normal');
+      expect(wrapper.find('.t-cascader__panel--empty').text()).not.toBe('');
+      wrapper.unmount();
+    });
+
+    it(':loadingText[string]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store), loading: true, loadingText: 'Loading options' },
+      });
+
+      expect(wrapper.text()).toBe('Loading options');
+      wrapper.unmount();
+    });
+
+    it(':loadingText[function]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: {
+          cascaderContext: createContext(store),
+          loading: true,
+          loadingText: () => <span class="function-loading">Loading function</span>,
+        },
+      });
+
+      expect(wrapper.find('.function-loading').text()).toBe('Loading function');
+      wrapper.unmount();
+    });
+
+    it(':loadingText[slot]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store), loading: true },
+        slots: { loadingText: () => <span class="slot-loading">Loading slot</span> },
+      });
+
+      expect(wrapper.find('.slot-loading').text()).toBe('Loading slot');
+      wrapper.unmount();
+    });
+
+    it(':empty[string]', () => {
+      const store = createStore([]);
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store), empty: 'No options' },
+      });
+
+      expect(wrapper.text()).toBe('No options');
+      wrapper.unmount();
+    });
+
+    it(':empty[function]', () => {
+      const store = createStore([]);
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store), empty: () => <span class="function-empty">Empty</span> },
+      });
+
+      expect(wrapper.find('.function-empty').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':empty[slot]', () => {
+      const store = createStore([]);
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store) },
+        slots: { empty: () => <span class="slot-empty">Empty slot</span> },
+      });
+
+      expect(wrapper.find('.slot-empty').exists()).toBe(true);
+      wrapper.unmount();
+    });
+
+    it(':option[function]', async () => {
+      const store = createStore();
+      const onChange = vi.fn();
+      const onExpand = vi.fn();
+      const wrapper = mount(CascaderSubPanel, {
+        props: {
+          cascaderContext: createContext(store),
+          option: (h, { item, onChange: change, onExpand: expand }) => (
+            <button
+              class="function-option"
+              onClick={() => {
+                change();
+                expand();
+                onChange();
+                onExpand();
+              }}
+            >
+              {String(item.label)}
+            </button>
+          ),
+        },
+      });
+
+      expect(wrapper.findAll('.function-option')).toHaveLength(2);
+      await wrapper.find('.function-option').trigger('click');
+      expect(onChange).toHaveBeenCalledOnce();
+      expect(onExpand).toHaveBeenCalledOnce();
+      wrapper.unmount();
+    });
+
+    it(':option[slot]', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store) },
+        slots: {
+          option: ({ item }: { item: CascaderOption }) => <span class="slot-option">{String(item.label)}</span>,
+        },
+      });
+
+      expect(wrapper.findAll('.slot-option')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it(':option[option.content]', () => {
+      const store = createStore([
+        {
+          label: 'Content option',
+          value: 'content',
+          content: () => h('span', { class: 'data-content' }, 'Data content'),
+        },
+      ]);
+      const wrapper = mount(CascaderSubPanel, { props: { cascaderContext: createContext(store) } });
+
+      expect(wrapper.find('.data-content').text()).toBe('Data content');
+      wrapper.unmount();
+    });
+
+    it(':columnHeader[slot] and :columnFooter[slot] receive panel context', () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store) },
+        slots: {
+          columnHeader: ({ panelIndex, options, filteredOptions }) => (
+            <div class="column-header">{`${panelIndex}:${options.length}:${filteredOptions.length}`}</div>
+          ),
+          columnFooter: ({ panelIndex, options, filteredOptions }) => (
+            <div class="column-footer">{`${panelIndex}:${options.length}:${filteredOptions.length}`}</div>
+          ),
+        },
+      });
+
+      expect(wrapper.find('.column-header').text()).toBe('0:2:2');
+      expect(wrapper.find('.column-footer').text()).toBe('0:2:2');
+      wrapper.unmount();
+    });
+
+    it(':columnHeader[slot] filters a panel by string and resets on whitespace', async () => {
+      const store = createStore();
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store) },
+        slots: {
+          columnHeader: ({ onFilter }: { onFilter: (filter: FilterValue) => void }) => (
+            <FilterControl onFilter={onFilter} />
+          ),
+        },
+      });
+      const input = wrapper.find('.column-filter');
+
+      await input.setValue('alpha');
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(1);
+      await input.setValue('   ');
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it(':columnFooter[slot] filters a panel with a function', async () => {
+      const store = createStore();
+      let onFilter: (filter: FilterValue) => void = () => undefined;
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: createContext(store) },
+        slots: {
+          columnFooter: (params: { onFilter: (filter: FilterValue) => void }) => {
+            onFilter = params.onFilter;
+            return <span class="function-filter-control" />;
+          },
+        },
+      });
+
+      onFilter((option, panelIndex) => option.value === 'beta' && panelIndex === 0);
+      await nextTick();
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(1);
+      expect(wrapper.text()).toContain('Beta');
+      wrapper.unmount();
+    });
+
+    it(':cascaderContext[object] renders a flat filtered list with inert column filtering', async () => {
+      const store = createStore();
+      let onFilter: (filter: FilterValue) => void = () => undefined;
+      const context = createContext(store, { inputVal: 'Alpha', treeNodes: [store.getNode('alpha-1')] });
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: context },
+        slots: {
+          columnHeader: (params: { onFilter: (filter: FilterValue) => void }) => {
+            onFilter = params.onFilter;
+            return <span class="flat-header" />;
+          },
+        },
+      });
+
+      expect(wrapper.find('.t-cascader__menu--filter').exists()).toBe(true);
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(1);
+      onFilter('nothing');
+      await nextTick();
+      expect(wrapper.findAll('.t-cascader__item')).toHaveLength(1);
+      wrapper.unmount();
+    });
+
+    it(':trigger[click] expands a second panel', async () => {
+      const store = createStore();
+      const context = createContext(store);
+      const wrapper = mount(CascaderSubPanel, { props: { cascaderContext: context, trigger: 'click' } });
+
+      await wrapper.findAll('.t-cascader__item')[0].trigger('click');
+      context.treeNodes = getVisibleNodes(store);
+      await wrapper.setProps({ cascaderContext: { ...context } });
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(2);
+      wrapper.unmount();
+    });
+
+    it(':trigger[hover] expands on mouseenter but not click', async () => {
+      const store = createStore();
+      const context = createContext(store);
+      const wrapper = mount(CascaderSubPanel, { props: { cascaderContext: context, trigger: 'hover' } });
+
+      await wrapper.findAll('.t-cascader__item')[0].trigger('click');
+      expect(store.getExpanded()).toEqual([]);
+      await wrapper.findAll('.t-cascader__item')[0].trigger('mouseenter');
+      expect(store.getExpanded()).toContain('alpha');
+      wrapper.unmount();
+    });
+
+    it('active column filters limit deeper panels and expansion restores the next level', async () => {
+      const store = createStore();
+      store.replaceExpanded(['alpha']);
+      store.refreshNodes();
+      const context = createContext(store, { treeNodes: getVisibleNodes(store) });
+      const filters: Array<(filter: FilterValue) => void> = [];
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: context, trigger: 'click' },
+        slots: {
+          columnHeader: ({ panelIndex, onFilter }) => {
+            filters[panelIndex] = onFilter;
+            return <span class="cascade-filter" />;
+          },
+        },
+      });
+
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(2);
+      filters[0]('missing');
+      await nextTick();
+      expect(wrapper.findAll('.t-cascader__menu')).toHaveLength(1);
+
+      filters[0]('alpha');
+      await nextTick();
+      await wrapper.find('.t-cascader__item').trigger('click');
+      await nextTick();
+      expect(wrapper.findAll('.t-cascader__menu').length).toBeGreaterThanOrEqual(1);
+      wrapper.unmount();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('cleans cached column callbacks when panels disappear and on unmount', async () => {
+      const store = createStore();
+      store.replaceExpanded(['alpha']);
+      store.refreshNodes();
+      const context = createContext(store, { treeNodes: getVisibleNodes(store) });
+      const filters: Array<(filter: FilterValue) => void> = [];
+      const wrapper = mount(CascaderSubPanel, {
+        props: { cascaderContext: context },
+        slots: {
+          columnHeader: ({ panelIndex, onFilter }) => {
+            filters[panelIndex] = onFilter;
+            return <span class="header" />;
+          },
+        },
+      });
+      expect(wrapper.findAll('.header')).toHaveLength(2);
+
+      context.treeNodes = context.treeNodes.filter((node) => node.level === 0);
+      await wrapper.setProps({ cascaderContext: { ...context } });
+      await nextTick();
+      expect(wrapper.findAll('.header')).toHaveLength(1);
+      expect(() => filters[1]('stale filter')).not.toThrow();
+      expect(() => wrapper.unmount()).not.toThrow();
+    });
+  });
+});

--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -1,839 +1,802 @@
-import { defineComponent, nextTick, ref, watch } from 'vue';
+/* eslint-disable vue/one-component-per-file */
+import { nextTick, ref } from 'vue';
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, afterEach } from 'vitest';
-import Cascader from '@tdesign/components/cascader';
-import type { TreeOptionData } from '@tdesign/components/common';
+import type { VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Cascader } from '@tdesign/components/cascader';
+import cascaderProps from '@tdesign/components/cascader/props';
+import type { CascaderOption } from '@tdesign/components/cascader/types';
+import { Checkbox } from '@tdesign/components/checkbox';
+import { SelectInput } from '@tdesign/components/select-input';
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
-type FilterValue = string | ((node: TreeOptionData, panelIndex: number) => boolean);
-
-interface ColumnHeaderSlotParams {
-  panelIndex: number;
-  options: TreeOptionData[];
-  filteredOptions: TreeOptionData[];
-  onFilter: (filter: FilterValue) => void;
-}
-
-interface ColumnFooterSlotParams {
-  panelIndex: number;
-  options: TreeOptionData[];
-  filteredOptions: TreeOptionData[];
-  onFilter: (filter: FilterValue) => void;
-}
-
-// ─── Test Data ──────────────────────────────────────────────────────────────
-
-const options: TreeOptionData[] = [
+const options: CascaderOption[] = [
   {
-    label: '选项一',
-    value: '1',
+    label: 'Parent A',
+    value: 'a',
     children: [
-      { label: '子选项一', value: '1.1' },
-      { label: '子选项二', value: '1.2' },
-      { label: '子选项三', value: '1.3' },
+      { label: 'Child A1', value: 'a1' },
+      { label: 'Child A2', value: 'a2' },
     ],
   },
   {
-    label: '选项二',
-    value: '2',
-    children: [
-      { label: '子选项一', value: '2.1' },
-      { label: '子选项二', value: '2.2' },
-    ],
+    label: 'Parent B',
+    value: 'b',
+    children: [{ label: 'Child B1', value: 'b1', disabled: true }],
   },
 ];
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-const cleanupPanel = () => {
-  document.querySelectorAll('.t-cascader__panel, .t-cascader__panel--content').forEach((node) => {
-    node.parentNode?.removeChild(node);
-  });
-};
-
-const setPopupVisible = async (wrapper: ReturnType<typeof mount>) =>
-  wrapper.setProps({ popupProps: { visible: true } });
-
-/**
- * 模拟用户在 slot 内的真实搜索框交互。
- *
- * 原来的模式是在 slot 渲染函数里 "偷" onFilter 引用到外部闭包，
- * 然后在测试里命令式调用 filterFn!('xxx')，这有几个问题：
- * 1. 不模拟用户行为 — 绕过了真实交互路径
- * 2. 依赖渲染时机 — filterFn 只有在 slot 被渲染后才非 null
- * 3. 18 个 no-non-null-assertion warning 全来自 filterFn!()
- *
- * 新的方案：构建一个真实的 FilterSlot 组件，渲染 <input> + 可选 <button>。
- * - 字符串过滤：用户输入 → watch → 调用 onFilter。测试通过 input 事件驱动。
- * - 函数过滤：点击 <button> → 调用 onFilter(fn)。测试通过 button.click() 驱动。
- *
- * 通过 props 控制模式，避免在每个测试中创建内联 defineComponent。
- */
-const FilterSlot = defineComponent({
-  name: 'FilterSlot',
-  props: {
-    onFilter: { type: Function, required: true },
-    /** 函数过滤器，非空时渲染 button 触发此函数过滤 */
-    fnFilter: { type: Function, default: undefined },
+const keyedOptions: CascaderOption[] = [
+  {
+    name: 'Custom parent',
+    id: 'custom',
+    items: [{ name: 'Custom child', id: 'custom-child' }],
   },
-  setup(props) {
-    const keyword = ref('');
-    watch(keyword, (val) => {
-      props.onFilter(val);
-    });
-    const handleBtnClick = () => {
-      if (props.fnFilter) {
-        props.onFilter(props.fnFilter);
-      }
-    };
-    return () => (
-      <div class="filter-slot">
-        <input
-          class="panel-filter-input"
-          value={keyword.value}
-          onInput={(e: Event) => {
-            keyword.value = (e.target as HTMLInputElement).value;
-          }}
-        />
-        {props.fnFilter && (
-          <button class="fn-filter-btn" onClick={handleBtnClick}>
-            Apply
-          </button>
-        )}
-      </div>
-    );
-  },
-});
-
-/** 模拟用户在 slot 搜索框中输入关键词 */
-const typeInFilterInput = async (value: string, index = 0) => {
-  const inputs = document.querySelectorAll('.panel-filter-input');
-  const input = inputs[index] as HTMLInputElement | undefined;
-  if (!input) throw new Error(`Filter input at index ${index} not found`);
-  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-  nativeInputValueSetter?.call(input, value);
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  await nextTick();
-};
-
-/** 模拟用户点击函数过滤按钮 */
-const clickFnFilterButton = async (index = 0) => {
-  const btns = document.querySelectorAll('.fn-filter-btn');
-  const btn = btns[index] as HTMLButtonElement | undefined;
-  if (!btn) throw new Error(`Function filter button at index ${index} not found`);
-  btn.click();
-  await nextTick();
-};
-
-/** 获取指定面板（从 0 开始）的选项列表 */
-const getPanelItems = (panelIndex = 0) => {
-  const menus = document.querySelectorAll('.t-cascader__menu');
-  return Array.from(menus[panelIndex]?.querySelectorAll('.t-cascader__item') ?? []);
-};
-
-/** 获取所有面板的选项总数 */
-const getAllItemCount = () => document.querySelectorAll('.t-cascader__item').length;
-
-/** 获取所有面板数量 */
-const getMenuCount = () => document.querySelectorAll('.t-cascader__menu').length;
-
-// ─── Tests ──────────────────────────────────────────────────────────────────
+];
 
 describe('Cascader', () => {
+  const wrappers: VueWrapper[] = [];
+
+  const renderCascader = (
+    props: Record<string, unknown> = {},
+    slots: Record<string, (...args: unknown[]) => unknown> = {},
+  ) => {
+    const wrapper = mount(Cascader, {
+      attachTo: document.body,
+      props: { options, ...props },
+      slots,
+    });
+    wrappers.push(wrapper);
+    return wrapper;
+  };
+
+  const getSelectInput = (wrapper: VueWrapper) => wrapper.findComponent(SelectInput);
+
+  const mountPanel = (wrapper: VueWrapper) => {
+    const panel = getSelectInput(wrapper).vm.$slots.panel;
+    const panelWrapper = mount({
+      name: 'CascaderPanelHost',
+      render: () => panel?.(),
+    });
+    wrappers.push(panelWrapper);
+    return panelWrapper;
+  };
+
   afterEach(() => {
-    cleanupPanel();
+    wrappers.splice(0).forEach((wrapper) => wrapper.unmount());
+    document.querySelectorAll('.t-popup, .t-cascader__panel').forEach((element) => element.remove());
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  describe(':props', () => {
-    describe(':base', () => {
-      it('should render correctly in single mode', async () => {
-        const wrapper = mount({
-          render: () => <Cascader options={options} />,
-        });
-        await setPopupVisible(wrapper);
+  describe('props', () => {
+    it('renders the single-select root', () => {
+      const wrapper = renderCascader();
 
-        expect(getMenuCount()).toBe(1);
-        expect(getAllItemCount()).toBe(2);
-        wrapper.unmount();
-      });
-
-      it('should render correctly in multiple mode', async () => {
-        const wrapper = mount({
-          render: () => <Cascader options={options} multiple />,
-        });
-        await setPopupVisible(wrapper);
-
-        expect(getMenuCount()).toBe(1);
-        expect(document.querySelectorAll('.t-checkbox').length).toBe(2);
-        wrapper.unmount();
-      });
-
-      it('should render disabled state correctly', () => {
-        const wrapper = mount({
-          render: () => <Cascader disabled options={options} />,
-        });
-        expect(wrapper.find('.t-is-disabled').exists()).toBe(true);
-        wrapper.unmount();
-      });
+      expect(wrapper.classes()).toContain('t-cascader');
+      expect(wrapper.classes()).toContain('t-cascader--single');
+      expect(getSelectInput(wrapper).exists()).toBe(true);
     });
 
-    describe(':value[string]', () => {
-      it('should render correctly with single value', async () => {
-        const wrapper = mount({
-          render: () => <Cascader value="1.1" options={options} />,
-        });
-        await setPopupVisible(wrapper);
+    it(':autofocus[boolean] is currently not forwarded to the input', () => {
+      const wrapper = renderCascader({ autofocus: true });
 
-        expect(getMenuCount()).toBe(2);
-        expect(getAllItemCount()).toBe(5);
-        wrapper.unmount();
-      });
+      expect(wrapper.find('input').attributes('autofocus')).toBeUndefined();
     });
 
-    describe(':value[array]', () => {
-      it('should render correctly with multiple values', async () => {
-        const wrapper = mount({
-          render: () => <Cascader value={['1.1']} multiple options={options} />,
-        });
-        await setPopupVisible(wrapper);
+    it(':borderless[boolean]', () => {
+      const wrapper = renderCascader({ borderless: true });
 
-        expect(getMenuCount()).toBe(2);
-        expect(getAllItemCount()).toBe(5);
-        expect(document.querySelectorAll('.t-checkbox').length).toBe(5);
-        wrapper.unmount();
-      });
+      expect(getSelectInput(wrapper).props('borderless')).toBe(true);
     });
 
-    describe(':size[string]', () => {
-      const sizeMap: Record<string, string> = { small: 's', large: 'l' };
+    it(':checkProps[object]', async () => {
+      const wrapper = renderCascader({ checkProps: { readonly: true }, multiple: true, popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
 
-      (['small', 'large'] as const).forEach((item) => {
-        it(`should render correctly with size ${item}`, async () => {
-          const wrapper = mount({
-            render: () => <Cascader options={options} size={item} />,
-          });
-          await setPopupVisible(wrapper);
+      expect(panel.findComponent(Checkbox).props('readonly')).toBe(true);
+    });
 
-          expect(document.querySelectorAll(`.t-size-${sizeMap[item]}`).length).toBe(2);
-          wrapper.unmount();
-        });
+    it(':checkStrictly[boolean]', async () => {
+      const onChange = vi.fn();
+      const wrapper = renderCascader({ checkStrictly: true, onChange, popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      await panel.find('.t-cascader__item').trigger('click');
+      await nextTick();
+      expect(onChange).toHaveBeenCalledWith('a', expect.objectContaining({ source: 'check' }));
+    });
+
+    it(':clearable[boolean]', () => {
+      const wrapper = renderCascader({ clearable: true });
+
+      expect(getSelectInput(wrapper).props('clearable')).toBe(true);
+    });
+
+    it(':collapsedItems[function]', () => {
+      const collapsedItems = vi.fn(() => <span class="function-collapsed">Collapsed</span>);
+      const wrapper = renderCascader({ collapsedItems, minCollapsedNum: 1, multiple: true, value: ['a1', 'a2'] });
+
+      expect(getSelectInput(wrapper).props('collapsedItems')).toBe(collapsedItems);
+    });
+
+    it(':collapsedItems[slot]', () => {
+      const wrapper = renderCascader(
+        { minCollapsedNum: 1, multiple: true, value: ['a1', 'a2'] },
+        { collapsedItems: () => <span class="slot-collapsed">Collapsed slot</span> },
+      );
+
+      expect(getSelectInput(wrapper).vm.$slots.collapsedItems).toBeDefined();
+    });
+
+    it(':columnHeader[string/function] and :columnFooter[string/function] are currently not forwarded', async () => {
+      const wrapper = renderCascader({
+        columnFooter: () => <span class="function-footer">Footer</span>,
+        columnHeader: 'Header',
+        popupVisible: true,
       });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.find('.function-footer').exists()).toBe(false);
+      expect(panel.text()).not.toContain('Header');
+    });
+
+    it(':columnHeader[slot] and :columnFooter[slot]', async () => {
+      const wrapper = renderCascader(
+        { popupVisible: true, value: 'a1' },
+        {
+          columnFooter: ({ panelIndex }) => <span class="slot-footer">Footer {String(panelIndex)}</span>,
+          columnHeader: ({ panelIndex }) => <span class="slot-header">Header {String(panelIndex)}</span>,
+        },
+      );
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.findAll('.slot-header')).toHaveLength(2);
+      expect(panel.findAll('.slot-footer')).toHaveLength(2);
+    });
+
+    it(':disabled[boolean]', () => {
+      const wrapper = renderCascader({ disabled: true });
+
+      expect(getSelectInput(wrapper).props('disabled')).toBe(true);
+      expect(wrapper.find('.t-is-disabled').exists()).toBe(true);
+    });
+
+    it(':empty[string]', async () => {
+      const wrapper = renderCascader({ empty: 'Nothing here', options: [], popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.text()).toBe('Nothing here');
+    });
+
+    it(':empty[function]', async () => {
+      const wrapper = renderCascader({
+        empty: () => <span class="function-empty">Nothing</span>,
+        options: [],
+        popupVisible: true,
+      });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.find('.function-empty').exists()).toBe(true);
+    });
+
+    it(':empty[slot]', async () => {
+      const wrapper = renderCascader(
+        { options: [], popupVisible: true },
+        { empty: () => <span class="slot-empty">Nothing</span> },
+      );
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.find('.slot-empty').exists()).toBe(true);
+    });
+
+    it(':filter[function]', async () => {
+      const filter = vi.fn((keyword: string, node) => String(node.label).includes(keyword));
+      const wrapper = renderCascader({ filter, popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+      const selectInput = getSelectInput(wrapper);
+
+      selectInput.props('onInputChange')('A1', { e: new InputEvent('input'), trigger: 'input' });
+      await nextTick();
+      expect(filter).toHaveBeenCalled();
+      expect(panel.findAll('.t-cascader__item')).toHaveLength(1);
+    });
+
+    it(':filterable[boolean]', () => {
+      const wrapper = renderCascader({ filterable: true });
+
+      expect(getSelectInput(wrapper).props('allowInput')).toBe(true);
+    });
+
+    it(':inputProps[object]', () => {
+      const wrapper = renderCascader({ inputProps: { autocomplete: 'off', size: 'large' }, size: 'small' });
+
+      expect(getSelectInput(wrapper).props('inputProps')).toEqual(
+        expect.objectContaining({ autocomplete: 'off', size: 'large' }),
+      );
+    });
+
+    it(':keys[object]', async () => {
+      const wrapper = renderCascader({
+        keys: { children: 'items', label: 'name', value: 'id' },
+        options: keyedOptions,
+        popupVisible: true,
+      });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.find('.t-cascader__item').text()).toContain('Custom parent');
+      expect(getSelectInput(wrapper).props('keys')).toEqual({ children: 'items', label: 'name', value: 'id' });
+    });
+
+    it(':label[string]', () => {
+      const wrapper = renderCascader({ label: 'Prefix' });
+
+      expect(wrapper.text()).toContain('Prefix');
+      expect(wrapper.find('.t-tag-input__prefix').exists()).toBe(true);
+    });
+
+    it(':label[function]', () => {
+      const wrapper = renderCascader({ label: () => <span class="function-label">Prefix</span> });
+
+      expect(wrapper.find('.function-label').exists()).toBe(true);
+    });
+
+    it(':label[slot]', () => {
+      const wrapper = renderCascader({}, { label: () => <span class="slot-label">Prefix</span> });
+
+      expect(wrapper.find('.slot-label').exists()).toBe(true);
+    });
+
+    it(':label[slot] is not wrapped in multiple mode', () => {
+      const wrapper = renderCascader({ multiple: true }, { label: () => <span class="multiple-label">Prefix</span> });
+
+      expect(wrapper.find('.multiple-label').exists()).toBe(true);
+    });
+
+    it(':lazy[boolean] and :load[function]', async () => {
+      const load = vi.fn(async () => [{ label: 'Lazy child', value: 'lazy-child' }]);
+      const wrapper = renderCascader({
+        lazy: true,
+        load,
+        options: [{ label: 'Lazy parent', value: 'lazy', children: true }],
+        popupVisible: true,
+      });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      await panel.find('.t-cascader__item').trigger('click');
+      await nextTick();
+      expect(load).toHaveBeenCalled();
+    });
+
+    it(':loading[boolean]', async () => {
+      const wrapper = renderCascader({ loading: true, popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(getSelectInput(wrapper).props('loading')).toBe(true);
+      expect(panel.find('.t-cascader__panel').classes()).not.toContain('t-cascader--normal');
+    });
+
+    it(':loadingText[string/function/slot]', async () => {
+      const stringWrapper = renderCascader({ loading: true, loadingText: 'Loading string', popupVisible: true });
+      const stringPanel = mountPanel(stringWrapper);
+      await nextTick();
+      expect(stringPanel.text()).toContain('Loading string');
+
+      const functionWrapper = renderCascader({
+        loading: true,
+        loadingText: () => <span class="function-loading">Loading</span>,
+        popupVisible: true,
+      });
+      const functionPanel = mountPanel(functionWrapper);
+      await nextTick();
+      expect(functionPanel.find('.function-loading').exists()).toBe(true);
+
+      const slotWrapper = renderCascader(
+        { loading: true, popupVisible: true },
+        { loadingText: () => <span class="slot-loading">Loading slot</span> },
+      );
+      const slotPanel = mountPanel(slotWrapper);
+      await nextTick();
+      expect(slotPanel.find('.slot-loading').exists()).toBe(true);
+    });
+
+    it(':max[number]', async () => {
+      const wrapper = renderCascader({ max: 1, multiple: true, popupVisible: true, value: ['a1'] });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.findAll('.t-checkbox').every((checkbox) => checkbox.classes().includes('t-is-disabled'))).toBe(true);
+    });
+
+    it(':minCollapsedNum[number]', () => {
+      const wrapper = renderCascader({ minCollapsedNum: 1, multiple: true });
+
+      expect(getSelectInput(wrapper).props('minCollapsedNum')).toBe(1);
+    });
+
+    it(':multiple[boolean]', async () => {
+      const wrapper = renderCascader({ multiple: true });
+      const panel = mountPanel(wrapper);
+
+      expect(wrapper.classes()).toContain('t-cascader--multiple');
+      expect(getSelectInput(wrapper).props('multiple')).toBe(true);
+      await panel.find('.t-cascader__item').trigger('click');
+      await nextTick();
+      expect(panel.findAll('.t-cascader__menu')).toHaveLength(2);
+    });
+
+    it(':option[function]', async () => {
+      const wrapper = renderCascader({
+        option: (_h: unknown, { item }: { item: CascaderOption }) => (
+          <span class="function-option">{String(item.label)}</span>
+        ),
+        popupVisible: true,
+      });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.findAll('.function-option')).toHaveLength(2);
+    });
+
+    it(':option[slot]', async () => {
+      const wrapper = renderCascader(
+        { popupVisible: true },
+        { option: ({ item }) => <span class="slot-option">{String(item.label)}</span> },
+      );
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.findAll('.slot-option')).toHaveLength(2);
+    });
+
+    it(':options[array]', async () => {
+      const wrapper = renderCascader({ popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.findAll('.t-cascader__item')).toHaveLength(2);
+    });
+
+    it(':panelTopContent[string] and :panelBottomContent[string]', async () => {
+      const wrapper = renderCascader({
+        panelBottomContent: 'Panel bottom',
+        panelTopContent: 'Panel top',
+        popupVisible: true,
+      });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.text()).toContain('Panel top');
+      expect(panel.text()).toContain('Panel bottom');
+    });
+
+    it(':panelTopContent[function] and :panelBottomContent[slot]', async () => {
+      const wrapper = renderCascader(
+        { panelTopContent: () => <span class="function-panel-top">Top</span>, popupVisible: true },
+        { panelBottomContent: () => <span class="slot-panel-bottom">Bottom</span> },
+      );
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(panel.find('.function-panel-top').exists()).toBe(true);
+      expect(panel.find('.slot-panel-bottom').exists()).toBe(true);
+    });
+
+    it(':placeholder[string]', async () => {
+      const wrapper = renderCascader({ placeholder: 'Choose one' });
+      expect(getSelectInput(wrapper).props('placeholder')).toBe('Choose one');
+
+      const selected = renderCascader({ popupVisible: true, value: 'a1' });
+      await nextTick();
+      expect(getSelectInput(selected).props('placeholder')).toBe('Parent A / Child A1');
+    });
+
+    it(':popupProps[object]', async () => {
+      const wrapper = renderCascader({
+        popupProps: { overlayClassName: 'custom-overlay', overlayStyle: { width: '320px' } },
+        popupVisible: true,
+      });
+      await nextTick();
+      const popupProps = getSelectInput(wrapper).props('popupProps');
+
+      expect(popupProps.overlayClassName).toEqual(['t-cascader__popup', 'custom-overlay']);
+      expect(popupProps.overlayInnerStyle).toEqual({ width: 'auto' });
+      expect(popupProps.overlayStyle).toEqual({ width: '320px' });
+    });
+
+    it(':popupProps[object] does not force panel width while loading or empty', () => {
+      const loading = renderCascader({ loading: true });
+      expect(getSelectInput(loading).props('popupProps').overlayInnerStyle).toBeUndefined();
+
+      const empty = renderCascader({ options: [] });
+      expect(getSelectInput(empty).props('popupProps').overlayInnerStyle).toBeUndefined();
+    });
+
+    it(':popupVisible[boolean]', async () => {
+      const wrapper = renderCascader({ popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
+
+      expect(getSelectInput(wrapper).props('popupVisible')).toBe(true);
+      expect(panel.find('.t-cascader__panel').exists()).toBe(true);
+    });
+
+    it(':defaultPopupVisible[boolean] is currently ineffective', () => {
+      const wrapper = mount(Cascader, {
+        attrs: { defaultPopupVisible: true },
+        props: { options },
+      });
+      wrappers.push(wrapper);
+
+      expect(getSelectInput(wrapper).props('popupVisible')).toBe(false);
+    });
+
+    it(':prefixIcon[function]', () => {
+      const wrapper = renderCascader({ prefixIcon: () => <span class="prefix-icon">P</span> });
+
+      expect(wrapper.find('.prefix-icon').exists()).toBe(true);
+    });
+
+    it(':prefixIcon[slot]', () => {
+      const wrapper = renderCascader({}, { prefixIcon: () => <span class="slot-prefix-icon">P</span> });
+
+      expect(wrapper.find('.slot-prefix-icon').exists()).toBe(true);
+    });
+
+    it(':readonly[boolean]', () => {
+      const wrapper = renderCascader({ readonly: true });
+
+      expect(getSelectInput(wrapper).props('readonly')).toBe(true);
+    });
+
+    it(':reserveKeyword[boolean]', () => {
+      const wrapper = renderCascader({ reserveKeyword: false });
+
+      expect(cascaderProps.reserveKeyword.default).toBe(true);
+      expect(wrapper.props('reserveKeyword')).toBe(false);
+    });
+
+    it(':selectInputProps[object]', () => {
+      const onPaste = vi.fn();
+      const wrapper = renderCascader({ selectInputProps: { allowInput: false, onPaste } });
+      const selectInput = getSelectInput(wrapper);
+
+      expect(selectInput.props('onPaste')).toBe(onPaste);
+      expect(selectInput.props('allowInput')).toBe(false);
+    });
+
+    it(':showAllLevels[boolean]', () => {
+      const full = renderCascader({ showAllLevels: true, value: 'a1' });
+      expect(getSelectInput(full).props('value')).toBe('Parent A / Child A1');
+
+      const leaf = renderCascader({ showAllLevels: false, value: 'a1' });
+      expect(getSelectInput(leaf).props('value')).toBe('Child A1');
+    });
+
+    it.each(['small', 'medium', 'large'] as const)(':size[string] supports %s', (size) => {
+      const wrapper = renderCascader({ size });
+
+      expect(getSelectInput(wrapper).props('inputProps')).toEqual(expect.objectContaining({ size }));
+      expect(getSelectInput(wrapper).props('tagInputProps')).toEqual(expect.objectContaining({ size }));
+    });
+
+    it(':size[string] validates supported values', () => {
+      expect(cascaderProps.size.validator(undefined)).toBe(true);
+      expect(cascaderProps.size.validator('small')).toBe(true);
+      // @ts-expect-error verify runtime validation
+      expect(cascaderProps.size.validator('invalid')).toBe(false);
+    });
+
+    it.each(['default', 'success', 'warning', 'error'] as const)(':status[string] supports %s', (status) => {
+      const wrapper = renderCascader({ status });
+
+      expect(getSelectInput(wrapper).props('status')).toBe(status);
+    });
+
+    it(':status[string] validates supported values', () => {
+      expect(cascaderProps.status.validator(undefined)).toBe(true);
+      expect(cascaderProps.status.validator('warning')).toBe(true);
+      // @ts-expect-error verify runtime validation
+      expect(cascaderProps.status.validator('invalid')).toBe(false);
+    });
+
+    it(':suffix[string]', () => {
+      const wrapper = renderCascader({ suffix: 'items' });
+
+      expect(wrapper.text()).toContain('items');
+    });
+
+    it(':suffix[function]', () => {
+      const wrapper = renderCascader({ suffix: () => <span class="function-suffix">items</span> });
+
+      expect(wrapper.find('.function-suffix').exists()).toBe(true);
+    });
+
+    it(':suffix[slot]', () => {
+      const wrapper = renderCascader({}, { suffix: () => <span class="slot-suffix">items</span> });
+
+      expect(wrapper.find('.slot-suffix').exists()).toBe(true);
+    });
+
+    it(':suffixIcon[function]', () => {
+      const wrapper = renderCascader({ suffixIcon: () => <span class="function-suffix-icon">S</span> });
+
+      expect(wrapper.find('.function-suffix-icon').exists()).toBe(true);
+      expect(wrapper.find('.t-fake-arrow').exists()).toBe(false);
+    });
+
+    it(':suffixIcon[slot]', () => {
+      const wrapper = renderCascader({}, { suffixIcon: () => <span class="slot-suffix-icon">S</span> });
+
+      expect(wrapper.find('.slot-suffix-icon').exists()).toBe(true);
+    });
+
+    it(':suffixIcon[default] renders the active fake arrow', async () => {
+      const wrapper = renderCascader({ popupVisible: true });
+      await nextTick();
+
+      expect(wrapper.find('.t-fake-arrow').classes()).toContain('t-fake-arrow--active');
+    });
+
+    it(':tagInputProps[object]', () => {
+      const wrapper = renderCascader({ tagInputProps: { autoWidth: true, size: 'large' }, size: 'small' });
+
+      expect(getSelectInput(wrapper).props('tagInputProps')).toEqual(
+        expect.objectContaining({ autoWidth: true, size: 'large' }),
+      );
+    });
+
+    it(':tagProps[object]', () => {
+      const wrapper = renderCascader({ tagProps: { closable: false, theme: 'primary' } });
+
+      expect(getSelectInput(wrapper).props('tagProps')).toEqual(
+        expect.objectContaining({ closable: false, theme: 'primary' }),
+      );
+    });
+
+    it(':tips[string]', () => {
+      const wrapper = renderCascader({ tips: 'Helpful tip' });
+
+      expect(getSelectInput(wrapper).props('tips')).toBe('Helpful tip');
+    });
+
+    it(':tips[function]', () => {
+      const wrapper = renderCascader({ tips: () => <span class="function-tips">Helpful</span> });
+
+      expect(wrapper.find('.function-tips').exists()).toBe(true);
+    });
+
+    it(':tips[slot] is currently not forwarded', () => {
+      const wrapper = renderCascader({}, { tips: () => <span class="slot-tips">Helpful</span> });
+
+      expect(wrapper.find('.slot-tips').exists()).toBe(false);
+    });
+
+    it(':trigger[string] supports click and hover', () => {
+      expect(cascaderProps.trigger.validator(undefined)).toBe(true);
+      expect(cascaderProps.trigger.validator('click')).toBe(true);
+      expect(cascaderProps.trigger.validator('hover')).toBe(true);
+      // @ts-expect-error verify runtime validation
+      expect(cascaderProps.trigger.validator('invalid')).toBe(false);
+    });
+
+    it(':value[string/number/array] and v-model', async () => {
+      const wrapper = renderCascader({ modelValue: 'a1' });
+      expect(getSelectInput(wrapper).props('value')).toBe('Parent A / Child A1');
+
+      await wrapper.setProps({ modelValue: 0, options: [{ label: 'Zero', value: 0 }] });
+      expect(getSelectInput(wrapper).props('value')).toBe('Zero');
+
+      await wrapper.setProps({ modelValue: ['a1'], multiple: true, options });
+      expect(getSelectInput(wrapper).props('value')).toEqual(['Parent A/Child A1']);
+    });
+
+    it(':defaultValue[string] controls uncontrolled initial state', () => {
+      const wrapper = renderCascader({ defaultValue: 'a1' });
+
+      expect(getSelectInput(wrapper).props('value')).toBe('Parent A / Child A1');
+    });
+
+    it(':valueDisplay[string]', () => {
+      const wrapper = renderCascader({ value: 'a1', valueDisplay: 'Selected value' });
+
+      expect(wrapper.text()).toContain('Selected value');
+    });
+
+    it(':valueDisplay[function]', async () => {
+      const valueDisplay = vi.fn((h, params) => (
+        <button class="function-value" onClick={() => params.onClose(0)}>
+          {`${String(params.value)}:${params.selectedOptions.length}`}
+        </button>
+      ));
+      const onRemove = vi.fn();
+      const wrapper = renderCascader({ multiple: true, onRemove, value: ['a1'], valueDisplay });
+
+      expect(wrapper.find('.function-value').text()).toBe('a1:1');
+      await wrapper.find('.function-value').trigger('click');
+      expect(onRemove).toHaveBeenCalledOnce();
+    });
+
+    it(':valueDisplay[slot]', () => {
+      const wrapper = renderCascader(
+        { value: 'a1' },
+        { valueDisplay: ({ value }) => <span class="slot-value">{String(value)}</span> },
+      );
+
+      expect(wrapper.find('.slot-value').text()).toBe('a1');
+    });
+
+    it(':valueMode[string] validates supported values', () => {
+      expect(cascaderProps.valueMode.validator(undefined)).toBe(true);
+      expect(cascaderProps.valueMode.validator('onlyLeaf')).toBe(true);
+      expect(cascaderProps.valueMode.validator('parentFirst')).toBe(true);
+      expect(cascaderProps.valueMode.validator('all')).toBe(true);
+      // @ts-expect-error verify runtime validation
+      expect(cascaderProps.valueMode.validator('invalid')).toBe(false);
+    });
+
+    it(':valueType[string] supports full paths and validates values', () => {
+      const wrapper = renderCascader({ value: ['a', 'a1'], valueType: 'full' });
+      expect(getSelectInput(wrapper).props('value')).toBe('Parent A / Child A1');
+
+      expect(cascaderProps.valueType.validator(undefined)).toBe(true);
+      expect(cascaderProps.valueType.validator('single')).toBe(true);
+      expect(cascaderProps.valueType.validator('full')).toBe(true);
+      // @ts-expect-error verify runtime validation
+      expect(cascaderProps.valueType.validator('invalid')).toBe(false);
     });
   });
 
-  // ─── Slot Rendering Tests ─────────────────────────────────────────────────
+  describe('events', () => {
+    it('blur', () => {
+      const onBlur = vi.fn();
+      const wrapper = renderCascader({ onBlur, value: 'a1' });
+      const event = new FocusEvent('blur');
 
-  describe(':slots', () => {
-    describe('columnHeader', () => {
-      it('should render columnHeader slot for each panel', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              value="1.1"
-              v-slots={{
-                columnHeader: ({ panelIndex }: ColumnHeaderSlotParams) => (
-                  <div class="custom-header">Header {panelIndex}</div>
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
+      getSelectInput(wrapper).props('onBlur')('', { e: event, inputValue: 'query' });
+      expect(onBlur).toHaveBeenCalledWith({ e: event, inputValue: 'query', value: 'a1' });
 
-        const headers = document.querySelectorAll('.custom-header');
-        expect(headers.length).toBe(2);
-        expect(headers[0].textContent).toBe('Header 0');
-        expect(headers[1].textContent).toBe('Header 1');
-        wrapper.unmount();
-      });
-
-      it('should render columnHeader with filter input and apply filter via user input', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-        expect(getAllItemCount()).toBe(2);
-
-        await typeInFilterInput('选项一');
-
-        const items = document.querySelectorAll('.t-cascader__item');
-        expect(items.length).toBe(1);
-        expect(items[0].textContent).toContain('选项一');
-        wrapper.unmount();
-      });
-
-      it('should provide filteredOptions that update after user input', async () => {
-        let capturedOptionsLength = 0;
-        let capturedFilteredLength = 0;
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ options: opts, filteredOptions, onFilter }: ColumnHeaderSlotParams) => {
-                  capturedOptionsLength = opts.length;
-                  capturedFilteredLength = filteredOptions.length;
-                  return <FilterSlot onFilter={onFilter} />;
-                },
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        expect(capturedOptionsLength).toBe(2);
-        expect(capturedFilteredLength).toBe(2);
-
-        await typeInFilterInput('选项一');
-
-        expect(capturedOptionsLength).toBe(2);
-        expect(capturedFilteredLength).toBe(1);
-        wrapper.unmount();
-      });
+      getSelectInput(wrapper).props('onBlur')('', { e: event, inputValue: undefined as unknown as string });
+      expect(onBlur).toHaveBeenLastCalledWith({ e: event, inputValue: '', value: 'a1' });
     });
 
-    describe('columnFooter', () => {
-      it('should render columnFooter slot for each panel', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              value="1.1"
-              v-slots={{
-                columnFooter: ({ panelIndex }: ColumnFooterSlotParams) => (
-                  <div class="custom-footer">Footer {panelIndex}</div>
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
+    it('focus', () => {
+      const onFocus = vi.fn();
+      const wrapper = renderCascader({ onFocus, value: 'a1' });
+      const event = new FocusEvent('focus');
 
-        const footers = document.querySelectorAll('.custom-footer');
-        expect(footers.length).toBe(2);
-        expect(footers[0].textContent).toBe('Footer 0');
-        expect(footers[1].textContent).toBe('Footer 1');
-        wrapper.unmount();
-      });
-
-      it('should render columnFooter with panel options context', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              value="1.1"
-              v-slots={{
-                columnFooter: ({ panelIndex, options: opts }: ColumnFooterSlotParams) => (
-                  <div class="custom-footer">
-                    Footer {panelIndex} - {opts.length} items
-                  </div>
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        const footers = document.querySelectorAll('.custom-footer');
-        expect(footers.length).toBe(2);
-        expect(footers[0].textContent).toContain('Footer 0 - 2 items');
-        expect(footers[1].textContent).toContain('Footer 1 - 3 items');
-        wrapper.unmount();
-      });
-
-      it('should provide filteredOptions equal to options when no filter is applied', async () => {
-        let capturedOptions: TreeOptionData[] = [];
-        let capturedFilteredOptions: TreeOptionData[] = [];
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnFooter: ({ options: opts, filteredOptions }: ColumnFooterSlotParams) => {
-                  capturedOptions = opts;
-                  capturedFilteredOptions = filteredOptions;
-                  return (
-                    <div class="custom-footer">
-                      Options: {opts.length}, Filtered: {filteredOptions.length}
-                    </div>
-                  );
-                },
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        expect(capturedOptions.length).toBe(2);
-        expect(capturedFilteredOptions.length).toBe(2);
-        expect(capturedFilteredOptions.map((o) => o.value)).toEqual(capturedOptions.map((o) => o.value));
-        wrapper.unmount();
-      });
-
-      it('should provide correct filteredOptions when filter is applied via columnHeader input', async () => {
-        let capturedOptionsLength = 0;
-        let capturedFilteredLength = 0;
-        let capturedFilteredLabels: string[] = [];
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-                columnFooter: ({ options: opts, filteredOptions }: ColumnFooterSlotParams) => {
-                  capturedOptionsLength = opts.length;
-                  capturedFilteredLength = filteredOptions.length;
-                  capturedFilteredLabels = filteredOptions.map((o) => String(o.label));
-                  return <div class="custom-footer">Filtered: {filteredOptions.length}</div>;
-                },
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        expect(capturedOptionsLength).toBe(2);
-        expect(capturedFilteredLength).toBe(2);
-
-        await typeInFilterInput('选项一');
-
-        expect(capturedOptionsLength).toBe(2);
-        expect(capturedFilteredLength).toBe(1);
-        expect(capturedFilteredLabels).toContain('选项一');
-        expect(capturedFilteredLabels).not.toContain('选项二');
-        wrapper.unmount();
-      });
-
-      it('should reset filteredOptions when filter input is cleared', async () => {
-        let capturedFilteredLength = 0;
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-                columnFooter: ({ filteredOptions }: ColumnFooterSlotParams) => {
-                  capturedFilteredLength = filteredOptions.length;
-                  return <div class="custom-footer">Filtered: {filteredOptions.length}</div>;
-                },
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await typeInFilterInput('选项一');
-        expect(capturedFilteredLength).toBe(1);
-
-        await typeInFilterInput('');
-        expect(capturedFilteredLength).toBe(2);
-        wrapper.unmount();
-      });
+      getSelectInput(wrapper).props('onFocus')('', { e: event, inputValue: '' });
+      expect(onFocus).toHaveBeenCalledWith({ e: event, value: 'a1' });
     });
 
-    it('should render both columnHeader and columnFooter slots', async () => {
-      const wrapper = mount({
-        render: () => (
-          <Cascader
-            options={options}
-            value="1.1"
-            v-slots={{
-              columnHeader: ({ panelIndex }: ColumnHeaderSlotParams) => (
-                <div class="custom-header">Header {panelIndex}</div>
-              ),
-              columnFooter: ({ panelIndex }: ColumnFooterSlotParams) => (
-                <div class="custom-footer">Footer {panelIndex}</div>
-              ),
-            }}
-          />
-        ),
-      });
-      await setPopupVisible(wrapper);
+    it('popup-visible-change', async () => {
+      const onPopupVisibleChange = vi.fn();
+      const wrapper = renderCascader({ onPopupVisibleChange });
 
-      expect(document.querySelectorAll('.custom-header').length).toBe(2);
-      expect(document.querySelectorAll('.custom-footer').length).toBe(2);
-      wrapper.unmount();
+      getSelectInput(wrapper).props('onPopupVisibleChange')(true, { trigger: 'trigger-element-click' });
+      await nextTick();
+      expect(onPopupVisibleChange).toHaveBeenCalledWith(true, { trigger: 'trigger-element-click' });
     });
 
-    it('should render slots when filterable prop is set', async () => {
-      const wrapper = mount({
-        render: () => (
-          <Cascader
-            options={options}
-            filterable
-            v-slots={{
-              columnHeader: ({ panelIndex }: ColumnHeaderSlotParams) => (
-                <div class="custom-header">Header {panelIndex}</div>
-              ),
-              columnFooter: ({ panelIndex }: ColumnFooterSlotParams) => (
-                <div class="custom-footer">Footer {panelIndex}</div>
-              ),
-            }}
-          />
-        ),
-      });
-      await setPopupVisible(wrapper);
+    it('popup-visible-change is ignored while disabled', () => {
+      const onPopupVisibleChange = vi.fn();
+      const wrapper = renderCascader({ disabled: true, onPopupVisibleChange });
 
-      expect(document.querySelectorAll('.custom-header').length).toBeGreaterThan(0);
-      expect(document.querySelectorAll('.custom-footer').length).toBeGreaterThan(0);
-      expect(getMenuCount()).toBeGreaterThan(0);
-      wrapper.unmount();
+      getSelectInput(wrapper).props('onPopupVisibleChange')(true, { trigger: 'trigger-element-click' });
+      expect(onPopupVisibleChange).not.toHaveBeenCalled();
     });
 
-    it('should render slots without filterable prop', async () => {
-      const wrapper = mount({
-        render: () => (
-          <Cascader
-            options={options}
-            v-slots={{
-              columnHeader: ({ panelIndex }: ColumnHeaderSlotParams) => (
-                <div class="custom-header">Header {panelIndex}</div>
-              ),
-              columnFooter: ({ panelIndex }: ColumnFooterSlotParams) => (
-                <div class="custom-footer">Footer {panelIndex}</div>
-              ),
-            }}
-          />
-        ),
-      });
-      await setPopupVisible(wrapper);
+    it('change', async () => {
+      const onChange = vi.fn();
+      const wrapper = renderCascader({ onChange, popupVisible: true });
+      const panel = mountPanel(wrapper);
+      await nextTick();
 
-      expect(document.querySelectorAll('.custom-header').length).toBeGreaterThan(0);
-      expect(document.querySelectorAll('.custom-footer').length).toBeGreaterThan(0);
-      wrapper.unmount();
+      await panel.findAll('.t-cascader__item')[0].trigger('click');
+      await nextTick();
+      await panel.findAll('.t-cascader__item')[2].trigger('click');
+      await nextTick();
+      expect(onChange).toHaveBeenCalledWith('a1', expect.objectContaining({ source: 'check' }));
+    });
+
+    it('change in multiple mode', async () => {
+      const onChange = vi.fn();
+      const wrapper = renderCascader({ multiple: true, onChange, popupVisible: true });
+      const panel = mountPanel(wrapper);
+
+      panel.findComponent(Checkbox).props('onChange')(true, { e: new Event('change') });
+      await nextTick();
+      expect(onChange).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ source: 'check' }));
+    });
+
+    it('change does not emit for the current controlled value', async () => {
+      const onChange = vi.fn();
+      const wrapper = renderCascader({ modelValue: 'a1', onChange, popupVisible: true });
+      const panel = mountPanel(wrapper);
+
+      await panel.findAll('.t-cascader__item')[2].trigger('click');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('remove ignores Enter tag changes and handles a removed tag', () => {
+      const onRemove = vi.fn();
+      const wrapper = renderCascader({ multiple: true, onRemove, value: ['a1'] });
+      const onTagChange = getSelectInput(wrapper).props('onTagChange');
+
+      onTagChange([], { index: 0, trigger: 'enter' });
+      expect(onRemove).not.toHaveBeenCalled();
+      onTagChange([], { index: 0, trigger: 'tag-remove' });
+      expect(onRemove).toHaveBeenCalledOnce();
+    });
+
+    it('clear', () => {
+      const onChange = vi.fn();
+      const wrapper = renderCascader({ onChange, value: 'a1' });
+
+      getSelectInput(wrapper).props('onClear')({ e: new MouseEvent('click') });
+      expect(onChange).toHaveBeenCalledWith('', expect.objectContaining({ source: 'clear' }));
+    });
+
+    it('input-change only updates filterable input and forwards selectInputProps callbacks', async () => {
+      const userInputChange = vi.fn();
+      const plain = renderCascader({ selectInputProps: { onInputChange: userInputChange } });
+      getSelectInput(plain).props('onInputChange')('ignored', { e: new InputEvent('input'), trigger: 'input' });
+      await nextTick();
+      expect(getSelectInput(plain).props('inputValue')).toBe('');
+      expect(userInputChange).toHaveBeenCalled();
+
+      const filterable = renderCascader({ filterable: true, popupVisible: true });
+      getSelectInput(filterable).props('onInputChange')('query', { e: new InputEvent('input'), trigger: 'input' });
+      await nextTick();
+      expect(getSelectInput(filterable).props('inputValue')).toBe('query');
     });
   });
 
-  // ─── Filter Behavior Tests ────────────────────────────────────────────────
+  describe('lifecycle', () => {
+    it('normalizes an invalid controlled value shape', async () => {
+      const onMultipleChange = vi.fn();
+      renderCascader({ modelValue: 'invalid', multiple: true, onChange: onMultipleChange });
+      await nextTick();
 
-  describe(':behavior', () => {
-    describe('filter in basic mode', () => {
-      it('should filter nodes with string input', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
+      expect(onMultipleChange).toHaveBeenCalledWith([], expect.objectContaining({ source: 'invalid-value' }));
 
-        await typeInFilterInput('选项一');
-
-        const items = document.querySelectorAll('.t-cascader__item');
-        expect(items.length).toBeGreaterThan(0);
-        expect(Array.from(items).some((item) => item.textContent?.includes('选项一'))).toBe(true);
-        wrapper.unmount();
-      });
-
-      it('should filter nodes with function filter via button click', async () => {
-        const matchByValue = (node: TreeOptionData) => node.value === '1';
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => (
-                  <FilterSlot onFilter={onFilter} fnFilter={matchByValue} />
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await clickFnFilterButton();
-
-        const items = document.querySelectorAll('.t-cascader__item');
-        expect(items.length).toBeGreaterThan(0);
-        wrapper.unmount();
-      });
-
-      it('should clear filter when input is emptied', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        const initialCount = getAllItemCount();
-        await typeInFilterInput('选项一');
-        expect(getAllItemCount()).toBeLessThan(initialCount);
-
-        await typeInFilterInput('');
-        expect(getAllItemCount()).toBeGreaterThanOrEqual(initialCount);
-        wrapper.unmount();
-      });
-
-      it('should treat whitespace-only input as no filter', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        const initialCount = getAllItemCount();
-        await typeInFilterInput('   ');
-
-        expect(getAllItemCount()).toBeGreaterThanOrEqual(initialCount);
-        wrapper.unmount();
-      });
-
-      it('should show zero items when function filter rejects all', async () => {
-        const rejectAll = () => false;
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => (
-                  <FilterSlot onFilter={onFilter} fnFilter={rejectAll} />
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await clickFnFilterButton();
-
-        expect(getPanelItems(0).length).toBe(0);
-        wrapper.unmount();
-      });
-
-      it('should keep all items when function filter accepts all', async () => {
-        const acceptAll = () => true;
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => (
-                  <FilterSlot onFilter={onFilter} fnFilter={acceptAll} />
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await clickFnFilterButton();
-
-        expect(getPanelItems(0).length).toBeGreaterThan(0);
-        wrapper.unmount();
-      });
-
-      it('should not match options with empty labels', async () => {
-        const optionsWithEmptyLabels: TreeOptionData[] = [
-          { label: '选项一', value: '1' },
-          { label: '', value: '2' },
-          { label: '选项三', value: '3' },
-        ];
-
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={optionsWithEmptyLabels}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await typeInFilterInput('选项');
-
-        const items = document.querySelectorAll('.t-cascader__item');
-        const itemTexts = Array.from(items).map((item) => item.textContent);
-        expect(itemTexts.some((text) => text?.includes('选项一'))).toBe(true);
-        expect(itemTexts.some((text) => text?.includes('选项三'))).toBe(true);
-        wrapper.unmount();
-      });
+      const onSingleChange = vi.fn();
+      renderCascader({ modelValue: ['a', 'a1'], onChange: onSingleChange, showAllLevels: false, valueType: 'single' });
+      await nextTick();
+      expect(onSingleChange).toHaveBeenCalledWith('', expect.objectContaining({ source: 'invalid-value' }));
     });
 
-    describe('filter in cascade mode', () => {
-      it('should support cascade filtering with string input', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await typeInFilterInput('选项一');
-
-        const items = document.querySelectorAll('.t-cascader__item');
-        expect(items.length).toBeGreaterThan(0);
-        expect(items[0].textContent).toContain('选项一');
-        wrapper.unmount();
+    it('resets filter input whenever a filterable popup opens', async () => {
+      const popupVisible = ref(true);
+      const wrapper = mount({
+        setup() {
+          return () => <Cascader options={options} filterable popupVisible={popupVisible.value} />;
+        },
       });
+      wrappers.push(wrapper);
+      const cascader = wrapper.findComponent(Cascader);
+      const selectInput = cascader.findComponent(SelectInput);
 
-      it('should support cascade filtering with function filter', async () => {
-        const matchByLabel = (node: TreeOptionData) => String(node.label).includes('选项');
+      selectInput.props('onInputChange')('query', { e: new InputEvent('input'), trigger: 'input' });
+      await nextTick();
+      expect(selectInput.props('inputValue')).toBe('query');
 
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => (
-                  <FilterSlot onFilter={onFilter} fnFilter={matchByLabel} />
-                ),
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await clickFnFilterButton();
-
-        expect(getAllItemCount()).toBeGreaterThan(0);
-        wrapper.unmount();
-      });
-
-      it('should show child panel when expanding node in cascade mode', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await typeInFilterInput('选项');
-
-        expect(getAllItemCount()).toBeGreaterThan(0);
-
-        const firstItem = document.querySelector('.t-cascader__item') as HTMLElement | null;
-        firstItem?.click();
-        await nextTick();
-
-        expect(getMenuCount()).toBeGreaterThan(0);
-        wrapper.unmount();
-      });
-
-      it('should hide child panels when no matches in parent cascade filter', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        await typeInFilterInput('不存在的选项');
-
-        expect(getAllItemCount()).toBe(0);
-        wrapper.unmount();
-      });
-
-      it('should clear filter when input is emptied in cascade mode', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        const initialCount = getAllItemCount();
-
-        await typeInFilterInput('选项一');
-        const filteredCount = getAllItemCount();
-        expect(filteredCount).toBeLessThan(initialCount);
-
-        await typeInFilterInput('');
-        expect(getAllItemCount()).toBeGreaterThanOrEqual(filteredCount);
-        wrapper.unmount();
-      });
-
-      it('should handle independent filters on different panels', async () => {
-        const wrapper = mount({
-          render: () => (
-            <Cascader
-              options={options}
-              v-slots={{
-                columnHeader: ({ onFilter }: ColumnHeaderSlotParams) => <FilterSlot onFilter={onFilter} />,
-              }}
-            />
-          ),
-        });
-        await setPopupVisible(wrapper);
-
-        // 在第一列过滤
-        await typeInFilterInput('选项一', 0);
-
-        const parentItems = getPanelItems(0);
-        expect(parentItems.length).toBeGreaterThan(0);
-        expect(parentItems[0].textContent).toContain('选项一');
-
-        // 清除过滤后，点击展开子面板
-        await typeInFilterInput('', 0);
-
-        const firstItem = document.querySelector('.t-cascader__item') as HTMLElement | null;
-        firstItem?.click();
-        await nextTick();
-
-        // 验证第二列出现后，在第二列搜索
-        const secondInputs = document.querySelectorAll('.panel-filter-input');
-        expect(secondInputs.length).toBeGreaterThanOrEqual(2);
-
-        await typeInFilterInput('子选项一', 1);
-
-        const childItems = getPanelItems(1);
-        expect(childItems.length).toBeGreaterThan(0);
-        expect(childItems[0].textContent).toContain('子选项一');
-        wrapper.unmount();
-      });
+      popupVisible.value = false;
+      await nextTick();
+      popupVisible.value = true;
+      await nextTick();
+      expect(cascader.findComponent(SelectInput).props('inputValue')).toBe('');
     });
   });
 });

--- a/packages/components/cascader/__tests__/cascader.utils.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.utils.test.tsx
@@ -1,0 +1,551 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FILTER_INACTIVE_LEVEL,
+  calculateExpand,
+  checkOptionMatchKeyword,
+  closeIconClickEffect,
+  expandClickEffect,
+  filterOptions,
+  getCascaderItemClass,
+  getCascaderItemIconClass,
+  getCascaderValue,
+  getFakeArrowIconClass,
+  getFullPathLabel,
+  getMultipleContent,
+  getNodeStatusClass,
+  getPanels,
+  getSingleContent,
+  getTreeValue,
+  handleRemoveTagEffect,
+  isEmptyValues,
+  isFilterActive,
+  isFilterLevelActive,
+  isValueInvalid,
+  treeNodesEffect,
+  treeStoreExpendEffect,
+  valueChangeEffect,
+} from '@tdesign/components/cascader/utils';
+import type { CascaderContextType, TreeNode, TreeNodeModel } from '@tdesign/components/cascader/types';
+
+const STATUS = {
+  disabled: 't-is-disabled',
+  expanded: 't-is-expanded',
+  selected: 't-is-selected',
+};
+const SIZE = { small: 't-size-s', medium: 't-size-m', large: 't-size-l' };
+
+const asNode = (node: Record<string, unknown>) => node as unknown as TreeNode;
+const asContext = (context: Record<string, unknown>) => context as unknown as CascaderContextType;
+
+const createPathNodes = () => {
+  const parent = asNode({ label: 'Parent', value: 'parent' });
+  const child = asNode({
+    data: { label: 'Child', value: 'child' },
+    label: 'Child',
+    value: 'child',
+    getPath: () => [parent, child],
+  });
+  return { parent, child };
+};
+
+describe('Cascader utils', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('helper', () => {
+    it('getSingleContent() handles empty, multiple, array, and missing-node values', () => {
+      const treeStore = { getNodes: vi.fn(() => []) };
+
+      expect(getSingleContent(asContext({ multiple: true, value: 'child', treeStore }))).toBe('');
+      expect(getSingleContent(asContext({ multiple: false, value: '', treeStore }))).toBe('');
+      expect(getSingleContent(asContext({ multiple: false, value: ['child'], treeStore }))).toBe('');
+      expect(getSingleContent(asContext({ multiple: false, value: 0, treeStore }))).toBe(0);
+      expect(getSingleContent(asContext({ multiple: false, value: 'unknown', treeStore }))).toBe('unknown');
+    });
+
+    it('getSingleContent() returns either the full path or leaf label', () => {
+      const { child } = createPathNodes();
+      const treeStore = { getNodes: vi.fn(() => [child]) };
+
+      expect(getSingleContent(asContext({ multiple: false, value: 'child', treeStore, showAllLevels: true }))).toBe(
+        'Parent / Child',
+      );
+      expect(getSingleContent(asContext({ multiple: false, value: 'child', treeStore, showAllLevels: false }))).toBe(
+        'Child',
+      );
+
+      const pathlessNode = asNode({ getPath: (): TreeNode[] => [], label: 'Pathless' });
+      treeStore.getNodes.mockReturnValue([pathlessNode]);
+      expect(getSingleContent(asContext({ multiple: false, value: 'raw', treeStore, showAllLevels: true }))).toBe(
+        'raw',
+      );
+    });
+
+    it('getMultipleContent() handles incompatible and missing values', () => {
+      expect(getMultipleContent(asContext({ multiple: false, value: [] }))).toEqual([]);
+      expect(getMultipleContent(asContext({ multiple: true, value: 'child' }))).toEqual([]);
+      expect(getMultipleContent(asContext({ multiple: true, value: ['child'], treeStore: undefined }))).toEqual([]);
+    });
+
+    it('getMultipleContent() returns leaf labels or full paths and drops unknown values', () => {
+      const { child } = createPathNodes();
+      const treeStore = {
+        getNodes: vi.fn((value: string | string[]) => {
+          if (Array.isArray(value)) return [child];
+          return value === 'child' ? [child] : [];
+        }),
+      };
+
+      expect(
+        getMultipleContent(asContext({ multiple: true, value: ['child', 'unknown'], treeStore, showAllLevels: false })),
+      ).toEqual(['Child']);
+      expect(
+        getMultipleContent(asContext({ multiple: true, value: ['child'], treeStore, showAllLevels: true })),
+      ).toEqual(['Parent/Child']);
+    });
+
+    it('getPanels() groups sparse tree levels', () => {
+      const nodes = [
+        asNode({ level: 0, value: 'a' }),
+        asNode({ level: 1, value: 'b' }),
+        asNode({ level: 0, value: 'c' }),
+      ];
+
+      expect(getPanels(nodes).map((panel) => panel.map((node) => node.value))).toEqual([['a', 'c'], ['b']]);
+    });
+
+    it('getFullPathLabel() supports custom separators and missing nodes', () => {
+      const { child } = createPathNodes();
+
+      expect(getFullPathLabel(child)).toBe('Parent/Child');
+      expect(getFullPathLabel(child, ' > ')).toBe('Parent > Child');
+      expect(getFullPathLabel(undefined as unknown as TreeNode)).toBeUndefined();
+    });
+
+    it.each([
+      [[], []],
+      [
+        ['a', 'b'],
+        ['a', 'b'],
+      ],
+      [[{ label: 'A', value: 'a' }], ['a']],
+      ['a', ['a']],
+      [0, [0]],
+      [{ label: 'A', value: 'a' }, ['a']],
+      ['', []],
+      [null, []],
+      [Number.NaN, []],
+    ])('getTreeValue(%j)', (value, expected) => {
+      expect(getTreeValue(value)).toEqual(expected);
+    });
+
+    it('getCascaderValue() handles single and full value modes', () => {
+      expect(getCascaderValue('leaf', 'single', false)).toBe('leaf');
+      expect(getCascaderValue(['parent', 'leaf'], 'full', false)).toBe('leaf');
+      expect(
+        getCascaderValue(
+          [
+            ['parent', 'first'],
+            ['parent', 'second'],
+          ],
+          'full',
+          true,
+        ),
+      ).toEqual(['first', 'second']);
+    });
+
+    it.each([
+      [0, false],
+      [1, false],
+      ['', true],
+      [[], true],
+      [{}, true],
+      [Number.NaN, true],
+    ])('isEmptyValues(%j)', (value, expected) => {
+      expect(isEmptyValues(value)).toBe(expected);
+    });
+
+    it('isValueInvalid() validates single and multiple shapes', () => {
+      expect(isValueInvalid('one', asContext({ multiple: true }))).toBe(true);
+      expect(isValueInvalid(['one'], asContext({ multiple: true }))).toBe(false);
+      expect(
+        isValueInvalid(['parent', 'leaf'], asContext({ multiple: false, valueType: 'single', showAllLevels: false })),
+      ).toBe(true);
+      expect(
+        isValueInvalid(['parent', 'leaf'], asContext({ multiple: false, valueType: 'full', showAllLevels: true })),
+      ).toBe(false);
+    });
+
+    it('filter helpers handle inactive, string, and function filters', () => {
+      const nodes = [
+        asNode({ data: { label: 'Alpha', value: 'a' }, label: 'Alpha' }),
+        asNode({ data: { label: '', value: 'empty' }, label: '' }),
+        asNode({ data: { label: 'Beta', value: 'b' }, label: 'Beta' }),
+      ];
+
+      expect(FILTER_INACTIVE_LEVEL).toBe(-1);
+      expect(isFilterLevelActive(-1)).toBe(false);
+      expect(isFilterLevelActive(0)).toBe(true);
+      expect(isFilterActive(undefined)).toBe(false);
+      expect(isFilterActive('   ')).toBe(false);
+      expect(isFilterActive('alpha')).toBe(true);
+      expect(isFilterActive(() => true)).toBe(true);
+      expect(checkOptionMatchKeyword(nodes[0], 'alpha')).toBe(true);
+      expect(checkOptionMatchKeyword(nodes[1], 'alpha')).toBe(false);
+      expect(checkOptionMatchKeyword(nodes[0], '')).toBe(false);
+      expect(filterOptions(nodes, ' ALPHA ', 0)).toEqual([nodes[0]]);
+      expect(filterOptions(nodes, '  ', 0)).toEqual(nodes);
+      expect(filterOptions(nodes, (option, index) => option.value === 'b' && index === 2, 2)).toEqual([nodes[2]]);
+    });
+  });
+
+  describe('className', () => {
+    it('getFakeArrowIconClass() reflects disabled state', () => {
+      expect(getFakeArrowIconClass('t', STATUS, asContext({ disabled: true }))).toEqual([
+        't-cascader__icon',
+        { 't-is-disabled': true },
+      ]);
+    });
+
+    it('getNodeStatusClass() reflects selected, expanded, and disabled states', () => {
+      const parent = asNode({ checked: false, disabled: false, expanded: true, isLeaf: () => false });
+      expect(
+        getNodeStatusClass(
+          parent,
+          STATUS,
+          asContext({ checkStrictly: false, multiple: true, value: [], max: 0, isParentFilterable: false }),
+        ),
+      ).toEqual([{ 't-is-disabled': false, 't-is-expanded': true, 't-is-selected': true }]);
+
+      const strictParent = asNode({ checked: true, disabled: false, expanded: true, isLeaf: () => false });
+      expect(
+        getNodeStatusClass(
+          strictParent,
+          STATUS,
+          asContext({ checkStrictly: true, multiple: false, value: 'a', max: 0, isParentFilterable: false }),
+        ),
+      ).toEqual([{ 't-is-disabled': false, 't-is-expanded': true, 't-is-selected': true }]);
+
+      const limitedLeaf = asNode({ checked: true, disabled: false, expanded: false, isLeaf: () => true });
+      expect(
+        getNodeStatusClass(
+          limitedLeaf,
+          STATUS,
+          asContext({ checkStrictly: false, multiple: true, value: ['a'], max: 1, isParentFilterable: false }),
+        ),
+      ).toEqual([{ 't-is-disabled': true, 't-is-expanded': false, 't-is-selected': false }]);
+    });
+
+    it('getCascaderItemClass() and getCascaderItemIconClass() compose item state', () => {
+      const node = asNode({
+        checked: false,
+        children: [],
+        disabled: false,
+        expanded: false,
+        isLeaf: () => true,
+      });
+      const context = asContext({
+        checkStrictly: false,
+        isParentFilterable: false,
+        max: 0,
+        multiple: false,
+        size: 'small',
+        value: '',
+      });
+
+      expect(getCascaderItemClass('t', node, SIZE, STATUS, context)).toEqual([
+        't-cascader__item',
+        { 't-is-disabled': false, 't-is-expanded': false, 't-is-selected': false },
+        't-size-s',
+        { 't-cascader__item--leaf': true, 't-cascader__item--with-icon': true },
+      ]);
+      expect(getCascaderItemIconClass('t', node, STATUS, context)).toEqual([
+        't-cascader__item-icon',
+        't-icon',
+        { 't-is-disabled': false, 't-is-expanded': false, 't-is-selected': false },
+      ]);
+    });
+  });
+
+  describe('effect', () => {
+    const createEffectFixture = (overrides: Record<string, unknown> = {}) => {
+      const treeStore = {
+        getExpanded: vi.fn(() => ['parent']),
+        getNode: vi.fn(),
+        getNodes: vi.fn(() => []),
+        refreshNodes: vi.fn(),
+        replaceChecked: vi.fn(),
+        replaceExpanded: vi.fn(),
+        resetChecked: vi.fn(),
+      };
+      const context = asContext({
+        checkStrictly: false,
+        disabled: false,
+        inputVal: '',
+        isParentFilterable: false,
+        max: 0,
+        multiple: false,
+        reserveKeyword: true,
+        setExpand: vi.fn(),
+        setInputVal: vi.fn(),
+        setTreeNodes: vi.fn(),
+        setValue: vi.fn(),
+        setVisible: vi.fn(),
+        treeNodes: [],
+        treeStore,
+        value: '',
+        valueType: 'single',
+        ...overrides,
+      });
+      return { context, treeStore };
+    };
+
+    const createEffectNode = (overrides: Record<string, unknown> = {}) => {
+      const node = asNode({
+        checked: false,
+        disabled: false,
+        getModel: vi.fn(() => ({ value: 'child' })),
+        getPath: vi.fn(() => [{ value: 'parent' }, { value: 'child' }]),
+        isChecked: vi.fn(() => false),
+        isLeaf: vi.fn(() => true),
+        setChecked: vi.fn(() => ['child']),
+        setExpanded: vi.fn(() => ['parent']),
+        value: 'child',
+        ...overrides,
+      });
+      return node;
+    };
+
+    it('expandClickEffect() ignores disabled and max-limited nodes', () => {
+      const node = createEffectNode({ disabled: true });
+      const { context } = createEffectFixture();
+      expandClickEffect('click', 'click', node, context);
+      expect(node.setExpanded).not.toHaveBeenCalled();
+
+      const limitedNode = createEffectNode();
+      const limited = createEffectFixture({ max: 1, multiple: true, value: ['selected'] });
+      expandClickEffect('click', 'click', limitedNode, limited.context);
+      expect(limitedNode.setExpanded).not.toHaveBeenCalled();
+    });
+
+    it('expandClickEffect() expands visible nodes and tracks multi-select expansion', () => {
+      const node = createEffectNode({ isLeaf: vi.fn(() => false) });
+      const visibleNode = createEffectNode({ visible: true });
+      const { context, treeStore } = createEffectFixture({ multiple: true, treeNodes: [visibleNode], value: [] });
+      treeStore.getNodes.mockReturnValue([visibleNode]);
+
+      expandClickEffect('click', 'click', node, context);
+      expect(treeStore.replaceExpanded).toHaveBeenCalledWith(['parent']);
+      expect(context.setTreeNodes).toHaveBeenCalledWith([visibleNode]);
+      expect(context.setExpand).toHaveBeenCalledWith(['parent']);
+    });
+
+    it('expandClickEffect() refreshes filtered nodes without tracking parent-filter expansion', () => {
+      const node = createEffectNode({ isLeaf: vi.fn(() => false) });
+      const { context, treeStore } = createEffectFixture({
+        inputVal: 'child',
+        isParentFilterable: true,
+        multiple: true,
+        value: [],
+      });
+
+      expandClickEffect('hover', 'hover', node, context);
+      expect(treeStore.refreshNodes).toHaveBeenCalledOnce();
+      expect(context.setExpand).not.toHaveBeenCalled();
+    });
+
+    it('expandClickEffect() selects a single leaf in single and full value modes', () => {
+      const node = createEffectNode();
+      const single = createEffectFixture();
+
+      expandClickEffect('click', 'click', node, single.context);
+      expect(single.treeStore.resetChecked).toHaveBeenCalledOnce();
+      expect(single.context.setValue).toHaveBeenCalledWith('child', 'check', { value: 'child' });
+      expect(single.context.setVisible).toHaveBeenCalledWith(false, {});
+
+      const fullNode = createEffectNode();
+      const full = createEffectFixture({ checkStrictly: true, valueType: 'full' });
+      expandClickEffect('click', 'click', fullNode, full.context);
+      expect(full.context.setValue).toHaveBeenCalledWith(['parent', 'child'], 'check', { value: 'child' });
+      expect(full.context.setVisible).not.toHaveBeenCalled();
+    });
+
+    it('expandClickEffect() closes a click selection when hover trigger or filtering is active', () => {
+      const node = createEffectNode();
+      const hover = createEffectFixture({ checkStrictly: true });
+      expandClickEffect('hover', 'click', node, hover.context);
+      expect(hover.context.setVisible).toHaveBeenCalledWith(false, {});
+
+      const filtered = createEffectFixture({ checkStrictly: true, inputVal: 'child' });
+      expandClickEffect('click', 'click', createEffectNode(), filtered.context);
+      expect(filtered.context.setVisible).toHaveBeenCalledWith(false, {});
+    });
+
+    it('valueChangeEffect() ignores unavailable nodes', () => {
+      const fixture = createEffectFixture();
+      valueChangeEffect(undefined as unknown as TreeNode, fixture.context);
+      valueChangeEffect(createEffectNode(), createEffectFixture({ disabled: true }).context);
+      valueChangeEffect(createEffectNode({ disabled: true }), fixture.context);
+      expect(fixture.context.setValue).not.toHaveBeenCalled();
+    });
+
+    it('valueChangeEffect() warns for negative max and stops values over a positive max', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const negative = createEffectFixture({ max: -1 });
+      valueChangeEffect(createEffectNode(), negative.context);
+      expect(warn).toHaveBeenCalledWith('TDesign Warn:', 'max should > 0');
+
+      const limited = createEffectFixture({ max: 1 });
+      valueChangeEffect(createEffectNode({ setChecked: vi.fn(() => ['a', 'b']) }), limited.context);
+      expect(limited.context.setValue).not.toHaveBeenCalled();
+    });
+
+    it('valueChangeEffect() restores expansion after clearing the final value', () => {
+      vi.useFakeTimers();
+      const { context, treeStore } = createEffectFixture();
+      valueChangeEffect(createEffectNode({ setChecked: vi.fn(() => []) }), context);
+
+      vi.runAllTimers();
+      expect(treeStore.replaceExpanded).toHaveBeenCalledWith(['parent']);
+      expect(treeStore.refreshNodes).toHaveBeenCalledOnce();
+      expect(context.setValue).toHaveBeenCalledWith([], 'check', { value: 'child' });
+    });
+
+    it('valueChangeEffect() closes a fully selected filter result and clears an unreserved keyword', () => {
+      const first = createEffectNode({ value: 'first' });
+      const second = createEffectNode({ value: 'second' });
+      const node = createEffectNode({ checked: true, setChecked: vi.fn(() => ['first', 'second']) });
+      const { context } = createEffectFixture({
+        inputVal: 'query',
+        reserveKeyword: false,
+        treeNodes: [first, second],
+      });
+
+      valueChangeEffect(node, context);
+      expect(context.setVisible).toHaveBeenCalledWith(false, {});
+      expect(context.setValue).toHaveBeenCalledWith(['first', 'second'], 'uncheck', { value: 'child' });
+      expect(context.setInputVal).toHaveBeenCalledWith('');
+    });
+
+    it('valueChangeEffect() emits full paths', () => {
+      const first = createEffectNode({ value: 'first' });
+      const { context, treeStore } = createEffectFixture({ treeNodes: [first], valueType: 'full' });
+      treeStore.getNode.mockReturnValue(first);
+
+      valueChangeEffect(createEffectNode({ setChecked: vi.fn(() => ['first']) }), context);
+      expect(context.setValue).toHaveBeenCalledWith([['parent', 'child']], 'check', { value: 'child' });
+    });
+
+    it('closeIconClickEffect() clears single and multiple values', () => {
+      const single = createEffectFixture();
+      closeIconClickEffect(single.context);
+      expect(single.context.setVisible).toHaveBeenCalledWith(false, {});
+      expect(single.context.setValue).toHaveBeenCalledWith('', 'clear');
+
+      const multiple = createEffectFixture({ multiple: true });
+      closeIconClickEffect(multiple.context);
+      expect(multiple.context.setValue).toHaveBeenCalledWith([], 'clear');
+    });
+
+    it('handleRemoveTagEffect() ignores disabled state and handles clear notifications', () => {
+      const onRemove = vi.fn();
+      const disabled = createEffectFixture({ disabled: true });
+      handleRemoveTagEffect(disabled.context, 0, onRemove);
+      expect(disabled.context.setValue).not.toHaveBeenCalled();
+
+      const clear = createEffectFixture({ value: ['a'] });
+      handleRemoveTagEffect(clear.context, undefined, onRemove);
+      expect(onRemove).toHaveBeenCalledWith({ value: ['a'], node: undefined });
+      expect(() => handleRemoveTagEffect(clear.context, undefined, undefined)).not.toThrow();
+    });
+
+    it('handleRemoveTagEffect() removes single and full path values', () => {
+      const onRemove = vi.fn();
+      const node = createEffectNode({ checked: true, setChecked: vi.fn(() => ['second']) });
+      const single = createEffectFixture({ value: ['first', 'second'] });
+      single.treeStore.getNodes.mockReturnValue([node]);
+
+      handleRemoveTagEffect(single.context, 0, onRemove);
+      expect(single.context.setValue).toHaveBeenCalledWith(['second'], 'uncheck', { value: 'child' });
+      expect(onRemove).toHaveBeenCalledWith({ value: ['second'], node });
+
+      const full = createEffectFixture({ value: [['parent', 'child']], valueType: 'full' });
+      full.treeStore.getNodes.mockReturnValue([node]);
+      full.treeStore.getNode.mockReturnValue(node);
+      handleRemoveTagEffect(full.context, 0, undefined);
+      expect(full.context.setValue).toHaveBeenCalledWith([['parent', 'child']], 'uncheck', { value: 'child' });
+    });
+
+    it('treeNodesEffect() handles missing stores, visible nodes, string filters, parent filters, and function filters', () => {
+      const setTreeNodes = vi.fn();
+      expect(() => treeNodesEffect('', undefined, setTreeNodes, undefined, false)).not.toThrow();
+
+      const parent = createEffectNode({
+        getPath: vi.fn(() => [{ label: 'Parent' }]),
+        isLeaf: vi.fn(() => false),
+        visible: true,
+      });
+      const leaf = createEffectNode({
+        getPath: vi.fn(() => [{ label: 'Parent' }, { label: 'Leaf' }]),
+        isLeaf: vi.fn(() => true),
+        visible: true,
+      });
+      const hidden = createEffectNode({ isLeaf: vi.fn(() => true), visible: false });
+      const treeStore = { getNodes: vi.fn(() => [parent, leaf, hidden]), nodes: [parent, leaf, hidden] };
+
+      treeNodesEffect('', treeStore as never, setTreeNodes, undefined, false);
+      expect(setTreeNodes).toHaveBeenLastCalledWith([parent, leaf]);
+      treeNodesEffect('ParentLeaf', treeStore as never, setTreeNodes, undefined, false);
+      expect(setTreeNodes).toHaveBeenLastCalledWith([leaf]);
+      treeNodesEffect('Parent', treeStore as never, setTreeNodes, undefined, true);
+      expect(setTreeNodes).toHaveBeenLastCalledWith([parent, leaf]);
+
+      const filter = vi.fn(
+        (keyword: string, node: TreeNodeModel) => keyword === 'custom' && node === (leaf as unknown as TreeNodeModel),
+      );
+      treeNodesEffect('custom', treeStore as never, setTreeNodes, filter, false);
+      expect(filter).toHaveBeenCalled();
+      expect(setTreeNodes).toHaveBeenLastCalledWith([leaf]);
+    });
+
+    it('calculateExpand() returns empty, refreshes unknown nodes, and includes ancestors', () => {
+      const { parent, child } = createPathNodes();
+      child.getParents = vi.fn(() => [parent]);
+      const treeStore = { getNode: vi.fn(), refreshNodes: vi.fn() };
+
+      expect(calculateExpand(treeStore as never, [])).toEqual([]);
+      treeStore.getNode.mockReturnValue(undefined);
+      expect(calculateExpand(treeStore as never, ['unknown'])).toEqual([]);
+      expect(treeStore.refreshNodes).toHaveBeenCalledOnce();
+      treeStore.getNode.mockReturnValue(child);
+      expect(calculateExpand(treeStore as never, ['child'])).toEqual(['child', 'parent']);
+    });
+
+    it('treeStoreExpendEffect() initializes and replaces tracked expansion', () => {
+      expect(() => treeStoreExpendEffect(undefined, 'child', [])).not.toThrow();
+      const { parent, child } = createPathNodes();
+      child.getParents = vi.fn(() => [parent]);
+      const treeStore = {
+        getExpanded: vi.fn(() => ['child']),
+        getNode: vi.fn(() => child),
+        refreshNodes: vi.fn(),
+        replaceExpanded: vi.fn(),
+      };
+
+      treeStoreExpendEffect(treeStore as never, 'child', []);
+      expect(treeStore.replaceExpanded).toHaveBeenCalledWith(['child', 'parent']);
+
+      treeStoreExpendEffect(treeStore as never, 'child', ['parent']);
+      expect(treeStore.replaceExpanded).toHaveBeenLastCalledWith(['parent']);
+      expect(treeStore.refreshNodes).toHaveBeenCalledTimes(2);
+
+      treeStore.getExpanded.mockReturnValue([]);
+      treeStoreExpendEffect(treeStore as never, '', ['parent']);
+      // getExpanded() returns an array, and even an empty array is truthy in the current implementation.
+      expect(treeStore.replaceExpanded).toHaveBeenCalledTimes(3);
+    });
+  });
+});


### PR DESCRIPTION
### 变更说明

按照 Form 风格直接重写 Cascader 旧单测，不在旧用例上叠加：

- 移除旧文件中重复、覆盖不完整的测试组织方式
- 按真实组件 / 子组件 / 工具函数拆成 5 个测试文件
- 使用 `props`、`events`、`lifecycle` 等行为分组
- 覆盖公开 props 的 String / Function / Slot 形式、v-model、交互事件、过滤、懒加载、多选、面板列过滤及生命周期
- 不使用快照断言，不包含 `ts-nocheck`
- 本 PR 只修改测试，不修改源码

### 用例

| 文件 | 用例数 | 内容 |
| --- | ---: | --- |
| `cascader.test.tsx` | 84 | Cascader 全部 props、事件、v-model、生命周期 |
| `cascader-panel.test.tsx` | 9 | 公开 CascaderPanel 行为 |
| `cascader-sub-panel.test.tsx` | 19 | 面板渲染、列过滤、展开与缓存清理 |
| `cascader-item.test.tsx` | 12 | 单项、复选框、过滤高亮、图标与事件 |
| `cascader.utils.test.tsx` | 43 | helper / className / effect 全部分支 |
| **合计** | **167** | 旧测试为 1 个文件、31 个用例 |

### 覆盖率

| 范围 | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| Cascader 核心文件（before） | 91.73% | 70% | 57.14% | 91.73% |
| Cascader 核心文件（after） | 100% | 100% | 100% | 100% |
| `components`（before） | 87.88% | 82.5% | 72.41% | 87.88% |
| `components`（after） | 100% | 98.21% | 100% | 100% |
| `hooks`（before） | 88.67% | 70.96% | 75% | 88.67% |
| `hooks`（after） | 100% | 100% | 100% | 100% |
| `utils`（before） | 66.27% | 70.29% | 83.33% | 66.27% |
| `utils`（after） | 100% | 100% | 100% | 100% |

Cascader 源码整体（排除纯类型文件）为 **100% / 99.54% / 100% / 100%**。剩余两个分支是内部已有前置条件保护下不可到达的防御性 fallback。

### 验证

- Cascader unit：167 pass
- Cascader coverage：167 pass
- 全量 unit：163 files / 3766 pass / 2 skipped / 3 todo
- 全量 snap：163 files / 3748 pass / 20 skipped / 3 todo
- `tsc --noEmit`：pass
- 目标 ESLint `--max-warnings 0`：pass
- 完整 `pnpm lint`：pass

### 源码问题

按当前真实行为断言并添加注释，未在本测试 PR 中修改源码。已集中记录在 #6903，包括：

- `autofocus` 回归（关联历史 #4203）
- `defaultPopupVisible` 未实现
- `columnHeader` / `columnFooter` 的 String / Function 形式未透传
- `tips` Slot 未透传
- CascaderPanel 丢失 option、loading、列内容及面板顶部/底部内容

Related to #5631
Related to #6903