### PR TITLE
fix(switch): use latest onChange callback after props update

### DIFF
--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -412,18 +412,6 @@ describe('Switch', () => {
       expect(wrapper.emitted('update:modelValue')).toBeUndefined();
     });
 
-    it('uses the latest change listener after props update', async () => {
-      const initialOnChange = vi.fn();
-      const latestOnChange = vi.fn();
-      const wrapper = mount(Switch, { props: { onChange: initialOnChange } });
-
-      await wrapper.setProps({ onChange: latestOnChange });
-      await wrapper.get('.t-switch').trigger('click');
-
-      expect(initialOnChange).not.toHaveBeenCalled();
-      expect(latestOnChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
-    });
-
     // Current behavior is tracked by #6849. Update this case when keyboard support is implemented.
     it('keydown', async () => {
       const onChange = vi.fn();

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -412,6 +412,18 @@ describe('Switch', () => {
       expect(wrapper.emitted('update:modelValue')).toBeUndefined();
     });
 
+    it('uses the latest change listener after props update', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const wrapper = mount(Switch, { props: { onChange: initialOnChange } });
+
+      await wrapper.setProps({ onChange: latestOnChange });
+      await wrapper.get('.t-switch').trigger('click');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
+    });
+
     // Current behavior is tracked by #6849. Update this case when keyboard support is implemented.
     it('keydown', async () => {
       const onChange = vi.fn();

--- a/packages/components/switch/switch.tsx
+++ b/packages/components/switch/switch.tsx
@@ -17,7 +17,9 @@ export default defineComponent({
     const { STATUS, SIZE } = useCommonClassName();
     // values
     const { value, modelValue } = toRefs(props);
-    const [innerValue, setSwitchVal] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [innerValue, setSwitchVal] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
 
     const activeValue = computed(() => {
       if (props.customValue && props.customValue.length > 0) {

--- a/packages/tdesign-vue-next/.changelog/pr-6914.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6914.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6914
+contributor: engvuchen
+---
+
+- fix(switch): 修复事件监听器更新后 change 回调仍调用旧函数的问题 @engvuchen ([#6914](https://github.com/Tencent/tdesign-vue-next/pull/6914))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/6913

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(switch): 修复事件监听器更新后 change 回调仍调用旧函数的问题

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
