### PR TITLE
fix(ImageViewer): 修复自定义预览标题不显示图片计数

### DIFF
--- a/packages/components/image-viewer/__tests__/image-viewer.test.tsx
+++ b/packages/components/image-viewer/__tests__/image-viewer.test.tsx
@@ -389,7 +389,7 @@ describe('ImageViewer', () => {
       // string
       mount(ImageViewer, { props: { visible: true, images, title: 'Custom Title' } });
       await nextTick();
-      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('Custom Title');
+      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('Custom Title1/3');
 
       document.body.innerHTML = '';
 
@@ -399,6 +399,7 @@ describe('ImageViewer', () => {
       });
       await nextTick();
       expect(document.querySelector('.custom-title')).toBeTruthy();
+      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toContain('1/3');
 
       document.body.innerHTML = '';
 
@@ -409,13 +410,13 @@ describe('ImageViewer', () => {
     });
 
     it(':title updates when index changes', async () => {
-      const wrapper = mount(ImageViewer, { props: { visible: true, images, index: 0 } });
+      const wrapper = mount(ImageViewer, { props: { visible: true, images, index: 0, title: 'Custom Title' } });
       await nextTick();
-      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('1/3');
+      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('Custom Title1/3');
 
       await wrapper.setProps({ index: 2 });
       await nextTick();
-      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('3/3');
+      expect(document.querySelector('.t-image-viewer__modal-index')?.textContent).toBe('Custom Title3/3');
     });
 
     it(':zIndex[number]', async () => {

--- a/packages/components/image-viewer/image-viewer.tsx
+++ b/packages/components/image-viewer/image-viewer.tsx
@@ -299,12 +299,18 @@ export default defineComponent({
 
     const renderTitle = () => {
       const titleContent = renderTNodeJSX('title');
+      const indexText = `${indexValue.value + 1}/${images.value.length}`;
 
-      return (
-        <div class={`${COMPONENT_NAME.value}__modal-index`}>
-          {titleContent ? titleContent : `${indexValue.value + 1}/${images.value.length}`}
-        </div>
-      );
+      if (titleContent) {
+        return (
+          <div class={`${COMPONENT_NAME.value}__modal-index`}>
+            <span>{titleContent}</span>
+            {indexText}
+          </div>
+        );
+      }
+
+      return <div class={`${COMPONENT_NAME.value}__modal-index`}>{indexText}</div>;
     };
 
     const renderNavigationArrow = (type: 'prev' | 'next') => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

before
<img width="1393" height="1060" alt="469c-b58a-e394e9a5fc6e" src="https://github.com/user-attachments/assets/350b270f-b663-43ba-95cf-9b8c0def6e6d" />

after
<img width="2226" height="1004" alt=" 6e3-4553-991e-d7c46b597729" src="https://github.com/user-attachments/assets/b9ca29ec-48ef-4dd8-a9d3-70acb55501f9" />


ImageViewer 相册预览设置 `title` 时，Vue 版本只展示自定义标题，没有展示当前图片序号和图片总数；React 版本会同时展示标题和计数。

本次修复让 ImageViewer 在存在自定义标题时同时渲染标题和 `当前序号/总数`，例如 `相册封面标题1/3`；没有自定义标题时继续展示原有的 `1/3`。图片切换后计数会同步更新。

本次不新增或修改公开 API，现有相册 Demo 即可覆盖该行为。该交互差异可参考需求截图中的 React/Vue 对比。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(ImageViewer): 修复自定义预览标题不显示图片计数的问题

#### @tdesign-vue-next/chat

无

#### @tdesign-vue-next/nuxt

无

#### @tdesign-vue-next/auto-import-resolver

无

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

验证结果：

- ImageViewer 定向测试：57/57 通过
- ESLint 通过
- TypeScript 全量检查通过
- `git diff --check` 通过
