### PR TITLE
fix(form-controls): 修复表单控件复用后的 onChange 回调仍调用旧函数的问题

### DIFF
--- a/packages/components/cascader/__tests__/cascader.test.tsx
+++ b/packages/components/cascader/__tests__/cascader.test.tsx
@@ -720,6 +720,26 @@ describe('Cascader', () => {
       expect(onChange).toHaveBeenCalledWith(expect.any(Array), expect.objectContaining({ source: 'check' }));
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Cascader options={options} onChange={onChange.value} popupVisible />,
+      });
+      const panel = mountPanel(wrapper);
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await panel.findAll('.t-cascader__item')[0].trigger('click');
+      await nextTick();
+      await panel.findAll('.t-cascader__item')[2].trigger('click');
+      await nextTick();
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith('a1', expect.objectContaining({ source: 'check' }));
+    });
+
     it('change does not emit for the current controlled value', async () => {
       const onChange = vi.fn();
       const wrapper = renderCascader({ modelValue: 'a1', onChange, popupVisible: true });

--- a/packages/components/cascader/hooks/index.ts
+++ b/packages/components/cascader/hooks/index.ts
@@ -105,7 +105,9 @@ export const useContext = (
 export const useCascaderContext = (props: TdCascaderProps) => {
   const isDisabled = useDisabled();
   const { value, modelValue, popupVisible } = toRefs(props);
-  const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+  const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+    props.onChange?.(newValue, context),
+  );
   const [innerPopupVisible, setPopupVisible] = useDefaultValue(
     popupVisible,
     false,

--- a/packages/components/checkbox/__tests__/checkbox-group.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox-group.test.tsx
@@ -1,5 +1,5 @@
 import { mount, shallowMount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Checkbox, CheckboxGroup } from '..';
@@ -31,6 +31,26 @@ describe('CheckboxGroup', () => {
       expect(group.findAll('.t-checkbox__label').map((item) => item.text())).toEqual(['Alpha', 'Beta']);
       expect(emptyOptions.get('.t-checkbox__label').text()).toBe('Slot option');
       expect(childWithoutProps.get('.t-checkbox__label').text()).toBe('Unconfigured option');
+    });
+
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <CheckboxGroup value={[]} options={['a']} onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await wrapper.get('input').trigger('change');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(
+        ['a'],
+        expect.objectContaining({ type: 'check', e: expect.any(Event) }),
+      );
+      wrapper.unmount();
     });
 
     it(':disabled[boolean]', () => {

--- a/packages/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Checkbox from '..';
@@ -51,6 +51,23 @@ describe('Checkbox', () => {
 
       expect(root.classes()).toContain('t-is-checked');
       expect((input.element as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Checkbox checked={false} onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await wrapper.get('input').trigger('change');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(true, { e: expect.any(Event) });
+      wrapper.unmount();
     });
 
     it(':modelValue[boolean]', async () => {

--- a/packages/components/checkbox/checkbox.tsx
+++ b/packages/components/checkbox/checkbox.tsx
@@ -37,7 +37,7 @@ export default defineComponent({
       checked,
       modelValue,
       props.defaultChecked,
-      props.onChange,
+      (newValue, context) => props.onChange?.(newValue, context),
       'checked',
     );
 

--- a/packages/components/checkbox/group.tsx
+++ b/packages/components/checkbox/group.tsx
@@ -17,7 +17,9 @@ export default defineComponent({
 
     const { isArray } = Array;
     const { value, modelValue } = toRefs(props);
-    const [rawValue, setRawValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [rawValue, setRawValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
     const innerValue = computed(() => (isArray(rawValue.value) ? rawValue.value : []));
 
     const optionList = ref<Array<CheckboxOptionObj>>([]);

--- a/packages/components/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/components/date-picker/__tests__/date-picker.test.tsx
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { nextTick } from 'vue';
+import { nextTick, ref } from 'vue';
 import MockDate from 'mockdate';
 import DatePicker, { DateRangePicker, DatePickerPanel, DateRangePickerPanel } from '@tdesign/components/date-picker';
 import dayjs from 'dayjs';
@@ -717,6 +717,42 @@ describe('DatePicker', () => {
       const textsR = viewersR.map((v) => v.textContent?.trim()).join(' ');
       expect(textsR).toContain('18:45:20');
     }
+  });
+
+  it('DatePicker onChange should use the latest handler after parent re-render', async () => {
+    const initialOnChange = vi.fn();
+    const latestOnChange = vi.fn();
+    const onChange = ref(initialOnChange);
+    const wrapper = mount({
+      setup: () => () => <DatePicker clearable value="2020-12-10" onChange={onChange.value} />,
+    });
+    const selectInput = wrapper.findComponent({ name: 'TSelectInput' });
+
+    onChange.value = latestOnChange;
+    await nextTick();
+    selectInput.props('onClear')({ e: new MouseEvent('click') });
+    await nextTick();
+
+    expect(initialOnChange).not.toHaveBeenCalled();
+    expect(latestOnChange).toHaveBeenCalledWith('', expect.objectContaining({ trigger: 'clear' }));
+  });
+
+  it('DateRangePicker onChange should use the latest handler after parent re-render', async () => {
+    const initialOnChange = vi.fn();
+    const latestOnChange = vi.fn();
+    const onChange = ref(initialOnChange);
+    const wrapper = mount({
+      setup: () => () => <DateRangePicker clearable value={['2020-12-10', '2020-12-20']} onChange={onChange.value} />,
+    });
+    const rangeInput = wrapper.findComponent({ name: 'TRangeInput' });
+
+    onChange.value = latestOnChange;
+    await nextTick();
+    rangeInput.props('onClear')({ e: new MouseEvent('click') });
+    await nextTick();
+
+    expect(initialOnChange).not.toHaveBeenCalled();
+    expect(latestOnChange).toHaveBeenCalledWith([], expect.objectContaining({ trigger: 'clear' }));
   });
 
   it('DatePickerPanel: enableTimePicker applied to dayjsValue (panel select time)', async () => {

--- a/packages/components/date-picker/hooks/useRangeValue.ts
+++ b/packages/components/date-picker/hooks/useRangeValue.ts
@@ -14,7 +14,9 @@ import {
 export function useRangeValue(props: TdDateRangePickerProps) {
   const { value: valueFromProps, modelValue } = toRefs(props);
 
-  const [rawValue, onRawChange] = useVModel(valueFromProps, modelValue, props.defaultValue, props.onChange);
+  const [rawValue, onRawChange] = useVModel(valueFromProps, modelValue, props.defaultValue, (newValue, context) =>
+    props.onChange?.(newValue, context),
+  );
   const value = computed(() => (Array.isArray(rawValue.value) ? rawValue.value : []));
 
   const formatRef = computed(() =>

--- a/packages/components/date-picker/hooks/useSingleValue.tsx
+++ b/packages/components/date-picker/hooks/useSingleValue.tsx
@@ -12,7 +12,9 @@ import { TdDatePickerProps, DateMultipleValue, DateValue } from '../type';
 
 export function useSingleValue(props: TdDatePickerProps) {
   const { value: valueFromProps, modelValue } = toRefs(props);
-  const [value, onChange] = useVModel(valueFromProps, modelValue, props.defaultValue, props.onChange);
+  const [value, onChange] = useVModel(valueFromProps, modelValue, props.defaultValue, (newValue, context) =>
+    props.onChange?.(newValue, context),
+  );
 
   const formatRef = computed(() =>
     getDefaultFormat({

--- a/packages/components/input-number/__tests__/input-number.test.tsx
+++ b/packages/components/input-number/__tests__/input-number.test.tsx
@@ -575,6 +575,24 @@ describe('InputNumber', () => {
       expect(onChange).toHaveBeenCalledWith(0, expect.objectContaining({ type: 'input' }));
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <InputNumber defaultValue={0} onChange={onChange.value} />,
+      });
+      const input = wrapper.find('.t-input input');
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await input.setValue('2');
+      await nextTick();
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(2, expect.objectContaining({ type: 'input' }));
+    });
+
     it(':onEnter', async () => {
       const value = ref(100);
       const fn = vi.fn();

--- a/packages/components/input-number/hooks/useInputNumber.tsx
+++ b/packages/components/input-number/hooks/useInputNumber.tsx
@@ -25,7 +25,9 @@ export default function useInputNumber(props: TdInputNumberProps) {
   const { classPrefix, SIZE, STATUS } = useCommonClassName();
   const { value, modelValue, max, min } = toRefs(props);
   // 统一处理受控、非受控、语法糖 v-model 等
-  const [tValue, setTValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+  const [tValue, setTValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+    props.onChange?.(newValue, context),
+  );
   const inputRef = ref();
   const userInput = ref('');
 

--- a/packages/components/input/__tests__/input.test.tsx
+++ b/packages/components/input/__tests__/input.test.tsx
@@ -1,4 +1,4 @@
-import { nextTick } from 'vue';
+import { nextTick, ref } from 'vue';
 import type { VueWrapper } from '@vue/test-utils';
 import { mount } from '@vue/test-utils';
 import { expect, vi } from 'vitest';
@@ -1061,6 +1061,23 @@ describe('Input', () => {
       const wrapper = mount(Input);
       // 由于没有设置 placeholder，应该使用全局配置的默认值
       expect(wrapper.find('input').attributes('placeholder')).toBeDefined();
+    });
+
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Input defaultValue="" onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      simulateInputChange(wrapper.find('input').element, 'latest value');
+      await nextTick();
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith('latest value', expect.objectContaining({ trigger: 'input' }));
     });
   });
 });

--- a/packages/components/input/hooks/useInput.ts
+++ b/packages/components/input/hooks/useInput.ts
@@ -26,7 +26,9 @@ export function useInput(props: ExtendsTdInputProps, expose: (exposed: Record<st
   const innerClickElement = ref();
   const disabled = useDisabled();
   const readonly = useReadonly();
-  const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+  const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+    props.onChange?.(newValue, context),
+  );
 
   const isHover = ref(false);
   const focused = ref(false);

--- a/packages/components/radio/__tests__/radio-group.test.tsx
+++ b/packages/components/radio/__tests__/radio-group.test.tsx
@@ -99,6 +99,23 @@ describe('RadioGroup', () => {
       expect(checkedChange).not.toHaveBeenCalled();
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <RadioGroup value={1} options={[1, 2]} onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await wrapper.findAll(RADIO)[1].trigger('click');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(2, { e: expect.any(MouseEvent), name: '' });
+      wrapper.unmount();
+    });
+
     it(':direction[horizontal/vertical]', async () => {
       const validateDirection = radioGroupProps.direction.validator as (value?: string) => boolean;
       expect(validateDirection()).toBe(true);

--- a/packages/components/radio/__tests__/radio.test.tsx
+++ b/packages/components/radio/__tests__/radio.test.tsx
@@ -52,6 +52,23 @@ describe('Radio', () => {
       expect(wrapper.get<HTMLInputElement>(INPUT).element.checked).toBe(true);
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Radio checked={false} onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await wrapper.get(RADIO).trigger('click');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
+      wrapper.unmount();
+    });
+
     it(':defaultChecked[boolean]', async () => {
       const wrapper = mount(Radio, {
         props: { allowUncheck: true, defaultChecked: true },

--- a/packages/components/radio/group.tsx
+++ b/packages/components/radio/group.tsx
@@ -37,7 +37,9 @@ export default defineComponent({
   props,
   setup(props) {
     const { value, modelValue } = toRefs(props);
-    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
 
     /** calculate bar style */
     const radioGroupRef = ref<HTMLElement>();

--- a/packages/components/radio/radio.tsx
+++ b/packages/components/radio/radio.tsx
@@ -27,7 +27,7 @@ export default defineComponent({
       checked,
       modelValue,
       props.defaultChecked,
-      props.onChange,
+      (newValue, context) => props.onChange?.(newValue, context),
       'checked',
     );
 

--- a/packages/components/range-input/__tests__/range-input.test.tsx
+++ b/packages/components/range-input/__tests__/range-input.test.tsx
@@ -343,6 +343,26 @@ describe('RangeInput', () => {
       }
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <RangeInput defaultValue={['', '']} onChange={onChange.value} />,
+      });
+      const firstInput = wrapper.find('input');
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await firstInput.setValue('latest value');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(
+        ['latest value', ''],
+        expect.objectContaining({ trigger: 'input', position: 'first' }),
+      );
+    });
+
     it('should trigger click event when input is clicked', async () => {
       const onClick = vi.fn();
       const wrapper = mount(<RangeInput onClick={onClick} />);

--- a/packages/components/range-input/range-input.tsx
+++ b/packages/components/range-input/range-input.tsx
@@ -44,7 +44,9 @@ export default defineComponent({
     const format = computed(() => calcArrayValue(props.format));
     const inputProps = computed(() => calcArrayValue(props.inputProps));
     const placeholder = computed(() => calcArrayValue(props.placeholder));
-    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
 
     const inputValue = computed(() => String((innerValue.value?.[0] || innerValue.value?.[1]) ?? ''));
 

--- a/packages/components/select/__tests__/select.test.tsx
+++ b/packages/components/select/__tests__/select.test.tsx
@@ -513,6 +513,27 @@ describe('Select', () => {
       wrapper.unmount();
     });
 
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Select value="" onChange={onChange.value} options={options} />,
+      });
+
+      await openPopup(wrapper);
+      onChange.value = latestOnChange;
+      await nextTick();
+
+      const panelNode = document.querySelector('.t-select__list');
+      (panelNode?.querySelectorAll('.t-select-option')[0] as HTMLElement).click();
+      await nextTick();
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(options[0].value, expect.any(Object));
+      wrapper.unmount();
+    });
+
     it('onClear', async () => {
       const triggerClear = async (wrapper: ReturnType<typeof mount>) => {
         const input = wrapper.find('.t-input');

--- a/packages/components/select/select.tsx
+++ b/packages/components/select/select.tsx
@@ -52,7 +52,9 @@ export default defineComponent({
       props.onInputChange,
       'inputValue',
     );
-    const [orgValue, setOrgValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [orgValue, setOrgValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
     const selectPanelRef = ref(null);
     const selectInputRef = ref(null);
     const keys = computed(() => ({

--- a/packages/components/switch/__tests__/switch.test.tsx
+++ b/packages/components/switch/__tests__/switch.test.tsx
@@ -1,5 +1,5 @@
 import { flushPromises, mount } from '@vue/test-utils';
-import { h, ref } from 'vue';
+import { h, nextTick, ref } from 'vue';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import Switch, { type SwitchProps, type SwitchValue } from '@tdesign/components/switch';
@@ -46,6 +46,23 @@ describe('Switch', () => {
 
       errorWrapper.element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       expect(errorHandler.mock.calls[0][0]).toBe(error);
+    });
+
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Switch value={false} onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await wrapper.get('.t-switch').trigger('click');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(true, { e: expect.any(MouseEvent) });
+      wrapper.unmount();
     });
 
     it(':beforeChange[Promise]', async () => {

--- a/packages/components/textarea/__tests__/textarea.test.tsx
+++ b/packages/components/textarea/__tests__/textarea.test.tsx
@@ -570,5 +570,21 @@ describe('Textarea', () => {
       exposed.focus();
       expect(focusSpy).toHaveBeenCalledOnce();
     });
+
+    it('onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <Textarea defaultValue="" onChange={onChange.value} />,
+      });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      await getTextarea(wrapper).setValue('latest value');
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith('latest value', { e: expect.objectContaining({ type: 'input' }) });
+    });
   });
 });

--- a/packages/components/textarea/textarea.tsx
+++ b/packages/components/textarea/textarea.tsx
@@ -44,7 +44,9 @@ export default defineComponent({
     const TEXTAREA_LIMIT = computed(() => `${name.value}__limit`);
 
     const { value, modelValue } = toRefs(props);
-    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue, context) =>
+      props.onChange?.(newValue, context),
+    );
     const disabled = useDisabled();
     const isReadonly = useReadonly();
     const textareaStyle = ref<CSSProperties>({});

--- a/packages/components/time-picker/__tests__/time-picker.test.tsx
+++ b/packages/components/time-picker/__tests__/time-picker.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
-import { TimePicker } from '@tdesign/components/time-picker';
+import { nextTick, ref } from 'vue';
+import { TimePicker, TimeRangePicker } from '@tdesign/components/time-picker';
 
 describe('TimePicker', () => {
   describe(':props', () => {
@@ -150,6 +151,40 @@ describe('TimePicker', () => {
       expect(minuteCells[0].innerHTML).toBe('00');
       expect(minuteCells[1].innerHTML).toBe('06');
       panelNode.parentNode.removeChild(panelNode);
+    });
+
+    it('TimePicker onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <TimePicker clearable value="10:00:00" onChange={onChange.value} />,
+      });
+      const selectInput = wrapper.findComponent({ name: 'TSelectInput' });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      selectInput.props('onClear')({ e: new MouseEvent('click') });
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(null);
+    });
+
+    it('TimeRangePicker onChange should use the latest handler after parent re-render', async () => {
+      const initialOnChange = vi.fn();
+      const latestOnChange = vi.fn();
+      const onChange = ref(initialOnChange);
+      const wrapper = mount({
+        setup: () => () => <TimeRangePicker clearable value={['10:00:00', '11:00:00']} onChange={onChange.value} />,
+      });
+      const rangeInput = wrapper.findComponent({ name: 'TRangeInput' });
+
+      onChange.value = latestOnChange;
+      await nextTick();
+      rangeInput.props('onClear')({ e: new MouseEvent('click') });
+
+      expect(initialOnChange).not.toHaveBeenCalled();
+      expect(latestOnChange).toHaveBeenCalledWith(null);
     });
 
     it('hideDisabledTime works fine', async () => {

--- a/packages/components/time-picker/time-picker.tsx
+++ b/packages/components/time-picker/time-picker.tsx
@@ -41,7 +41,9 @@ export default defineComponent({
     const isReadonly = useReadonly();
 
     const { value, modelValue } = toRefs(props);
-    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange);
+    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue) =>
+      props.onChange?.(newValue),
+    );
 
     const isDisabled = useDisabled() as ComputedRef<boolean>;
     const { allowInput, format } = toRefs(props);

--- a/packages/components/time-picker/time-range-picker.tsx
+++ b/packages/components/time-picker/time-range-picker.tsx
@@ -52,7 +52,9 @@ export default defineComponent({
       },
     ]);
     const { value, modelValue, allowInput, format } = toRefs(props);
-    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, props.onChange as any);
+    const [innerValue, setInnerValue] = useVModel(value, modelValue, props.defaultValue, (newValue) =>
+      props.onChange?.(newValue),
+    );
 
     const handleShowPopup = (visible: boolean, context: any) => {
       if (isReadOnly.value) return;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 其他

### 🔗 相关 ISSUE

Fixes #6928

### 💡 需求背景和解决方案

部分表单控件在 `setup` 阶段直接将 `props.onChange` 传入 `useVModel`。当父组件重渲染并替换 `onChange` 时，复用的控件实例仍可能调用旧回调，导致回调闭包中的 `rowIndex` 等上下文过期，最终修改错误的数据行。

本 PR 修复了以下组件形态：

- `Select`
- `Switch`
- `Checkbox`
- `CheckboxGroup`
- `Radio`
- `RadioGroup`
- `Input`
- `Textarea`
- `InputNumber`
- `Cascader`
- `DatePicker`
- `DateRangePicker`
- `TimePicker`
- `TimeRangePicker`
- `RangeInput`

修复方式：

- 不修改共享 `useVModel` API；
- 将直接传递的 `props.onChange` 改为运行时读取最新 listener 的 wrapper；
- `value + context` 类型的组件保留 `context` 参数；
- `TimePicker` 和 `TimeRangePicker` 按现有 value-only 契约传递 value；
- 移除 `TimeRangePicker` 中的 `props.onChange as any`。

### 🔍 验证

- 新增/更新 13 个组件测试文件；
- 共 507 条测试通过；
- 覆盖父级替换 listener 后继续交互的回归场景；
- 覆盖单值和范围值组件；
- 完成高频组件人工交互验证；
- `corepack pnpm lint:tsc` 通过；
- 本次修改文件 ESLint 通过；
- `git diff --check` 通过。

### 📝 后续 TODO

以下组件仍存在同机制风险，留待后续 PR：

- `AutoComplete`
- `Slider`
- `Rate`
- `TagInput`
- `Transfer`
- `TreeSelect`

后续应先分别补充 listener 替换回归测试，再按各组件公开的回调签名增加动态 wrapper。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(select): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(checkbox): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(checkbox-group): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(radio): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(radio-group): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(input): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(textarea): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(input-number): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(cascader): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(date-picker): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(date-range-picker): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(time-picker): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(time-range-picker): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu
- fix(range-input): 修复组件复用或父组件更新后，`onChange` 回调仍调用旧函数的问题 @zndkqiu

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供