### PR TITLE
test(Slider): replace random step with deterministic cases

### DIFF
--- a/packages/components/slider/__tests__/slider.test.tsx
+++ b/packages/components/slider/__tests__/slider.test.tsx
@@ -219,17 +219,11 @@ describe('Slider', () => {
       expect(wrapperShowStep.findAll('.t-slider__stop').length > 0).toBe(true);
     });
 
-    it(':showStep[boolean] + :step[number]', async () => {
-      const step = Math.floor(Math.random() * 100);
-      const stepCount = 100 / step;
-      const result = [];
-      for (let i = 1; i < stepCount; i++) {
-        result.push(i);
-      }
+    it.each([1, 2, 5, 10, 20, 25, 50, 100])(':showStep[boolean] + :step[number] (step: %i)', async (step) => {
       const wrapper = mount(<Slider showStep step={step} />);
       await nextTick();
       const stopElements = wrapper.findAll('.t-slider__stop');
-      expect(stopElements.length === result.length).toBe(true);
+      expect(stopElements).toHaveLength(100 / step - 1);
     });
 
     it(':tooltipProps[object]', async () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

无关联 Issue。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

Slider 的 `showStep + step` 测试通过 `Math.random()` 生成 `step`。当随机值为 `0` 时，`100 / step` 会得到 `Infinity`，随后构造预期刻度数组时抛出 `RangeError: Invalid array length`，导致 CI 偶发失败且难以复现。

将该用例改为参数化测试，固定覆盖 `1、2、5、10、20、25、50、100` 八个合法步长，并直接断言各步长对应的刻度数量。改动仅涉及测试，不改变 Slider 组件行为。

本地校验：

- Prettier 检查通过。
- ESLint 检查通过（0 warning）。
- `git diff --check` 通过。
- Slider 定向 Vitest 在测试收集前受本机 `canvas@3.1.2` 缺少原生 `canvas.node` 阻断，未执行测试用例；以远端 CI 结果为准。

### 📝 更新日志

- [x] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next
<!--
- feat(组件名称): 处理问题或特性描述
--> 

#### @tdesign-vue-next/chat
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/nuxt
<!--
- feat(组件名称): 处理问题或特性描述
-->

#### @tdesign-vue-next/auto-import-resolver
<!--
- feat(组件名称): 处理问题或特性描述
-->

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
