### PR TITLE
fix(Table): fix source data mutation when row is not explicitly modified

### DIFF
--- a/packages/components/table/primary-table.tsx
+++ b/packages/components/table/primary-table.tsx
@@ -1,5 +1,5 @@
 import { computed, defineComponent, toRefs, h, ref, onMounted, getCurrentInstance } from 'vue';
-import { get, omit } from 'lodash-es';
+import { cloneDeep, get, isEqual, omit, set } from 'lodash-es';
 import baseTableProps from './base-table-props';
 import primaryTableProps from './primary-table-props';
 import BaseTable from './base-table';
@@ -225,15 +225,19 @@ export default defineComponent({
     const onEditableCellChange: EditableCellProps['onChange'] = (params) => {
       const rowKey = props.rowKey || 'id';
       const sourceRowValue = get(params.row, rowKey);
+      const colKey = params.col.colKey;
+      const valueBeforeRowEdit = cloneDeep(get(params.row, colKey));
       props.onRowEdit?.(params);
       const sourceRow = props.data.find((row) => get(row, rowKey) === sourceRowValue);
-      // TODO: 当前为兼容 rowEdit 中直接修改 row 的行为，后续应通过受控数据更新机制替代对 props.data 的直接修改。
-      if (sourceRow && sourceRow !== params.row) {
-        Object.assign(sourceRow, params.row);
+      const valueAfterRowEdit = get(params.row, colKey);
+      // 未主动修改 row 时，仅保留内部编辑态数据，避免取消编辑后原始数据被污染。
+      // TODO: 受控更新机制替代对 row 的直接修改
+      if (sourceRow && sourceRow !== params.row && !isEqual(valueBeforeRowEdit, valueAfterRowEdit)) {
+        set(sourceRow, colKey, valueAfterRowEdit);
       }
       const rowValue = get(params.editedRow, rowKey);
       onUpdateEditedCell(rowValue, params.row, {
-        [params.col.colKey]: params.value,
+        [colKey]: params.value,
       });
     };
 

--- a/packages/tdesign-vue-next/.changelog/pr-6919.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6919.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6919
+contributor: uyarn
+---
+
+- fix(Table): 修复 `1.20.4` 版本后，未主动修改 row 时，污染原始数据导致取消编辑功能异常的问题 @uyarn ([#6919](https://github.com/Tencent/tdesign-vue-next/pull/6919))


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 
- fix(Table): 修复 `1.20.4` 版本后，未主动修改 row 时，污染原始数据导致取消编辑功能异常的问题
#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
