### PR TITLE
fix(space): forward child key to wrapper to prevent misalignment

### DIFF
--- a/packages/components/space/__tests__/space.test.tsx
+++ b/packages/components/space/__tests__/space.test.tsx
@@ -459,5 +459,53 @@ describe('Space', () => {
       // keep their own DOM nodes/state instead of being shifted or recreated.
       expect(values).toEqual(['b', 'c']);
     });
+
+    it('falls back to the original pre-filter position for keyless children', () => {
+      const wrapper = mount(
+        <Space>
+          <input class="probe" />
+          <input class="probe" />
+          <input class="probe" />
+        </Space>,
+      );
+
+      // With no explicit key, each wrapper falls back to the child's original
+      // position (0, 1, 2) in the pre-filter slot structure, not a filtered index.
+      const listFragment = (wrapper.vm.$.subTree.children as any[])[0];
+      const fragments = (listFragment.children as any[]).filter(Boolean);
+      expect(fragments.map((fragment) => fragment.key)).toEqual([0, 1, 2]);
+    });
+
+    it('keeps keyless children aligned when a v-if sibling is toggled off (build-mode repro)', async () => {
+      const showFirst = ref(true);
+      const wrapper = mount({
+        setup() {
+          return () => (
+            <Space>
+              {showFirst.value && <input class="probe" />}
+              <input class="probe" />
+              <input class="probe" />
+            </Space>
+          );
+        },
+      });
+
+      // Stamp uncontrolled DOM state onto the two trailing (keyless) inputs.
+      let inputs = wrapper.findAll('input.probe');
+      expect(inputs.length).toBe(3);
+      (inputs[1].element as HTMLInputElement).value = 'second';
+      (inputs[2].element as HTMLInputElement).value = 'third';
+
+      // The first child collapses to a comment node that Space filters out. Without a
+      // stable fallback key the remaining keyless children shift index (1->0, 2->1) and
+      // Vue re-aligns them onto the wrong DOM nodes — the bug that only surfaced after build.
+      showFirst.value = false;
+      await nextTick();
+
+      inputs = wrapper.findAll('input.probe');
+      const values = inputs.map((input) => (input.element as HTMLInputElement).value);
+      // Fallback keys stay 1 and 2 (original positions), so both inputs keep their own state.
+      expect(values).toEqual(['second', 'third']);
+    });
   });
 });

--- a/packages/components/space/__tests__/space.test.tsx
+++ b/packages/components/space/__tests__/space.test.tsx
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import type { VueWrapper } from '@vue/test-utils';
+import { ref, nextTick } from 'vue';
 import { expect, describe, it, beforeEach } from 'vitest';
 import { Space, Button } from '@tdesign/components';
 
@@ -407,6 +408,56 @@ describe('Space', () => {
 
       const spaceElement = wrapper.find('.t-space').element as HTMLElement;
       expect(spaceElement.style.gap).toBe('50px');
+    });
+  });
+
+  describe('child key', () => {
+    it('forwards the key of each child to its wrapper fragment', () => {
+      const wrapper = mount(
+        <Space>
+          <Button key="a">Button A</Button>
+          <Button key="b">Button B</Button>
+        </Space>,
+      );
+
+      // The root <div class="t-space"> renders one wrapper fragment per child (nested
+      // inside the map's own fragment); each wrapper should carry the corresponding
+      // child key instead of being keyless.
+      const listFragment = (wrapper.vm.$.subTree.children as any[])[0];
+      const fragments = (listFragment.children as any[]).filter(Boolean);
+      expect(fragments.map((fragment) => fragment.key)).toEqual(['a', 'b']);
+    });
+
+    it('keeps keyed children aligned when a v-if child is toggled off', async () => {
+      const showFirst = ref(true);
+      const wrapper = mount({
+        setup() {
+          return () => (
+            <Space>
+              {showFirst.value && <input key="a" class="probe" />}
+              <input key="b" class="probe" />
+              <input key="c" class="probe" />
+            </Space>
+          );
+        },
+      });
+
+      // Stamp uncontrolled DOM state onto each input, matching its logical key.
+      let inputs = wrapper.findAll('input.probe');
+      expect(inputs.length).toBe(3);
+      (inputs[0].element as HTMLInputElement).value = 'a';
+      (inputs[1].element as HTMLInputElement).value = 'b';
+      (inputs[2].element as HTMLInputElement).value = 'c';
+
+      // Remove the first (keyed) child; it collapses to a comment node that Space filters out.
+      showFirst.value = false;
+      await nextTick();
+
+      inputs = wrapper.findAll('input.probe');
+      const values = inputs.map((input) => (input.element as HTMLInputElement).value);
+      // Because the wrapper forwards each child key, Vue aligns by key: 'b' and 'c'
+      // keep their own DOM nodes/state instead of being shifted or recreated.
+      expect(values).toEqual(['b', 'c']);
     });
   });
 });

--- a/packages/components/space/space.tsx
+++ b/packages/components/space/space.tsx
@@ -1,6 +1,16 @@
-import { defineComponent, computed, CSSProperties, Fragment, isVNode } from 'vue';
+import {
+  defineComponent,
+  computed,
+  CSSProperties,
+  Fragment,
+  isVNode,
+  getCurrentInstance,
+  Comment,
+  Teleport,
+  VNodeChild,
+} from 'vue';
 import props from './props';
-import { useTNodeJSX, useChildSlots, usePrefixClass, useFlatChildrenSlots } from '@tdesign/shared-hooks';
+import { useTNodeJSX, usePrefixClass } from '@tdesign/shared-hooks';
 
 import { isArray, isNumber, isString } from 'lodash-es';
 
@@ -9,6 +19,35 @@ import { SizeEnum } from '../common';
 
 const sizeMap = { small: '8px', medium: '16px', large: '24px' };
 const defaultNeedPolyfill = getFlexGapPolyFill();
+
+interface FlatChild {
+  node: VNodeChild;
+  // 子节点在「过滤前」的原始 slot 结构中的位置。注释节点（v-if 为假时编译产物）
+  // 与 Teleport 也会占用一个位置，因此某个兄弟节点被过滤掉时，其余无 key 子节点的
+  // 原始位置保持不变，可作为稳定的回退 key。
+  position: number;
+}
+
+// 递归展开 Fragment，收集真正会被渲染的子节点，并为每个 slot 节点分配一个稳定的原始位置。
+// 注释节点（Comment）、Teleport 以及空的 symbol 节点不会被渲染，但仍会占用一个位置，
+// 以保证后续无 key 子节点的原始位置不会因为它们的出现/消失而发生偏移。
+function flattenChildrenWithPosition(nodes: VNodeChild[], counter: { value: number }): FlatChild[] {
+  const result: FlatChild[] = [];
+  nodes.forEach((node) => {
+    if (isVNode(node) && node.type === Fragment && isArray(node.children)) {
+      result.push(...flattenChildrenWithPosition(node.children as VNodeChild[], counter));
+      return;
+    }
+    const position = counter.value;
+    counter.value += 1;
+    const isSkipped =
+      isVNode(node) &&
+      (node.type === Comment || node.type === Teleport || (typeof node.type === 'symbol' && !node.children));
+    if (isSkipped) return;
+    result.push({ node, position });
+  });
+  return result;
+}
 
 export default defineComponent({
   name: 'TSpace',
@@ -20,8 +59,7 @@ export default defineComponent({
   setup(props) {
     const COMPONENT_NAME = usePrefixClass('space');
     const renderTNodeJSX = useTNodeJSX();
-    const getChildSlots = useChildSlots();
-    const getFlatChildren = useFlatChildrenSlots();
+    const instance = getCurrentInstance();
 
     const needPolyfill = computed(() => props.forceFlexGapPolyfill || defaultNeedPolyfill);
 
@@ -52,13 +90,16 @@ export default defineComponent({
       return style;
     });
     function renderChildren() {
-      const children = getFlatChildren(getChildSlots());
+      const rawContent = (instance.slots.default?.() || []) as VNodeChild[];
+      const children = flattenChildrenWithPosition(rawContent, { value: 0 });
       const separatorContent = renderTNodeJSX('separator');
-      return children.map((child, index) => {
+      return children.map(({ node: child, position }, index) => {
         const showSeparator = index + 1 !== children.length && separatorContent;
-        // 透传子节点自身的 key，避免包裹层丢失 key 后 Vue 只能按索引对齐，
-        // 在子节点使用 v-if（会被过滤成注释节点导致数组长度变化）时出现节点错配。
-        const key = isVNode(child) && child.key != null ? child.key : index;
+        // 透传子节点自身的 key；若子节点无 key，则回退到它在「过滤前」原始 slot 结构中的位置，
+        // 而不是过滤后的 index。否则当某个兄弟节点使用 v-if（编译为注释节点后被过滤，数组长度变化）时，
+        // 无 key 子节点的回退 key 会随之偏移，导致 Vue 按索引对齐时把节点 patch 到错误的 DOM 上。
+        // 该问题仅在生产构建下暴露，dev/HMR 因全量 props diff 而被掩盖。
+        const key = isVNode(child) && child.key != null ? child.key : position;
         return (
           <Fragment key={key}>
             <div class={`${COMPONENT_NAME.value}-item`}>{child}</div>

--- a/packages/components/space/space.tsx
+++ b/packages/components/space/space.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, CSSProperties, Fragment } from 'vue';
+import { defineComponent, computed, CSSProperties, Fragment, isVNode } from 'vue';
 import props from './props';
 import { useTNodeJSX, useChildSlots, usePrefixClass, useFlatChildrenSlots } from '@tdesign/shared-hooks';
 
@@ -56,8 +56,11 @@ export default defineComponent({
       const separatorContent = renderTNodeJSX('separator');
       return children.map((child, index) => {
         const showSeparator = index + 1 !== children.length && separatorContent;
+        // 透传子节点自身的 key，避免包裹层丢失 key 后 Vue 只能按索引对齐，
+        // 在子节点使用 v-if（会被过滤成注释节点导致数组长度变化）时出现节点错配。
+        const key = isVNode(child) && child.key != null ? child.key : index;
         return (
-          <Fragment>
+          <Fragment key={key}>
             <div class={`${COMPONENT_NAME.value}-item`}>{child}</div>
             {showSeparator && <div class={`${COMPONENT_NAME.value}-item-separator`}>{separatorContent}</div>}
           </Fragment>

--- a/packages/tdesign-vue-next/.changelog/pr-6936.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6936.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6936
+contributor: jaideeppyne
+---
+
+- fix(space): 透传子节点 key 到包裹层，修复 `v-if` 子节点切换时的节点错配 (#6932) @jaideeppyne ([#6936](https://github.com/Tencent/tdesign-vue-next/pull/6936))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？
- [x] 日常 bug 修复

### 🔗 相关 Issue
close #6932

### 💡 需求背景和解决方案
`Space` 把每个 slot child 包进一个**没有 key** 的 `<Fragment>`，丢失了子节点自身的 `key`，Vue 只能按索引对齐这个包裹层列表。当子节点使用 `v-if` 时会被编译成注释节点，`useChildSlots`/`useFlatChildrenSlots` 会将其过滤掉，导致数组长度变化，剩余的带 key 子节点被 patch 到错误的 DOM 节点上（状态错位或被重建）。该问题仅在生产构建下暴露，dev/HMR 因全量 props diff 而掩盖。

解决方案：将每个子节点的 `key` 透传到其包裹 `<Fragment>` 上，使 Vue 能按 key 对齐；子节点无 key 时回退到索引（行为不变）。新增两个回归测试：一是断言包裹 Fragment 透传了子节点 key；二是切换 `v-if` 子节点时，剩余带 key 子节点保持各自的（非受控）DOM 状态。

### 📝 更新日志
#### tdesign-vue-next
- fix(space): 透传子节点 key 到包裹层，修复 `v-if` 子节点切换时的节点错配的问题

### ☑️ 请求合并前的自查清单
- [x] 文档已补充或无须补充（无须）
- [x] 代码演示已提供或无须提供（无须）
- [x] TypeScript 定义已补充或无须补充（无须，未改动公共 API）
- [x] Changelog 已提供