### PR TITLE
fix(Dropdown): restore onClick option type

### DIFF
--- a/packages/components/dropdown/__tests__/dropdown.test.tsx
+++ b/packages/components/dropdown/__tests__/dropdown.test.tsx
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import type { VueWrapper } from '@vue/test-utils';
 import { expect, vi } from 'vitest';
 import { Dropdown, DropdownMenu, DropdownItem, Button } from '@tdesign/components';
-import { DropdownOption } from '@tdesign/components/dropdown/type';
+import type { DropdownOption, TdDropdownProps } from '@tdesign/components/dropdown/type';
 import DropdownProps from '@tdesign/components/dropdown/props';
 import { sleep } from '@tdesign/internal-utils';
 
@@ -263,7 +263,9 @@ describe('Dropdown', () => {
 
   describe('events', () => {
     it(':onClick', async () => {
-      const onClick = vi.fn();
+      const onClick = vi.fn<NonNullable<TdDropdownProps['onClick']>>((dropdownItem) => {
+        expect(dropdownItem.content).toBe('Option 1');
+      });
       const options = [
         { content: 'Option 1', value: '1' },
         { content: 'Option 2', value: '2' },
@@ -287,7 +289,7 @@ describe('Dropdown', () => {
         await nextTick();
 
         expect(onClick).toHaveBeenCalled();
-        expect(onClick.mock.calls[0][0]).toMatchObject({ value: '1' });
+        expect(onClick.mock.calls[0][0]).toMatchObject({ content: 'Option 1', value: '1' });
         expect(onClick.mock.calls[0][1]).toHaveProperty('e');
       }
     });

--- a/packages/components/dropdown/type.ts
+++ b/packages/components/dropdown/type.ts
@@ -80,7 +80,7 @@ export interface TdDropdownProps {
   /**
    * 下拉操作项点击时触发
    */
-  onClick?: (dropdownItem: TdDropdownItemProps['value'], context: { e: MouseEvent }) => void;
+  onClick?: (dropdownItem: DropdownOption, context: { e: MouseEvent }) => void;
 }
 
 export interface TdDropdownItemProps {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

Fixes #6958

### 💡 需求背景和解决方案

从 1.20.6 起，`TdDropdownProps.onClick` 的首参被收窄为 `TdDropdownItemProps['value']`，导致官方示例中读取 `data.content` 时出现 TS18048 / TS2339。实际运行时仍通过 `handleMenuClick` 向顶层 Dropdown 回调传递完整的 `DropdownOption`，中英文 API 文档以及 `tdesign-api` 中的源定义也都保持该契约。

本 PR：

- 仅把顶层 `TdDropdownProps.onClick` 的首参恢复为 `DropdownOption`；
- 保留独立 `TdDropdownItemProps.onClick` 当前接收 value 的契约，不扩大修复范围；
- 强化现有点击回归测试：使用公开回调类型声明 mock，并同时断言 `content` 和 `value`，从而让类型和实际 payload 再次不一致时直接失败。

`tdesign-api` 的 canonical Dropdown 定义当前已经是 `DropdownOption`，因此无需额外修改 API 仓库。

### 📝 更新日志

- [ ] 本条 PR 不需要纳入 Changelog

#### tdesign-vue-next

- fix(Dropdown): 修复 `onClick` 回调参数类型与运行时不一致的问题

#### @tdesign-vue-next/chat

#### @tdesign-vue-next/nuxt

#### @tdesign-vue-next/auto-import-resolver

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

### 🧪 自测说明

- TypeScript 5.9.3 聚焦合同测试：未修复基线稳定报 TS18048 / TS2339，修复后通过。
- 运行时/声明 AST 合同检查：`handleMenuClick` 与 `props.onClick` 均传递完整 `DropdownOption`，通过。
- Prettier 2.8.8（仓库声明版本）检查通过。
- `git diff --check` 与签名提交验证通过。
- 本地 checkout 为仅含目标组件的 sparse/blobless 验证副本；当前磁盘余量不足以在满足项目 10 GiB 安全余量的前提下安装完整 monorepo 依赖，因此未声称执行仓库全量 Vitest / `tsc`，交由 CI 做完整验证。
