### PR TITLE
feat(Form): add last item class

### DIFF
--- a/packages/components/form/__tests__/form-item.test.tsx
+++ b/packages/components/form/__tests__/form-item.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { defineComponent } from 'vue';
 import { expect } from 'vitest';
 import { CheckCircleFilledIcon, CloseCircleFilledIcon } from 'tdesign-icons-vue-next';
 import { FormItem, Form, Input } from '@tdesign/components';
@@ -321,6 +322,102 @@ describe('FormItem', () => {
       );
       expect(slotWrapper.find('.t-form-item-tips').text()).toBe(tips);
       expect(functionWrapper.find('.t-form-item-tips').findComponent(CheckCircleFilledIcon).exists()).toBe(true);
+    });
+  });
+
+  describe('scenarios', () => {
+    describe('--last', () => {
+      // 借 `t-form-item__{name}` 反解出被标记为末位的表单项，避免断言依赖 DOM 顺序
+      const getLastItemNames = (wrapper: VueWrapper<any>) =>
+        wrapper.findAll('.t-form__item--last').map((item) =>
+          item
+            .classes()
+            .find((name) => name.startsWith('t-form-item__'))
+            ?.slice('t-form-item__'.length),
+        );
+
+      it('标记直接子元素中的末位表单项', async () => {
+        const wrapper = mount(
+          <Form>
+            <FormItem name="a" />
+            <FormItem name="b" />
+          </Form>,
+        );
+        await flushPromises();
+
+        expect(getLastItemNames(wrapper)).toEqual(['b']);
+      });
+
+      it('按父容器分组，各自标记末位表单项', async () => {
+        const wrapper = mount(
+          <Form>
+            <div>
+              <FormItem name="a" />
+              <FormItem name="b" />
+            </div>
+            <div>
+              <FormItem name="c" />
+              <FormItem name="d" />
+            </div>
+          </Form>,
+        );
+        await flushPromises();
+
+        expect(getLastItemNames(wrapper)).toEqual(['b', 'd']);
+      });
+
+      it('未设置 name 的表单项不参与末位判定', async () => {
+        const wrapper = mount(
+          <Form>
+            <FormItem name="a" />
+            <FormItem name="b" />
+            <FormItem>
+              <button type="submit">提交</button>
+            </FormItem>
+          </Form>,
+        );
+        await flushPromises();
+
+        expect(getLastItemNames(wrapper)).toEqual(['b']);
+      });
+
+      it('inline 布局下不标记末位表单项', async () => {
+        const wrapper = mount(
+          <Form layout="inline">
+            <FormItem name="a" />
+            <FormItem name="b" />
+          </Form>,
+        );
+        await flushPromises();
+
+        expect(getLastItemNames(wrapper)).toEqual([]);
+      });
+
+      it('末位表单项被移除后重新标记', async () => {
+        const wrapper = mount(
+          defineComponent({
+            data() {
+              return { names: ['a', 'b'] };
+            },
+            render() {
+              return (
+                <Form>
+                  {this.names.map((name) => (
+                    <FormItem key={name} name={name} />
+                  ))}
+                </Form>
+              );
+            },
+          }),
+        );
+        await flushPromises();
+        expect(getLastItemNames(wrapper)).toEqual(['b']);
+
+        wrapper.vm.names = ['a'];
+        await flushPromises();
+
+        expect(getLastItemNames(wrapper)).toEqual(['a']);
+      });
     });
   });
 });

--- a/packages/components/form/constants/index.ts
+++ b/packages/components/form/constants/index.ts
@@ -117,6 +117,8 @@ export const FormInjectionKey: InjectionKey<{
   resetType: TdFormProps['resetType'];
   children: FormItemContext[];
   renderContent: ReturnType<typeof useTNodeJSX>;
+  registerFormItem: (node: HTMLElement) => () => void;
+  lastFormItemElements: Set<HTMLElement>;
 }> = Symbol('FormProvide');
 
 export const FormItemInjectionKey: InjectionKey<{

--- a/packages/components/form/form-item.tsx
+++ b/packages/components/form/form-item.tsx
@@ -360,12 +360,18 @@ export default defineComponent({
       setValidateMessage,
     });
 
+    const formItemRef = ref<HTMLElement>(null);
+    let unregisterFormItem: () => void;
+
     onMounted(() => {
       initialValue.value = cloneDeep(value.value);
       form?.children.push(context);
+      // 无 name 的表单项（如提交/重置按钮容器）不参与末位判定
+      unregisterFormItem = !props.name ? undefined : form?.registerFormItem(formItemRef.value);
     });
 
     onBeforeUnmount(() => {
+      unregisterFormItem?.();
       if (form) form.children = form?.children.filter((ctx) => ctx !== context);
     });
 
@@ -391,12 +397,18 @@ export default defineComponent({
       return form?.showErrorMessage;
     });
 
+    const isLastFormItem = computed(() => {
+      const el = formItemRef.value;
+      return !!el && !!form?.lastFormItemElements.has(el);
+    });
+
     const classes = computed(() => [
       CLASS_NAMES.value.formItem,
       getFormItemClassName(formItemClassPrefix.value, props.name),
       {
         [CLASS_NAMES.value.formItemWithHelp]: helpNode.value,
         [CLASS_NAMES.value.formItemWithExtra]: extraNode.value,
+        [`${CLASS_NAMES.value.formItem}--last`]: isLastFormItem.value,
       },
     ]);
     const helpNode = computed<VNode>(() => {
@@ -435,7 +447,7 @@ export default defineComponent({
     });
 
     return () => (
-      <div class={classes.value}>
+      <div ref={formItemRef} class={classes.value}>
         {renderLabel()}
         <div class={contentClasses.value} style={contentStyle.value}>
           <div class={CLASS_NAMES.value.controlsContent}>

--- a/packages/components/form/form.tsx
+++ b/packages/components/form/form.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, provide, reactive, ref, toRefs } from 'vue';
+import { computed, defineComponent, provide, reactive, ref, shallowRef, toRefs } from 'vue';
 import { isEmpty, isArray, isBoolean, isFunction } from 'lodash-es';
 
 import { requestSubmit } from '@tdesign/shared-utils';
@@ -37,6 +37,48 @@ export default defineComponent({
     const formRef = ref<HTMLFormElement>(null);
     const children = ref<FormItemContext[]>([]);
 
+    const COMPONENT_NAME = usePrefixClass('form');
+    // 仅在 refreshLastFormItem 内读取，故无需响应式
+    const formItemElements: HTMLElement[] = [];
+    const lastFormItemElements = shallowRef<Set<HTMLElement>>(new Set());
+
+    // 标记每个父容器内文档顺序最靠后的表单项，样式层据此去掉末项的 margin
+    const refreshLastFormItem = () => {
+      const formItemSelector = `.${COMPONENT_NAME.value}__item`;
+      const next = new Set<HTMLElement>();
+
+      if (props.layout !== 'inline') {
+        const groups = new Map<HTMLElement, HTMLElement[]>();
+        formItemElements.forEach((el) => {
+          const { parentElement } = el;
+          if (!parentElement) return;
+          // 嵌套在其它表单项内部的子项不参与末位判定
+          if (parentElement.closest(formItemSelector)) return;
+
+          const siblings = groups.get(parentElement);
+          if (siblings) siblings.push(el);
+          else groups.set(parentElement, [el]);
+        });
+        groups.forEach((siblings) => {
+          siblings.sort((a, b) => (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1));
+          next.add(siblings[siblings.length - 1]);
+        });
+      }
+
+      lastFormItemElements.value = next;
+    };
+
+    const registerFormItem = (node: HTMLElement) => {
+      formItemElements.push(node);
+      refreshLastFormItem();
+
+      return () => {
+        const index = formItemElements.indexOf(node);
+        if (index > -1) formItemElements.splice(index, 1);
+        refreshLastFormItem();
+      };
+    };
+
     const {
       showErrorMessage,
       labelWidth,
@@ -64,10 +106,11 @@ export default defineComponent({
         resetType,
         children,
         renderContent,
+        lastFormItemElements,
+        registerFormItem,
       }),
     );
 
-    const COMPONENT_NAME = usePrefixClass('form');
     const CLASS_NAMES = useCLASSNAMES();
     const formClass = computed(() => [
       CLASS_NAMES.value.form,

--- a/packages/tdesign-vue-next/.changelog/pr-6952.md
+++ b/packages/tdesign-vue-next/.changelog/pr-6952.md
@@ -1,0 +1,6 @@
+---
+pr_number: 6952
+contributor: Zn-Dk
+---
+
+- feat(Form): 末尾表单项增加 `--last` 标识，保证 `margin` 样式正常生效 @Zn-Dk ([#6952](https://github.com/Tencent/tdesign-vue-next/pull/6952))


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- 样式来源：https://github.com/Tencent/tdesign-common/pull/2669
- 已落地的对位实现：https://github.com/Tencent/tdesign-react/pull/4356
- 引入回归的提交：https://github.com/Tencent/tdesign-common/pull/2557

### 💡 需求背景和解决方案

**背景**：tdesign-common#2557 把 `.t-form__item:last-of-type` 收紧为 `> .t-form__item:last-of-type`，嵌套容器内的末项不再去掉 `margin`；#2669 为此新增 `.t-form__item--last` 兜底，但**只改了 less，没有任何代码添加该 class**，规则是死的。tdesign-react 已通过 #4356 补上 JS 实现，vue-next 侧尚未落地（已检索确认 vue-next 无相关 issue / PR）。

**最小复现**：

```html
<t-form>
  <t-card>
    <t-form-item name="a" />
    <t-form-item name="b" />
    <!-- b 的 margin-bottom: 24px 无法归零 -->
  </t-card>
</t-form>
```

**解决方案**（按 #4356 的语义移植到 vue-next）：

- `Form` 提供 `registerFormItem`，收集具名表单项的根节点
- 按 `parentElement` 分组，用 `compareDocumentPosition` 取每组文档顺序最靠后的一项，写入 `lastFormItemElements`
- `FormItem` 在 `classes` 中根据自身是否在集合内拼接 `t-form__item--last`
- `inline` 布局下跳过（该样式本身不生效）；未设置 `name` 的表单项与嵌套在其它表单项内的子项不参与判定

**与 react 实现的有意差异**：未引入 `MutationObserver`。Vue 的 `onMounted` / `onBeforeUnmount` 已能覆盖组件驱动的表单项增删；外部直接操作 DOM 的场景留待按需补充。

### 📝 更新日志

#### tdesign-vue-next
- feat(Form): 末尾表单项增加 `--last` 标识，保证 `margin` 样式正常生效

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须提供
- [x] Changelog 已提供或无须提供

### 🧪 自测说明

- `packages/components/form/__tests__/form-item.test.tsx` 新增 5 个用例（平铺末项 / 按容器分组 / 无 name 不参与 / inline 跳过 / 移除末项后重新标记）；已验证去掉源码改动后其中 4 个会失败
- form 组件全量单测 93 通过；仓库全量单测 180 文件 / 4402 用例通过；`tsc --noEmit` 与 ESLint 均无报错
- 未更新 `test/src/snap` 下的快照：该目录未被 CI 覆盖（`vitest.config.ts` 的 include 指向已不存在的 `test/unit/snap`），且快照本身已有大量历史 diff（本地实测 1368 用例中 917 失败），与本次改动无关
